### PR TITLE
Add support for MathML 3.0

### DIFF
--- a/cnxml/jing.py
+++ b/cnxml/jing.py
@@ -47,7 +47,7 @@ def _parse_jing_output(output):
 def jing(rng_filepath, xml_filepath):
     """Run jing.jar using the RNG file against the given XML file."""
     cmd = ['java', '-jar']
-    cmd.extend([str(JING_JAR), str(rng_filepath), str(xml_filepath)])
+    cmd.extend([str(JING_JAR), '-i', str(rng_filepath), str(xml_filepath)])
     proc = subprocess.Popen(cmd,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,

--- a/cnxml/validation.py
+++ b/cnxml/validation.py
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 
-CNXML_JING_RNG = lookup_resource('xml/cnxml/schema/rng/0.7/cnxml-jing.rng')
+CNXML_JING_RNG = lookup_resource('xml/cnxml/schema/rng/any/cnxml-jing.rng')
 COLLXML_JING_RNG = lookup_resource(
     'xml/collxml/schema/rng/2.0/collxml-jing.rng')
 

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-abstract-defs.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-abstract-defs.rng
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <define name="cnxml-abstract-content">
+    <oneOrMore>
+      <choice>
+        <ref name="cnxml-abstract-para"/>
+        <ref name="cnxml-abstract-para-content"/>
+      </choice>
+    </oneOrMore>
+  </define>
+
+  <define name="cnxml-abstract-para">
+    <element name="para">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-para-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-para-content">
+    <oneOrMore>
+      <choice>
+        <ref name="cnxml-abstract-inline-class"/>
+        <ref name="cnxml-abstract-block-class"/>
+      </choice>
+    </oneOrMore>
+  </define>
+
+  <define name="cnxml-abstract-block-class">
+    <choice>
+      <ref name="cnxml-abstract-quote"/>
+      <ref name="cnxml-abstract-preformat"/>
+      <ref name="cnxml-abstract-list"/>
+    </choice>
+  </define>
+
+  <define name="cnxml-abstract-text-extras">
+    <notAllowed/>
+  </define>
+
+  <define name="cnxml-abstract-inline-class">
+    <choice>
+      <ref name="cnxml-abstract-emphasis"/>
+      <ref name="cnxml-abstract-term"/>
+      <ref name="cnxml-abstract-foreign"/>
+      <ref name="cnxml-abstract-cite"/>
+      <ref name="cnxml-abstract-span"/>
+      <ref name="cnxml-abstract-sup"/>
+      <ref name="cnxml-abstract-sub"/>
+      <ref name="cnxml-abstract-code"/>
+      <ref name="cnxml-abstract-text-extras"/>
+      <text/>
+    </choice>
+  </define>
+
+  <define name="cnxml-abstract-inline-content">
+    <oneOrMore>
+      <ref name="cnxml-abstract-inline-class"/>
+    </oneOrMore>
+  </define>
+
+  <define name="cnxml-abstract-emphasis">
+    <element name="emphasis">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-term">
+    <element name="term">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-foreign">
+    <element name="foreign">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-cite">
+    <element name="cite">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-span">
+    <element name="span">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-sup">
+    <element name="sup">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-sub">
+    <element name="sub">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-code">
+    <element name="code">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-display-attribute"/>
+      <ref name="cnxml-abstract-inline-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-quote">
+    <element name="quote">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-display-attribute"/>
+      <ref name="cnxml-abstract-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-preformat">
+    <element name="preformat">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-display-attribute"/>
+      <ref name="cnxml-abstract-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-list">
+    <element name="list">
+      <ref name="cnxml-abstract-list-type-attribute"/>
+      <ref name="cnxml-abstract-display-attribute"/>
+      <ref name="cnxml-abstract-common-attributes"/>
+      <oneOrMore>
+        <ref name="cnxml-abstract-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-list-type-attribute">
+    <empty/>
+  </define>
+
+  <define name="cnxml-abstract-display-attribute">
+    <empty/>
+  </define>
+
+  <define name="cnxml-abstract-item">
+    <element name="item">
+      <ref name="cnxml-abstract-common-attributes"/>
+      <ref name="cnxml-abstract-para-content"/>
+    </element>
+  </define>
+
+  <define name="cnxml-abstract-common-attributes">
+    <empty/>
+  </define>
+
+</grammar>
+

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-abstract-driver.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-abstract-driver.rng
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         ns="http://cnx.rice.edu/collxml">
+
+  <start>
+    <ref name="mdml-abstract"/>
+  </start>
+
+  <include href="cnxml-abstract-defs.rng">
+    <define name="cnxml-abstract-common-attributes">
+      <ref name="common-attributes-noclass"/>
+    </define>
+    <define name="cnxml-abstract-list-type-attribute">
+      <choice>
+        <ref name="bulleted-list-type-attribute"/>
+        <ref name="enumerated-list-type-attribute"/>
+      </choice>
+    </define>
+    <define name="cnxml-abstract-display-attribute">
+      <ref name="display-attribute"/>
+    </define>
+  </include>
+
+  <define name="cnxml-abstract-text-extras" combine="choice">
+    <ref name="mathml-math"/>
+  </define>
+
+  <include href="../../../../mdml/schema/rng/0.5/mdml-defs.rng">
+    <define name="mdml-metadata">
+      <notAllowed/>
+    </define>
+    <define name="mdml-abstract-content">
+      <ref name="cnxml-abstract-content"/>
+    </define>
+    <define name="mdml-common-attributes">
+      <ref name="common-attributes"/>
+    </define>
+    <define name="mdml-extended-attribution">
+      <element name="extended-attribution" ns="http://cnx.rice.edu/mdml">
+        <ref name="mdml-common-attributes"/>
+        <oneOrMore>
+          <ref name="link-group"/>
+        </oneOrMore>
+      </element>
+    </define>
+    <define name="mdml-derived-from">
+      <element name="derived-from" ns="http://cnx.rice.edu/mdml">
+        <choice>
+          <ref name="url-attribute"/>
+          <group>
+            <ref name="document-attribute"/>
+            <optional>
+              <ref name="version-attribute"/>
+            </optional>
+            <optional>
+              <ref name="repository-attribute"/>
+            </optional>
+          </group>
+        </choice>
+        <zeroOrMore>
+          <ref name="mdml-derived-from"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </include>
+
+  <include href="cnxml-defs.rng"/>
+
+  <define name="mathml-math">
+    <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+  </define>
+
+  <define name="repository-attribute">
+    <attribute name="repository"/>
+  </define>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-common-jing.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-common-jing.rng
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Same as cnxml-common.rng except for the @hrefs -->
+
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:cnxml="http://cnx.rice.edu/cnxml"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <include href="cnxml-abstract-defs.rng">
+    <define name="cnxml-abstract-common-attributes">
+      <ref name="common-attributes-noclass"/>
+    </define>
+    <define name="cnxml-abstract-list-type-attribute">
+      <choice>
+        <ref name="bulleted-list-type-attribute"/>
+        <ref name="enumerated-list-type-attribute"/>
+      </choice>
+    </define>
+    <define name="cnxml-abstract-display-attribute">
+      <ref name="display-attribute"/>
+    </define>
+  </include>
+
+  <define name="cnxml-abstract-text-extras" combine="choice">
+    <ref name="mathml-math"/>
+  </define>
+<!-- Make these relative -->
+  <include href="../../../../mdml/schema/rng/0.5/mdml-defs.rng">
+    <define name="mdml-metadata">
+      <notAllowed/>
+    </define>
+    <define name="mdml-abstract-content">
+      <ref name="cnxml-abstract-content"/>
+    </define>
+    <define name="mdml-common-attributes">
+      <ref name="common-attributes"/>
+    </define>
+    <define name="mdml-extended-attribution-content">
+      <cnxml:para>Contains CNXML 'linkgroup' elements that contain 'link' elements naming and referring to those to whom attribution is being given.</cnxml:para>
+      <oneOrMore>
+        <ref name="link-group"/>
+      </oneOrMore>
+    </define>
+    <define name="mdml-derived-from-attributes">
+      <cnxml:para>Makes use of the attributes from CNXML 'link' to form references to the parent works.</cnxml:para>
+      <choice>
+        <ref name="url-attribute"/>
+        <group>
+          <ref name="document-attribute"/>
+          <optional>
+            <ref name="version-attribute"/>
+          </optional>
+          <optional>
+            <ref name="repository-attribute"/>
+          </optional>
+        </group>
+      </choice>
+    </define>
+  </include>
+
+  <define name="mathml-math">
+    <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+  </define>
+
+  <include href="../../../../qml/schema/rng/1.0/qml-defs.rng">
+    <define name="qml-text">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="media"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+  </include>
+
+  <include href="cnxml-defs.rng">
+    <define name="metadata-content">
+      <ref name="mdml-metadata-content"/>
+    </define>
+    <define name="content-content">
+      <choice>
+        <oneOrMore>
+          <ref name="section-content-class"/>
+        </oneOrMore>
+        <ref name="qml.problemset"/>
+      </choice>
+    </define>
+    <define name="exercise-content-extras">
+      <ref name="qml.item"/>
+    </define>
+    <define name="equation-content-extras">
+      <ref name="mathml-math"/>
+    </define>
+    <define name="bibliography">
+      <externalRef href="../../../../bibtexml/schema/rng/1.0/bibtexml.rng"/>
+    </define>
+  </include>
+
+  <define name="text-extras" combine="choice">
+    <ref name="mathml-math"/>
+  </define>
+
+  <define name="metadata-extra-attributes" combine="interleave">
+    <attribute name="mdml-version">
+      <value>0.5</value>
+    </attribute>
+  </define>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-common.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-common.rng
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:cnxml="http://cnx.rice.edu/cnxml"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <include href="cnxml-abstract-defs.rng">
+    <define name="cnxml-abstract-common-attributes">
+      <ref name="common-attributes-noclass"/>
+    </define>
+    <define name="cnxml-abstract-list-type-attribute">
+      <choice>
+        <ref name="bulleted-list-type-attribute"/>
+        <ref name="enumerated-list-type-attribute"/>
+      </choice>
+    </define>
+    <define name="cnxml-abstract-display-attribute">
+      <ref name="display-attribute"/>
+    </define>
+  </include>
+
+  <define name="cnxml-abstract-text-extras" combine="choice">
+    <ref name="mathml-math"/>
+  </define>
+
+  <include href="http://cnx.rice.edu/technology/mdml/schema/rng/0.5/mdml-defs.rng">
+    <define name="mdml-metadata">
+      <notAllowed/>
+    </define>
+    <define name="mdml-abstract-content">
+      <ref name="cnxml-abstract-content"/>
+    </define>
+    <define name="mdml-common-attributes">
+      <ref name="common-attributes"/>
+    </define>
+    <define name="mdml-extended-attribution-content">
+      <cnxml:para>Contains CNXML 'linkgroup' elements that contain 'link' elements naming and referring to those to whom attribution is being given.</cnxml:para>
+      <oneOrMore>
+        <ref name="link-group"/>
+      </oneOrMore>
+    </define>
+    <define name="mdml-derived-from-attributes">
+      <cnxml:para>Makes use of the attributes from CNXML 'link' to form references to the parent works.</cnxml:para>
+      <choice>
+        <ref name="url-attribute"/>
+        <group>
+          <ref name="document-attribute"/>
+          <optional>
+            <ref name="version-attribute"/>
+          </optional>
+          <optional>
+            <ref name="repository-attribute"/>
+          </optional>
+        </group>
+      </choice>
+    </define>
+  </include>
+
+  <define name="mathml-math">
+    <externalRef href="https://www.w3.org/Math/RelaxNG/mathml3/mathml3.rng"/>
+  </define>
+
+  <include href="http://cnx.rice.edu/technology/qml/schema/rng/1.0/qml-defs.rng">
+    <define name="qml-text">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="media"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+  </include>
+
+  <include href="cnxml-defs.rng">
+    <define name="metadata-content">
+      <ref name="mdml-metadata-content"/>
+    </define>
+    <define name="content-content">
+      <choice>
+        <oneOrMore>
+          <ref name="section-content-class"/>
+        </oneOrMore>
+        <ref name="qml.problemset"/>
+      </choice>
+    </define>
+    <define name="exercise-content-extras">
+      <ref name="qml.item"/>
+    </define>
+    <define name="equation-content-extras">
+      <ref name="mathml-math"/>
+    </define>
+    <define name="bibliography">
+      <externalRef href="http://cnx.rice.edu/technology/bibtexml/schema/rng/1.0/bibtexml.rng"/>
+    </define>
+  </include>
+
+  <define name="text-extras" combine="choice">
+    <ref name="mathml-math"/>
+  </define>
+
+  <define name="metadata-extra-attributes" combine="interleave">
+    <attribute name="mdml-version">
+      <value>0.5</value>
+    </attribute>
+  </define>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-defs.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-defs.rng
@@ -1,0 +1,2372 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+         xmlns:cnxml="http://cnx.rice.edu/cnxml"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         ns="http://cnx.rice.edu/cnxml">
+
+<!--
+    Attribute Definitions
+-->
+
+  <define name="id-attribute">
+    <cnxml:para class="description">An attribute of the ID type, whose value must be unique within the module document.</cnxml:para>
+    <attribute name="id">
+      <data type="ID"/>
+    </attribute>
+  </define>
+
+  <define name="class-attribute">
+    <cnxml:para class="description">An attribute whose values authors may use to augment the semantics of the element to which it is applied.</cnxml:para>
+    <cnxml:para class="content">Content: a space-separated list of text nodes (Relax NG 'token').</cnxml:para>
+    <attribute name="class">
+      <data type="token"/>
+    </attribute>
+  </define>
+
+  <define name="foreign-namespaced-attribute">
+    <cnxml:para class="description">Any attribute except (1) one not in a namespace; (2) one in the CNXML, CollXML, or Connexions system-info namespaces; and (3) @xml:lang.</cnxml:para>
+    <zeroOrMore>
+      <attribute>
+        <anyName>
+          <except>
+            <nsName ns=""/>
+            <nsName ns="http://cnx.rice.edu/cnxml"/>
+            <nsName ns="http://cnx.rice.edu/collxml"/>
+            <nsName ns="http://cnx.rice.edu/system-info"/>
+            <name>xml:lang</name>
+          </except>
+        </anyName>
+      </attribute>
+    </zeroOrMore>
+  </define>
+
+  <!-- We enumerate supported values, but any text values are accepted. -->
+  <define name="effect-attribute">
+    <cnxml:para class="description">An attribute whose value specifies a display property for the content of the element to which the attribute is attached.</cnxml:para>
+    <cnxml:para class="content">Content is text with no spaces (NMTOKEN).</cnxml:para>
+    <attribute name="effect">
+      <choice cnxml:class="supported-values">
+        <value>bold</value>
+        <value>italics</value>
+        <value>underline</value>
+        <value>normal</value>
+        <value>smallcaps</value>
+        <data type="NMTOKEN"/>
+      </choice>
+    </attribute>
+  </define>
+
+  <div>
+    <cnxml:para class="description">An attribute that specifies how its parent element displays with respect to the flow of content. A value of 'block' causes the parent element to be set off from preceding and following text with vertical space; a value of 'inline' causes the parent element to be displayed continuously with any preceding and following content that is also 'inline'; a value of 'none' causes the element not to be rendered.</cnxml:para>
+    <cnxml:list class="possible-values">
+      <cnxml:title>Possible values:</cnxml:title>
+      <cnxml:item>block</cnxml:item>
+      <cnxml:item>inline</cnxml:item>
+      <cnxml:item>none</cnxml:item>
+    </cnxml:list>
+    <define name="display-attribute">
+      <optional>
+        <choice>
+          <ref name="display-block-attribute"/>
+          <ref name="display-inline-attribute"/>
+          <ref name="display-none-attribute"/>
+        </choice>
+      </optional>
+    </define>
+
+    <define name="display-block-default-attribute">
+      <cnxml:para class="description">An attribute that specifies how a parent element in a block-only context displays with respect to the flow of content. A value of 'block' causes the parent element to be set off from preceding and following text with vertical space; a value of 'none' causes the element not to be rendered.</cnxml:para>
+      <optional>
+        <attribute name="display" a:defaultValue="block">
+          <choice cnxml:class="possible-values">
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+    </define>
+
+    <define name="display-block-attribute">
+      <cnxml:para class="description">An attribute that specifies how a parent element in a block-only context displays with respect to the flow of content. A value of 'block' causes the parent element to be set off from preceding and following text with vertical space; a value of 'none' causes the element not to be rendered.</cnxml:para>
+      <attribute name="display">
+        <choice cnxml:class="possible-values">
+          <value>block</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+    </define>
+
+    <define name="display-inline-default-attribute">
+      <optional>
+        <attribute name="display" a:defaultValue="inline">
+          <choice>
+            <value>inline</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+    </define>
+
+    <define name="display-any-attribute">
+      <optional>
+        <attribute name="display">
+          <choice>
+            <value>block</value>
+            <value>inline</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+    </define>
+
+    <define name="display-inline-attribute">
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+    </define>
+
+    <define name="display-none-attribute">
+      <attribute name="display">
+        <value>none</value>
+      </attribute>
+    </define>
+  </div>
+
+  <define name="type-attribute">
+    <cnxml:para class="description">An attribute whose value affects the numbering of its parent element.  Numbered elements are numbered with elements having the same element name and 'type' value.  Elements have a default 'type' identical to their element name.  Thus, a 'definition' with a type of 'lemma' will not be numbered in the same sequence with 'definition' elements having the default 'type' value.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <optional>
+      <attribute name="type"/>
+    </optional>
+  </define>
+
+  <define name="strength-attribute">
+    <cnxml:para class="description">An attribute that indicates how strongly related the parent 'link' element is to the content in which it occurs.</cnxml:para>
+    <attribute name="strength">
+      <choice cnxml:class="possible-values">
+        <value>1</value>
+        <value>2</value>
+        <value>3</value>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="window-attribute">
+    <cnxml:para class="description">An attribute that instructs the browser either to replace the current window with the link target, or to open the link target in a new window, when the parent 'link' element is activated.</cnxml:para>
+    <optional>
+      <attribute name="window" a:defaultValue="replace">
+        <choice cnxml:class="possible-values">
+          <value>replace</value>
+          <value>new</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="url-attribute">
+    <cnxml:para class="description">An attribute containing the URL of the resource the parent link points to.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="url"/>
+  </define>
+
+  <define name="document-attribute">
+    <cnxml:para class="description">An attribute containing the module or collection ID of the learning object the parent link points to.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="document"/>
+  </define>
+
+  <define name="version-attribute">
+    <cnxml:para class="description">An attribute containing the version number of the learning object the parent link points to.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="version"/>
+  </define>
+
+  <define name="targetid-attribute">
+    <cnxml:para class="description">An attribute containing the XML element ID of the element the parent link points to.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="target-id"/>
+  </define>
+
+  <define name="resource-attribute">
+    <cnxml:para class="description">An attribute containing the XML element ID of the element the parent link points to.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="resource"/>
+  </define>
+
+  <!-- Attributes pattern for 'link' element.  Require at least one
+       attribute that points to a link target: either @url, or at
+       least one of the old cnxn-style linking attributes (@document,
+       @targetid, or @resource).  It takes a little effort to make
+       this pattern unambiguous.  -->
+  <define name="link-attributes">
+    <group>
+      <optional>
+        <ref name="strength-attribute"/>
+      </optional>
+      <ref name="window-attribute"/>
+      <choice>
+        <ref name="url-attribute"/>
+        <group>
+          <ref name="document-attribute"/>
+          <ref name="version-attribute"/>
+          <optional>
+            <choice>
+              <ref name="targetid-attribute"/>
+              <ref name="resource-attribute"/>
+            </choice>
+          </optional>
+        </group>
+        <group>
+          <ref name="document-attribute"/>
+          <optional>
+            <choice>
+              <ref name="targetid-attribute"/>
+              <ref name="resource-attribute"/>
+            </choice>
+          </optional>
+        </group>
+        <group>
+          <ref name="version-attribute"/>
+          <optional>
+            <choice>
+              <ref name="targetid-attribute"/>
+              <ref name="resource-attribute"/>
+            </choice>
+          </optional>
+        </group>
+        <group>
+          <choice>
+            <ref name="targetid-attribute"/>
+            <ref name="resource-attribute"/>
+          </choice>
+        </group>
+      </choice>
+    </group>
+  </define>
+
+  <!-- For linking elements other than 'link'.  Here we can afford to
+       make each attribute optional, so no problems with ambiguity.  -->
+  <define name="linking-attributes">
+    <group>
+      <ref name="window-attribute"/>
+      <choice>
+        <optional>
+          <ref name="url-attribute"/>
+        </optional>
+        <group>
+          <optional>
+            <ref name="document-attribute"/>
+          </optional>
+          <optional>
+            <ref name="version-attribute"/>
+          </optional>
+          <optional>
+            <choice>
+              <ref name="targetid-attribute"/>
+              <ref name="resource-attribute"/>
+            </choice>
+          </optional>
+        </group>
+      </choice>
+    </group>
+  </define>
+
+  <define name="note-type-attribute">
+    <cnxml:para class="description">An attribute that controls the automatically generated label for the parent 'note' element.</cnxml:para>
+    <cnxml:para class="content">Content is text, except the case-insensitive string 'footnote' (Relax NG).</cnxml:para>
+    <optional>
+      <attribute name="type" a:defaultValue="note">
+        <choice cnxml:class="supported-values">
+          <value>note</value>
+          <value>aside</value>
+          <value>warning</value>
+          <value>tip</value>
+          <value>important</value>
+          <data type="token">
+            <except>
+              <data type="token">
+                <param name="pattern">[fF][oO][oO][tT][nN][oO][tT][eE]</param>
+              </data>
+            </except>
+          </data>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <div>
+    <cnxml:para class="description">An attribute whether the list's items should be rendered with bullets, enumerations, or labels as the item marks.</cnxml:para>
+    <cnxml:list class="possible-values">
+      <cnxml:title>Possible values:</cnxml:title>
+      <cnxml:item>bulleted</cnxml:item>
+      <cnxml:item>enumerated</cnxml:item>
+      <cnxml:item>labeled-item</cnxml:item>
+    </cnxml:list>
+    <define name="list-type-attribute">
+      <optional>
+        <attribute name="list-type" a:defaultValue="bulleted">
+          <choice>
+            <value>bulleted</value>
+            <value>enumerated</value>
+            <value>labeled-item</value>
+          </choice>
+        </attribute>
+      </optional>
+    </define>
+
+    <define name="bulleted-list-type-attribute">
+      <optional>
+        <attribute name="list-type" a:defaultValue="bulleted">
+          <value>bulleted</value>
+        </attribute>
+      </optional>
+    </define>
+
+    <define name="enumerated-list-type-attribute">
+      <attribute name="list-type">
+        <value>enumerated</value>
+      </attribute>
+    </define>
+
+    <define name="labeled-item-list-type-attribute">
+      <attribute name="list-type">
+        <value>labeled-item</value>
+      </attribute>
+    </define>
+  </div>
+
+  <define name="bullet-style-attribute">
+    <cnxml:para class="description">An attribute that specifies the symbol to use for the bullets in the parent 'list' element's 'item' children.  May occur only on 'list' elements with a 'list-type' of 'bulleted'.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <optional>
+      <attribute name="bullet-style" a:defaultValue="bullet">
+        <choice cnxml:class="supported-values">
+          <value>bullet</value>
+          <value>open-circle</value>
+          <value>pilcrow</value>
+          <value>rpilcrow</value>
+          <value>asterisk</value>
+          <value>dash</value>
+          <value>section</value>
+          <value>none</value>
+          <text/>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="number-style-attribute">
+    <cnxml:para class="description">An attribute that style of number to use for the enumerations in the parent 'list' element's 'item' children.  May occur only on 'list' elements with a 'list-type' of 'enumerated'.</cnxml:para>
+    <optional>
+      <attribute name="number-style" a:defaultValue="arabic">
+        <choice cnxml:class="possible-values">
+          <value>arabic</value>
+          <value>upper-alpha</value>
+          <value>lower-alpha</value>
+          <value>upper-roman</value>
+          <value>lower-roman</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="mark-prefix-attribute">
+    <cnxml:para class="description">An attribute that specifies characters that should appear beforethe marks of the 'item' children of the parent 'list' element.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <cnxml:para class="default-value">Default is the empty string.</cnxml:para>
+    <optional>
+      <attribute name="mark-prefix"/>
+    </optional>
+  </define>
+
+  <define name="mark-suffix-attribute">
+    <cnxml:para class="description">An attribute that specifies characters that should appear after the marks and before the content of the 'item' children of the parent 'list' element for lists whose 'list-type' attribute is 'enumerated'.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <cnxml:para class="default-value">Default is the period '.'.</cnxml:para>
+    <optional>
+      <attribute name="mark-suffix" a:defaultValue="."/>
+    </optional>
+  </define>
+
+  <define name="bulleted-mark-suffix-attribute">
+    <cnxml:para class="description">An attribute that specifies characters that should appear after the marks and before the content of the 'item' children of the parent 'list' element for lists whose 'list-type' attribute is 'bulleted'.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <cnxml:para class="default-value">Default is the empty string.</cnxml:para>
+    <optional>
+      <attribute name="mark-suffix" a:defaultValue=""/>
+    </optional>
+  </define>
+
+  <define name="labeled-item-mark-suffix-attribute">
+    <cnxml:para class="description">An attribute that specifies characters that should appear after the marks and before the content of the 'item' children of the parent 'list' element for lists whose 'list-type' attribute is 'labeled-item'.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <cnxml:para class="default-value">Default is the colon ':'.</cnxml:para>
+    <optional>
+      <attribute name="mark-suffix" a:defaultValue=":"/>
+    </optional>
+  </define>
+
+  <define name="block-item-sep-attribute">
+    <cnxml:para class="description">An attribute that specifies characters that should appear at the end of list items in 'list' elements whose 'list-type' attribute is 'block'.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <cnxml:para class="default-value">Default is the empty string.</cnxml:para>
+    <optional>
+      <attribute name="item-sep"/>
+    </optional>
+  </define>
+
+  <define name="inline-item-sep-attribute">
+    <cnxml:para class="description">An attribute that specifies characters that should appear at the end of list items in 'list' elements whose 'list-type' attribute is 'inline'.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <cnxml:para class="default-value">Default is the semicolon ';'.</cnxml:para>
+    <optional>
+      <attribute name="item-sep" a:defaultValue=";"/>
+    </optional>
+  </define>
+
+  <define name="start-value-attribute">
+    <cnxml:para class="description">An attribute that specifies the starting value of the enumerations of 'item' children of 'list' elements whose 'list-type' attribute is 'enumerated'.</cnxml:para>
+    <cnxml:para class="content">Content is an integer >= 0 (XSD datatype).</cnxml:para>
+    <cnxml:para class="default-value">Default is 1.</cnxml:para>
+    <optional>
+      <attribute name="start-value" a:defaultValue="1">
+        <data type="integer">
+          <param name="minInclusive">1</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="code-lang-attribute">
+    <cnxml:para class="description">An attribute whose value denotes the computer language of the code in the parent code element.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="lang"/>
+  </define>
+
+  <define name="alt-attribute">
+    <cnxml:para class="description">An attribute whose value specifies alternate text for user agents that cannot display images and other audiovisual media.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="alt"/>
+  </define>
+
+  <define name="longdesc-attribute">
+    <cnxml:para class="description">An attribute whose value specifies a longer description of the parent media object as a supplement to the alternate text in the 'alt' attribute.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG).</cnxml:para>
+    <attribute name="longdesc"/>
+  </define>
+
+  <define name="height-attribute">
+    <attribute name="height"/>
+  </define>
+
+  <define name="width-attribute">
+    <attribute name="width"/>
+  </define>
+
+  <define name="print-width-attribute">
+    <cnxml:para class="description">An attribute whose value specifies an absolute or proportional width for the parent media object when it is rendered in print.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG). Authors should supply a number followed by a two-letter abbreviation for units of length as used in LaTeX (e.g. <cnxml:list display="inline" item-sep=", " bullet-style="none"><cnxml:item>'cm'</cnxml:item><cnxml:item>'mm'</cnxml:item><cnxml:item>'in'</cnxml:item><cnxml:item>'pt'</cnxml:item><cnxml:item>'em'</cnxml:item><cnxml:item>'pc'</cnxml:item></cnxml:list>), or by a percent sign '%' for proportional scaling.</cnxml:para>
+    <attribute name="print-width"/>
+  </define>
+
+  <define name="src-attribute">
+    <cnxml:para class="description">An attribute whose value specifies a URL or filesystem path to the media object represented by the parent media object element.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG). Authors should supply a filesystem or URL path.</cnxml:para>
+    <attribute name="src"/>
+  </define>
+
+  <define name="mime-type-attribute">
+    <cnxml:para class="description">An attribute whose value specifies the type of media object represented by the parent media object element.</cnxml:para>
+    <cnxml:para class="content">Content is text (Relax NG). Authors should supply a value from the IANA registry of MIME media types.</cnxml:para>
+    <attribute name="mime-type"/>
+  </define>
+
+  <define name="for-attribute">
+    <cnxml:para class="description">An attribute whose value specifies the output format for which the parent media object is intended.</cnxml:para>
+    <cnxml:para class="content">Content is text (NMTOKEN).</cnxml:para>
+    <attribute name="for">
+      <choice cnxml:class="supported-values">
+        <value>online</value>
+        <value>pdf</value>
+        <data type="NMTOKEN"/>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="thumbnail-attribute">
+    <attribute name="thumbnail"/>
+  </define>
+
+  <define name="codebase-attribute">
+    <attribute name="codebase"/>
+  </define>
+
+  <define name="code-attribute">
+    <attribute name="code"/>
+  </define>
+
+  <define name="archive-attribute">
+    <attribute name="archive"/>
+  </define>
+
+  <define name="name-attribute">
+    <attribute name="name"/>
+  </define>
+
+  <define name="wmode-attribute">
+    <attribute name="wmode">
+      <choice>
+        <value>window</value>
+        <value>opaque</value>
+        <value>transparent</value>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="quality-attribute">
+    <attribute name="quality">
+      <choice>
+        <value>low</value>
+        <value>autolow</value>
+        <value>autohigh</value>
+        <value>medium</value>
+        <value>high</value>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="scale-attribute">
+    <optional>
+      <attribute name="scale" a:defaultValue="default">
+        <choice>
+          <value>default</value>
+          <value>noorder</value>
+          <value>exactfit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="bgcolor-attribute">
+    <attribute name="bgcolor">
+      <data type="token">
+        <param name="pattern">#[a-fA-F0-9]{6}</param>
+      </data>
+    </attribute>
+  </define>
+
+  <define name="flash-vars-attribute">
+    <attribute name="flash-vars">
+      <text/>
+    </attribute>
+  </define>
+
+  <define name="standby-attribute">
+    <optional>
+      <attribute name="standby">
+        <text/>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="autoplay-attribute">
+    <optional>
+      <attribute name="autoplay" a:defaultValue="false">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="loop-attribute">
+    <optional>
+      <attribute name="loop" a:defaultValue="false">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="controller-attribute">
+    <optional>
+      <attribute name="controller" a:defaultValue="false">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="volume-attribute">
+    <optional>
+      <attribute name="volume" a:defaultValue="50">
+        <data type="integer">
+          <param name="minInclusive">1</param>
+          <param name="maxInclusive">100</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="viname-attribute">
+    <attribute name="viname"/>
+  </define>
+
+  <define name="labview-version-attribute">
+    <attribute name="version">
+      <choice>
+        <value>7.0</value>
+        <value>8.0</value>
+        <value>8.2</value>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="pub-type">
+    <cnxml:para class="description">An attribute that denotes the type of publication being cited by the parent 'cite-title' element.</cnxml:para>
+    <attribute name="pub-type">
+      <choice cnxml:class="possible-values">
+        <value>article</value>
+        <value>book</value>
+        <value>booklet</value>
+        <value>conference</value>
+        <value>inbook</value>
+        <value>incollection</value>
+        <value>inproceedings</value>
+        <value>manual</value>
+        <value>mastersthesis</value>
+        <value>misc</value>
+        <value>phdthesis</value>
+        <value>proceedings</value>
+        <value>techreport</value>
+        <value>unpublished</value>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="link-group-type-attribute">
+    <attribute name="type">
+      <choice>
+        <value>prerequisite</value>
+        <value>example</value>
+        <value>supplemental</value>
+        <text/>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="rule-type-attribute">
+    <optional>
+      <attribute name="type" a:defaultValue="rule">
+        <choice>
+          <value>rule</value>
+          <value>theorem</value>
+          <value>lemma</value>
+          <value>corollary</value>
+          <value>law</value>
+          <value>proposition</value>
+          <text/>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="seealso-type-attribute">
+    <optional>
+      <attribute name="type">
+        <choice>
+          <value>related-term</value>
+          <value>narrower-term</value>
+          <value>broader-term</value>
+          <value>use-for</value>
+          <value>use</value>
+          <text/>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="cnxml-version">
+    <attribute name="cnxml-version">
+      <value>0.8</value>
+    </attribute>
+  </define>
+
+  <define name="count-attribute">
+    <optional>
+      <attribute name="count" a:defaultValue="1">
+        <data type="integer">
+          <param name="minInclusive">1</param>
+        </data>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="print-placement-attribute">
+    <optional>
+      <attribute name="print-placement">
+        <choice>
+          <value>here</value>
+          <value>end</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="common-attributes-noclass">
+    <ref name="foreign-namespaced-attribute"/>
+    <optional>
+      <attribute name="xml:lang"/>
+    </optional>
+  </define>
+
+  <define name="common-attributes">
+    <ref name="common-attributes-noclass"/>
+    <optional>
+      <ref name="class-attribute"/>
+    </optional>
+  </define>
+
+<!--
+    Content Classes
+-->
+
+  <define name="text-extras">
+    <text/>
+  </define>
+
+  <define name="inline-class">
+    <choice>
+      <ref name="text-extras"/>
+      <ref name="span"/>
+      <ref name="term"/>
+      <ref name="cite"/>
+      <ref name="cite-title"/>
+      <ref name="foreign"/>
+      <ref name="emphasis"/>
+      <ref name="sub"/>
+      <ref name="sup"/>
+      <ref name="inline-code"/>
+      <ref name="inline-preformat"/>
+      <ref name="inline-quote"/>
+      <ref name="inline-note"/>
+      <ref name="inline-list"/>
+      <ref name="inline-media"/>
+      <ref name="footnote"/>
+      <ref name="link"/>
+      <ref name="newline"/>
+      <ref name="space"/>
+    </choice>
+  </define>
+
+  <define name="basic-blocks-class">
+    <choice>
+      <ref name='div'/>
+      <ref name='definition'/>
+      <ref name='example'/>
+      <ref name='figure'/>
+      <ref name='block-code'/>
+      <ref name='block-preformat'/>
+      <ref name='block-quote'/>
+      <ref name='block-note'/>
+      <ref name='block-media'/>
+      <ref name='block-list'/>
+      <ref name='table'/>
+      <ref name='rule'/>
+      <ref name='equation'/>
+      <ref name='exercise'/>
+    </choice>
+  </define>
+
+  <define name="para-content-class">
+    <choice>
+      <ref name="inline-class"/>
+      <ref name="basic-blocks-class"/>
+    </choice>
+  </define>
+
+  <define name="div-content-class">
+    <choice>
+      <ref name="para"/>
+      <ref name="para-content-class"/>
+    </choice>
+  </define>
+
+  <define name="section-content-class">
+    <choice>
+      <ref name="section"/>
+      <ref name="basic-blocks-class"/>
+      <ref name="para"/>
+    </choice>
+  </define>
+
+  <define name="media-object-class">
+    <choice>
+      <ref name="object"/>
+      <ref name="image"/>
+      <ref name="audio"/>
+      <ref name="video"/>
+      <ref name="java-applet"/>
+      <ref name="flash"/>
+      <ref name="iframe"/>
+      <ref name="labview"/>
+      <ref name="text"/>
+      <ref name="download"/>
+    </choice>
+  </define>
+
+  <define name="media-object-fallback-class">
+    <choice>
+      <ref name="text-extras"/>
+      <ref name="span"/>
+      <ref name="term"/>
+      <ref name="cite"/>
+      <ref name="cite-title"/>
+      <ref name="foreign"/>
+      <ref name="emphasis"/>
+      <ref name="sub"/>
+      <ref name="sup"/>
+      <ref name="inline-code"/>
+      <ref name="inline-preformat"/>
+      <ref name="inline-quote"/>
+      <ref name="inline-note"/>
+      <ref name="inline-list"/>
+      <ref name="media-object-class"/>
+    </choice>
+  </define>
+<!--
+    Shared Content Models
+-->
+
+  <define name="inline-content">
+    <ref name="common-attributes"/>
+    <optional>
+      <ref name="id-attribute"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="inline-class"/>
+    </zeroOrMore>
+  </define>
+
+  <define name="div-content">
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <ref name="div-content-class"/>
+    </oneOrMore>
+  </define>
+
+  <define name="section-content">
+    <ref name="common-attributes"/>
+    <ref name="id-attribute"/>
+    <ref name="type-attribute"/>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <ref name="section-content-class"/>
+    </oneOrMore>
+  </define>
+
+  <define name="statement-content">
+    <ref name="section-content"/>
+  </define>
+<!--
+    Element Definitions
+-->
+
+  <define name="anyElement">
+    <element>
+      <anyName/>
+      <zeroOrMore>
+	<choice>
+	  <attribute>
+	    <anyName/>
+	  </attribute>
+	  <text/>
+	  <ref name="anyElement"/>
+	</choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="document">
+    <element name="document">
+      <ref name="id-attribute"/><!-- Rename this object-id -->
+      <ref name="common-attributes"/>
+      <ref name="document-title"/>
+      <ref name="cnxml-version"/>
+      <attribute name="module-id"/>
+      <optional>
+        <ref name="metadata"/>
+      </optional>
+      <optional>
+        <ref name="featured-links"/>
+      </optional>
+      <ref name="content"/>
+      <optional>
+        <ref name="glossary"/>
+      </optional>
+      <optional>
+        <ref name="bibliography"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="metadata">
+    <element name="metadata">
+      <ref name="common-attributes"/>
+      <ref name="metadata-extra-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="metadata-content"/>
+    </element>
+  </define>
+
+  <define name="metadata-extra-attributes">
+    <empty/>
+  </define>
+
+  <define name="featured-links">
+    <element name="featured-links">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <oneOrMore>
+        <ref name="link-group"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="link-group">
+    <element name="link-group">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="link-group-type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <oneOrMore>
+        <ref name="link"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="metadata-content">
+    <zeroOrMore>
+      <choice>
+        <ref name="anyElement"/>
+        <text/>
+      </choice>
+    </zeroOrMore>
+  </define>
+
+  <define name="content">
+    <element name="content">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="content-content"/>
+    </element>
+  </define>
+
+  <define name="content-content">
+    <oneOrMore>
+      <ref name="section-content-class"/>
+    </oneOrMore>
+  </define>
+
+  <define name="glossary">
+    <element name="glossary">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <oneOrMore>
+        <ref name="definition"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="bibliography">
+    <empty/>
+  </define>
+
+  <define name="section">
+    <element name="section">
+      <ref name="section-content"/>
+    </element>
+  </define>
+
+  <define name="div">
+    <element name="div">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+  <define name="block-preformat">
+    <element name="preformat">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="display-block-default-attribute"/>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+  <define name="inline-preformat">
+    <element name="preformat">
+      <ref name="display-inline-attribute"/>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="para">
+    <element name="para">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="para-content-class"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="title">
+    <element name="title">
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="document-title">
+    <element name="title">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
+
+  <define name="label">
+    <element name="label">
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="newline">
+    <element name="newline">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="count-attribute"/>
+      <optional>
+        <ref name="effect-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="space">
+    <element name="space">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="count-attribute"/>
+      <optional>
+        <ref name="effect-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="span">
+    <element name="span">
+      <optional>
+        <ref name="effect-attribute"/>
+      </optional>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="cite">
+    <element name="cite">
+      <ref name="linking-attributes"/>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="cite-title">
+    <element name="cite-title">
+      <optional>
+        <ref name="pub-type"/>
+      </optional>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="link">
+    <element name="link">
+      <ref name="link-attributes"/>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="emphasis">
+    <element name="emphasis">
+      <optional>
+        <ref name="effect-attribute"/>
+      </optional>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="term">
+    <element name="term">
+      <ref name="linking-attributes"/>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="sub">
+    <element name="sub">
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="sup">
+    <element name="sup">
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="block-quote">
+    <element name="quote">
+      <ref name="display-block-default-attribute"/>
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="type-attribute"/>
+      <ref name="linking-attributes"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+  <define name="inline-quote">
+    <element name="quote">
+      <ref name="display-inline-attribute"/>
+      <ref name="linking-attributes"/>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="foreign">
+    <element name="foreign">
+      <ref name="linking-attributes"/>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="footnote">
+    <element name="footnote">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+<!-- FIXME: Do we want to continue to permit 'media' or text in 'equation'? -->
+  <define name="equation">
+    <element name="equation">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <choice>
+        <ref name="media"/>
+        <text/>
+        <ref name="equation-content-extras"/>
+      </choice>
+    </element>
+  </define>
+
+  <define name="equation-content-extras">
+    <empty/>
+  </define>
+
+  <define name="block-note">
+    <element name="note">
+      <ref name="display-block-default-attribute"/>
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="note-type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+  <define name="inline-note">
+    <element name="note">
+      <ref name="display-inline-attribute"/>
+      <ref name="note-type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="note">
+    <choice>
+      <ref name="block-note"/>
+      <ref name="inline-note"/>
+    </choice>
+  </define>
+
+  <define name="list-common-content">
+    <ref name="common-attributes"/>
+    <ref name="mark-prefix-attribute"/>
+    <ref name="type-attribute"/>
+  </define>
+
+  <define name="block-list-common-content">
+    <ref name="display-block-default-attribute"/>
+    <ref name="id-attribute"/>
+    <ref name="block-item-sep-attribute"/>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <ref name="block-list-item"/>
+    </oneOrMore>
+  </define>
+
+  <define name="inline-list-common-content">
+    <ref name="display-inline-attribute"/>
+    <optional>
+      <ref name="id-attribute"/>
+    </optional>
+    <ref name="inline-item-sep-attribute"/>
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="title"/>
+    </optional>
+    <oneOrMore>
+      <ref name="inline-list-item"/>
+    </oneOrMore>
+  </define>
+
+  <define name="bulleted-list-common-content">
+    <ref name="bulleted-list-type-attribute"/>
+    <ref name="bulleted-mark-suffix-attribute"/>
+    <ref name="bullet-style-attribute"/>
+    <ref name="list-common-content"/>
+  </define>
+
+  <define name="bulleted-block-list">
+    <element name="list">
+      <ref name="bulleted-list-common-content"/>
+      <ref name="block-list-common-content"/>
+    </element>
+  </define>
+
+  <define name="bulleted-inline-list">
+    <element name="list">
+      <ref name="bulleted-list-common-content"/>
+      <ref name="inline-list-common-content"/>
+    </element>
+  </define>
+
+  <define name="enumerated-list-common-content">
+    <ref name="mark-suffix-attribute"/>
+    <ref name="enumerated-list-type-attribute"/>
+    <ref name="number-style-attribute"/>
+    <ref name="start-value-attribute"/>
+    <ref name="list-common-content"/>
+  </define>
+
+  <define name="enumerated-block-list">
+    <element name="list">
+      <ref name="enumerated-list-common-content"/>
+      <ref name="block-list-common-content"/>
+    </element>
+  </define>
+
+  <define name="enumerated-inline-list">
+    <element name="list">
+      <ref name="enumerated-list-common-content"/>
+      <ref name="inline-list-common-content"/>
+    </element>
+  </define>
+
+  <define name="labeled-item-list-common-content">
+    <ref name="labeled-item-mark-suffix-attribute"/>
+    <ref name="labeled-item-list-type-attribute"/>
+    <ref name="list-common-content"/>
+  </define>
+
+  <define name="labeled-item-block-list">
+    <element name="list">
+      <ref name="labeled-item-list-common-content"/>
+      <ref name="block-list-common-content"/>
+    </element>
+  </define>
+
+  <define name="labeled-item-inline-list">
+    <element name="list">
+      <ref name="labeled-item-list-common-content"/>
+      <ref name="inline-list-common-content"/>
+    </element>
+  </define>
+
+  <define name="block-list">
+    <choice>
+      <ref name="bulleted-block-list"/>
+      <ref name="enumerated-block-list"/>
+      <ref name="labeled-item-block-list"/>
+    </choice>
+  </define>
+
+  <define name="inline-list">
+    <choice>
+      <ref name="bulleted-inline-list"/>
+      <ref name="enumerated-inline-list"/>
+      <ref name="labeled-item-inline-list"/>
+    </choice>
+  </define>
+
+  <define name="list">
+    <choice>
+      <ref name="block-list"/>
+      <ref name="inline-list"/>
+    </choice>
+  </define>
+
+  <define name="block-list-item">
+    <element name="item">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="div-content-class"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="inline-list-item">
+    <element name="item">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="inline-class"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="inline-code">
+    <element name="code">
+      <ref name="display-inline-default-attribute"/>
+      <optional>
+        <ref name="code-lang-attribute"/>
+      </optional>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="common-attributes"/>
+      <oneOrMore>
+        <ref name="inline-class"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="block-code">
+    <element name="code">
+      <ref name="display-block-attribute"/>
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <optional>
+        <ref name="code-lang-attribute"/>
+      </optional>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+          <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="inline-class"/>
+      </oneOrMore>
+      <optional>
+          <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="code">
+    <choice>
+      <ref name="inline-code"/>
+      <ref name="block-code"/>
+    </choice>
+  </define>
+
+<!-- NOTE: I have removed 'table' and 'code' as possible content for
+     'figure', but this decision can be revisited. -->
+  <define name="figure">
+    <element name="figure">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <optional>
+        <attribute name="orient" a:defaultValue="horizontal">
+          <choice>
+            <value>horizontal</value>
+            <value>vertical</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <choice>
+        <ref name="media"/>
+        <ref name="table"/>
+        <ref name="code"/>
+        <group>
+          <ref name="subfigure"/>
+          <oneOrMore>
+            <ref name="subfigure"/>
+          </oneOrMore>
+        </group>
+      </choice>
+      <optional>
+        <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="subfigure">
+    <element name="subfigure">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <choice>
+        <ref name="media"/>
+        <ref name="table"/>
+        <ref name="code"/>
+      </choice>
+      <optional>
+        <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="caption">
+    <element name="caption">
+      <ref name="inline-content"/>
+    </element>
+  </define>
+
+  <define name="media-common-content">
+    <ref name="common-attributes"/>
+    <ref name="id-attribute"/>
+    <ref name="alt-attribute"/>
+    <optional>
+      <ref name="longdesc"/>
+    </optional>
+    <ref name="media-object-class"/>
+    <zeroOrMore>
+      <ref name="media-object-class"/>
+    </zeroOrMore>
+  </define>
+
+  <define name="inline-media">
+    <element name="media">
+      <optional>
+        <ref name="display-inline-attribute"/>
+      </optional>
+      <ref name="media-common-content"/>
+    </element>
+  </define>
+
+  <define name="block-media">
+    <element name="media">
+      <ref name="display-any-attribute"/>
+      <ref name="media-common-content"/>
+    </element>
+  </define>
+
+  <define name="nodisplay-media">
+    <element name="media">
+      <ref name="display-none-attribute"/>
+      <ref name="media-common-content"/>
+    </element>
+  </define>
+
+  <define name="longdesc-element">
+    <element name="longdesc">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+  <define name="longdesc">
+    <choice>
+      <ref name="longdesc-attribute"/>
+      <ref name="longdesc-element"/>
+    </choice>
+  </define>
+
+  <define name="media">
+    <choice>
+      <ref name="block-media"/>
+      <ref name="inline-media"/>
+    </choice>
+  </define>
+
+  <define name="param">
+    <element name="param">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <attribute name="name"/>
+      <attribute name="value"/>
+    </element>
+  </define>
+
+<!-- @src must be handled per-element -->
+  <define name="media-object-common-content">
+    <ref name="common-attributes"/>
+    <optional>
+      <ref name="id-attribute"/>
+    </optional>
+    <optional>
+      <ref name="height-attribute"/>
+    </optional>
+    <optional>
+      <ref name="width-attribute"/>
+    </optional>
+    <ref name="mime-type-attribute"/>
+    <optional>
+      <ref name="for-attribute"/>
+    </optional>
+    <optional>
+      <ref name="longdesc"/>
+    </optional>
+    <zeroOrMore>
+      <ref name="param"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="media-object-fallback-class"/>
+    </zeroOrMore>
+  </define>
+
+  <define name="audio-video-common-content">
+    <ref name="media-object-common-content"/>
+    <ref name="src-attribute"/>
+    <ref name="standby-attribute"/>
+    <ref name="autoplay-attribute"/>
+    <ref name="loop-attribute"/>
+    <ref name="controller-attribute"/>
+    <ref name="volume-attribute"/>
+  </define>
+
+  <define name="object">
+    <element name="object">
+      <ref name="media-object-common-content"/>
+      <ref name="src-attribute"/>
+    </element>
+  </define>
+
+  <define name="image">
+    <element name="image">
+      <ref name="media-object-common-content"/>
+      <ref name="src-attribute"/>
+      <optional>
+        <ref name="print-width-attribute"/>
+      </optional>
+      <optional>
+        <ref name="thumbnail-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="audio">
+    <element name="audio">
+      <ref name="audio-video-common-content"/>
+    </element>
+  </define>
+
+  <define name="video">
+    <element name="video">
+      <ref name="audio-video-common-content"/>
+    </element>
+  </define>
+
+  <define name="java-applet">
+    <element name="java-applet">
+      <ref name="media-object-common-content"/>
+      <optional>
+        <ref name="src-attribute"/>
+      </optional>
+      <optional>
+        <ref name="codebase-attribute"/>
+      </optional>
+      <ref name="code-attribute"/>
+      <optional>
+        <ref name="archive-attribute"/>
+      </optional>
+      <optional>
+        <ref name="name-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="flash">
+    <element name="flash">
+      <ref name="media-object-common-content"/>
+      <ref name="src-attribute"/>
+      <optional>
+        <ref name="wmode-attribute"/>
+      </optional>
+      <optional>
+        <ref name="loop-attribute"/>
+      </optional>
+      <optional>
+        <ref name="quality-attribute"/>
+      </optional>
+      <optional>
+        <ref name="scale-attribute"/>
+      </optional>
+      <optional>
+        <ref name="bgcolor-attribute"/>
+      </optional>
+      <optional>
+        <ref name="flash-vars-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="iframe">
+    <element name="iframe">
+      <ref name="src-attribute"/>
+    <optional>
+      <ref name="id-attribute"/>
+    </optional>
+    <optional>
+      <ref name="height-attribute"/>
+    </optional>
+    <optional>
+      <ref name="width-attribute"/>
+    </optional>
+    </element>
+  </define>
+
+  <define name="labview">
+    <element name="labview">
+      <ref name="media-object-common-content"/>
+      <ref name="src-attribute"/>
+      <ref name="viname-attribute"/>
+      <ref name="labview-version-attribute"/>
+    </element>
+  </define>
+
+  <define name="text">
+    <element name="text">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <optional>
+        <ref name="height-attribute"/>
+      </optional>
+      <optional>
+        <ref name="width-attribute"/>
+      </optional>
+      <optional>
+        <ref name="mime-type-attribute"/>
+      </optional>
+      <optional>
+        <ref name="longdesc"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="src-attribute"/>
+      </optional>
+      <optional>
+        <ref name="for-attribute"/>
+      </optional>
+      <oneOrMore>
+        <ref name="div-content-class"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="download">
+    <element name="download">
+      <ref name="media-object-common-content"/>
+      <ref name="src-attribute"/>
+    </element>
+  </define>
+
+  <define name="example">
+    <element name="example">
+      <ref name="section-content"/>
+    </element>
+  </define>
+
+  <define name="exercise">
+    <element name="exercise">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="print-placement-attribute"/>
+      <ref name="type-attribute"/>
+      <choice>
+        <group>
+          <optional>
+            <ref name="label"/>
+          </optional>
+          <optional>
+            <ref name="title"/>
+          </optional>
+          <ref name="problem"/>
+          <zeroOrMore>
+            <ref name="solution"/>
+          </zeroOrMore>
+          <optional>
+            <ref name="commentary"/>
+          </optional>
+        </group>
+        <ref name="exercise-content-extras"/>
+      </choice>
+    </element>
+  </define>
+
+  <define name="exercise-content-extras">
+    <empty/>
+  </define>
+
+  <define name="problem">
+    <element name="problem">
+      <ref name="section-content"/>
+    </element>
+  </define>
+
+  <define name="solution">
+    <element name="solution">
+      <ref name="print-placement-attribute"/>
+      <ref name="section-content"/>
+    </element>
+  </define>
+
+  <define name="commentary">
+    <element name="commentary">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="div-content-class"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="definition">
+    <element name="definition">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="term"/>
+      <choice>
+        <ref name="seealso"/>
+        <group>
+          <oneOrMore>
+            <ref name="meaning"/>
+            <zeroOrMore>
+              <ref name="example"/>
+            </zeroOrMore>
+          </oneOrMore>
+          <optional>
+            <ref name="seealso"/>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+
+  <define name="meaning">
+    <element name="meaning">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="div-content"/>
+    </element>
+  </define>
+
+  <define name="seealso">
+    <element name="seealso">
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="seealso-type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <oneOrMore>
+        <ref name="term"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="rule">
+    <element name="rule">
+      <ref name="common-attributes"/>
+      <ref name="id-attribute"/>
+      <ref name="rule-type-attribute"/>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="statement"/>
+      </oneOrMore>
+      <zeroOrMore>
+        <choice>
+          <ref name="proof"/>
+          <ref name="example"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="statement">
+    <element name="statement">
+      <ref name="statement-content"/>
+    </element>
+  </define>
+
+  <define name="proof">
+    <element name="proof">
+      <ref name="statement-content"/>
+    </element>
+  </define>
+
+<!--
+    CALS Table Definitions
+ -->
+
+  <define name="bodyatt">
+    <empty/>
+  </define>
+
+  <define name="secur">
+    <empty/>
+  </define>
+
+  <define name="yesorno">
+    <data type="integer">
+      <param name="minInclusive">0</param>
+    </data>
+  </define>
+
+  <define name="colsep-attribute">
+    <optional>
+      <attribute name="colsep">
+        <ref name="yesorno"/>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="rowsep-attribute">
+    <optional>
+      <attribute name="rowsep">
+        <ref name="yesorno"/>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="align-attribute">
+    <attribute name="align">
+      <choice>
+        <value>left</value>
+        <value>right</value>
+        <value>center</value>
+        <value>justify</value>
+        <value>char</value>
+      </choice>
+    </attribute>
+  </define>
+
+  <define name="valign-attribute">
+    <optional>
+      <attribute name="valign">
+        <choice>
+          <value>top</value>
+          <value>middle</value>
+          <value>bottom</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="char-attribute">
+    <attribute name="char"/>
+  </define>
+
+  <define name="charoff-attribute">
+    <attribute name="charoff"/>
+  </define>
+
+  <define name="cols-attribute">
+    <attribute name="cols"/>
+  </define>
+
+  <define name="colname-attribute">
+    <attribute name="colname"/>
+  </define>
+
+  <define name="spanname-attribute">
+    <attribute name="spanname"/>
+  </define>
+
+  <define name="morerows-attribute">
+    <attribute name="morerows"/>
+  </define>
+
+  <define name="namest-attribute">
+    <attribute name="namest"/>
+  </define>
+
+  <define name="nameend-attribute">
+    <attribute name="nameend"/>
+  </define>
+
+  <define name="table.title">
+    <ref name="title"/>
+  </define>
+
+  <define name="table-main.mdl">
+    <oneOrMore>
+      <ref name="tgroup"/>
+    </oneOrMore>
+  </define>
+
+  <define name="table.mdl">
+    <optional>
+      <ref name="label"/>
+    </optional>
+    <optional>
+      <ref name="table.title"/>
+    </optional>
+    <ref name="table-main.mdl"/>
+    <optional>
+      <ref name="caption"/>
+    </optional>
+  </define>
+
+  <define name="table.att">
+    <ref name="id-attribute"/>
+    <optional>
+      <attribute name="tabstyle"/>
+    </optional>
+    <optional>
+      <attribute name="tocentry">
+        <ref name="yesorno"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="shortentry">
+        <ref name="yesorno"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="orient">
+        <choice>
+          <value>port</value>
+          <value>land</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="pgwide">
+        <ref name="yesorno"/>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="tgroup.mdl">
+    <zeroOrMore>
+      <ref name="colspec"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="spanspec"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="thead"/>
+    </optional>
+    <optional>
+      <ref name="tfoot"/>
+    </optional>
+    <ref name="tbody"/>
+  </define>
+
+  <define name="tgroup.att">
+    <optional>
+      <attribute name="tgroupstyle">
+        <text/>
+      </attribute>
+    </optional>
+  </define>
+
+  <define name="hdft.mdl">
+    <zeroOrMore>
+      <ref name="colspec"/>
+    </zeroOrMore>
+    <oneOrMore>
+      <ref name="row"/>
+    </oneOrMore>
+  </define>
+
+  <define name="row.mdl">
+    <oneOrMore>
+      <choice>
+        <ref name="entry"/>
+        <ref name="entrytbl"/>
+      </choice>
+    </oneOrMore>
+  </define>
+
+  <define name="entrytbl.mdl">
+    <zeroOrMore>
+      <ref name="colspec"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="spanspec"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="thead"/>
+    </optional>
+    <ref name="tbody"/>
+  </define>
+
+  <define name="entry.mdl">
+    <zeroOrMore>
+      <ref name="div-content-class"/>
+    </zeroOrMore>
+  </define>
+
+  <define name="table">
+    <element name="table">
+      <optional>
+        <attribute name="frame">
+          <choice>
+            <value>top</value>
+            <value>bottom</value>
+            <value>topbot</value>
+            <value>all</value>
+            <value>sides</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="summary"/>
+      <ref name="colsep-attribute"/>
+      <ref name="rowsep-attribute"/>
+      <ref name="table.att"/>
+      <ref name="bodyatt"/>
+      <ref name="secur"/>
+      <ref name="type-attribute"/>
+      <ref name="common-attributes"/>
+      <ref name="table.mdl"/>
+    </element>
+  </define>
+
+  <define name="tgroup">
+    <element name="tgroup">
+      <ref name="cols-attribute"/>
+      <ref name="tgroup.att"/>
+      <ref name="colsep-attribute"/>
+      <ref name="rowsep-attribute"/>
+      <optional>
+        <ref name="align-attribute"/>
+      </optional>
+      <optional>
+        <ref name="char-attribute"/>
+      </optional>
+      <optional>
+        <ref name="charoff-attribute"/>
+      </optional>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="tgroup.mdl"/>
+    </element>
+  </define>
+
+  <define name="colspec">
+    <element name="colspec">
+      <optional>
+        <attribute name="colnum"/>
+      </optional>
+      <optional>
+        <attribute name="colname"/>
+      </optional>
+      <optional>
+        <attribute name="colwidth"/>
+      </optional>
+      <ref name="colsep-attribute"/>
+      <ref name="rowsep-attribute"/>
+      <optional>
+        <ref name="align-attribute"/>
+      </optional>
+      <optional>
+        <ref name="char-attribute"/>
+      </optional>
+      <optional>
+        <ref name="charoff-attribute"/>
+      </optional>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="spanspec">
+    <element name="spanspec">
+      <optional>
+        <attribute name="namest"/>
+      </optional>
+      <optional>
+        <attribute name="nameend"/>
+      </optional>
+      <ref name="spanname-attribute"/>
+      <optional>
+        <attribute name="colwidth"/>
+      </optional>
+      <ref name="colsep-attribute"/>
+      <ref name="rowsep-attribute"/>
+      <optional>
+        <ref name="align-attribute"/>
+      </optional>
+      <optional>
+        <ref name="char-attribute"/>
+      </optional>
+      <optional>
+        <ref name="charoff-attribute"/>
+      </optional>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="thead">
+    <element name="thead">
+      <ref name="valign-attribute"/>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="hdft.mdl"/>
+    </element>
+  </define>
+
+  <define name="tfoot">
+    <element name="tfoot">
+      <ref name="valign-attribute"/>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="hdft.mdl"/>
+    </element>
+  </define>
+
+  <define name="tbody">
+    <element name="tbody">
+      <ref name="valign-attribute"/>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <oneOrMore>
+        <ref name="row"/>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="row">
+    <element name="row">
+      <ref name="rowsep-attribute"/>
+      <ref name="valign-attribute"/>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="row.mdl"/>
+    </element>
+  </define>
+
+  <define name="entrytbl">
+    <element name="entrytbl">
+      <ref name="cols-attribute"/>
+      <ref name="tgroup.att"/>
+      <optional>
+        <ref name="colname-attribute"/>
+      </optional>
+      <optional>
+        <ref name="spanname-attribute"/>
+      </optional>
+      <optional>
+        <ref name="namest-attribute"/>
+      </optional>
+      <optional>
+        <ref name="nameend-attribute"/>
+      </optional>
+      <ref name="colsep-attribute"/>
+      <ref name="rowsep-attribute"/>
+      <optional>
+        <ref name="align-attribute"/>
+      </optional>
+      <optional>
+        <ref name="char-attribute"/>
+      </optional>
+      <optional>
+        <ref name="charoff-attribute"/>
+      </optional>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="entrytbl.mdl"/>
+    </element>
+  </define>
+
+  <define name="entry">
+    <element name="entry">
+      <optional>
+        <ref name="colname-attribute"/>
+      </optional>
+      <optional>
+        <ref name="namest-attribute"/>
+      </optional>
+      <optional>
+        <ref name="nameend-attribute"/>
+      </optional>
+      <optional>
+        <ref name="spanname-attribute"/>
+      </optional>
+      <optional>
+        <ref name="morerows-attribute"/>
+      </optional>
+      <ref name="colsep-attribute"/>
+      <ref name="rowsep-attribute"/>
+      <optional>
+        <ref name="align-attribute"/>
+      </optional>
+      <optional>
+        <ref name="char-attribute"/>
+      </optional>
+      <optional>
+        <ref name="charoff-attribute"/>
+      </optional>
+      <optional>
+        <attribute name="rotate">
+          <ref name="yesorno"/>
+        </attribute>
+      </optional>
+      <ref name="valign-attribute"/>
+      <ref name="secur"/>
+      <ref name="common-attributes"/>
+      <optional>
+        <ref name="id-attribute"/>
+      </optional>
+      <ref name="entry.mdl"/>
+    </element>
+  </define>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-fragment-jing.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-fragment-jing.rng
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <start>
+    <choice>
+      <ref name="para"/>
+      <ref name="title"/>
+      <ref name="list"/>
+      <ref name="equation"/>
+      <ref name="exercise"/>
+      <ref name="figure"/>
+      <ref name="code"/>
+      <ref name="note"/>
+      <ref name="example"/>
+      <ref name="table"/>
+      <ref name="list"/>
+      <ref name="section"/>
+      <ref name="rule"/>
+      <ref name="definition"/>
+      <ref name="metadata"/>
+      <ref name="mdml-metadata"/>
+      <ref name="mdml-abstract"/>
+    </choice>
+  </start>
+
+  <include href="cnxml-common-jing.rng"/>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-jing.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-jing.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <start>
+    <choice>
+      <ref name="document"/>
+    </choice>
+  </start>
+
+  <include href="cnxml-common-jing.rng"/>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml-simplified.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml-simplified.rng
@@ -1,0 +1,7558 @@
+<?xml version="1.0"?>
+<!-- Automatically generated from tools/simplificator.xsl .
+Used for human consumption (all nested refs are resolved) -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://cnx.rice.edu/cnxml">
+  <start>
+    <choice>
+      <ref name="document"/>
+    </choice>
+  </start>
+  <!--starting cnxml-common-jing.rng-->
+  <!--included elements-->
+  <!--starting cnxml-abstract-defs.rng-->
+  <!--included elements-->
+  <define name="cnxml-abstract-para">
+    <element name="para" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+          <ref name="cnxml-abstract-quote"/>
+          <ref name="cnxml-abstract-preformat"/>
+          <ref name="cnxml-abstract-list"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-emphasis">
+    <element name="emphasis" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-term">
+    <element name="term" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-foreign">
+    <element name="foreign" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-cite">
+    <element name="cite" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-span">
+    <element name="span" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-sup">
+    <element name="sup" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-sub">
+    <element name="sub" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-code">
+    <element name="code" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="display">
+            <choice>
+              <value>block</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <choice>
+              <value>inline</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <value>none</value>
+          </attribute>
+        </choice>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-quote">
+    <element name="quote" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="display">
+            <choice>
+              <value>block</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <choice>
+              <value>inline</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <value>none</value>
+          </attribute>
+        </choice>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-para"/>
+          <oneOrMore>
+            <choice>
+              <ref name="cnxml-abstract-emphasis"/>
+              <ref name="cnxml-abstract-term"/>
+              <ref name="cnxml-abstract-foreign"/>
+              <ref name="cnxml-abstract-cite"/>
+              <ref name="cnxml-abstract-span"/>
+              <ref name="cnxml-abstract-sup"/>
+              <ref name="cnxml-abstract-sub"/>
+              <ref name="cnxml-abstract-code"/>
+              <notAllowed/>
+              <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+              <text/>
+              <ref name="cnxml-abstract-quote"/>
+              <ref name="cnxml-abstract-preformat"/>
+              <ref name="cnxml-abstract-list"/>
+            </choice>
+          </oneOrMore>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-preformat">
+    <element name="preformat" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="display">
+            <choice>
+              <value>block</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <choice>
+              <value>inline</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <value>none</value>
+          </attribute>
+        </choice>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-para"/>
+          <oneOrMore>
+            <choice>
+              <ref name="cnxml-abstract-emphasis"/>
+              <ref name="cnxml-abstract-term"/>
+              <ref name="cnxml-abstract-foreign"/>
+              <ref name="cnxml-abstract-cite"/>
+              <ref name="cnxml-abstract-span"/>
+              <ref name="cnxml-abstract-sup"/>
+              <ref name="cnxml-abstract-sub"/>
+              <ref name="cnxml-abstract-code"/>
+              <notAllowed/>
+              <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+              <text/>
+              <ref name="cnxml-abstract-quote"/>
+              <ref name="cnxml-abstract-preformat"/>
+              <ref name="cnxml-abstract-list"/>
+            </choice>
+          </oneOrMore>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-list">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <choice>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="list-type" a:defaultValue="bulleted">
+            <value>bulleted</value>
+          </attribute>
+        </optional>
+        <attribute name="list-type">
+          <value>enumerated</value>
+        </attribute>
+      </choice>
+      <optional>
+        <choice>
+          <attribute name="display">
+            <choice>
+              <value>block</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <choice>
+              <value>inline</value>
+              <value>none</value>
+            </choice>
+          </attribute>
+          <attribute name="display">
+            <value>none</value>
+          </attribute>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <ref name="cnxml-abstract-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="cnxml-abstract-item">
+    <element name="item" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-emphasis"/>
+          <ref name="cnxml-abstract-term"/>
+          <ref name="cnxml-abstract-foreign"/>
+          <ref name="cnxml-abstract-cite"/>
+          <ref name="cnxml-abstract-span"/>
+          <ref name="cnxml-abstract-sup"/>
+          <ref name="cnxml-abstract-sub"/>
+          <ref name="cnxml-abstract-code"/>
+          <notAllowed/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <text/>
+          <ref name="cnxml-abstract-quote"/>
+          <ref name="cnxml-abstract-preformat"/>
+          <ref name="cnxml-abstract-list"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <!--the rest-->
+  <!--ending cnxml-abstract-defs.rng-->
+  <!--starting ../../../../mdml/schema/rng/0.5/mdml-defs.rng-->
+  <!--included elements-->
+  <define name="mdml-content-id" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="content-id" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <data type="NMTOKEN"/>
+    </element>
+  </define>
+  <define name="mdml-repository" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="repository" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-content-url" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="content-url" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-title" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="title" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-version" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="version" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-short-title" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="short-title" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-subtitle" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="subtitle" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-created" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="created" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-revised" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="revised" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-homepage" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="homepage" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-actors" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="actors" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="mdml-person"/>
+          <ref name="mdml-organization"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-person" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="person" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="userid"/>
+      </optional>
+      <interleave>
+        <optional>
+          <ref name="mdml-honorific"/>
+        </optional>
+        <ref name="mdml-firstname"/>
+        <optional>
+          <ref name="mdml-othername"/>
+        </optional>
+        <ref name="mdml-surname"/>
+        <optional>
+          <ref name="mdml-lineage"/>
+        </optional>
+        <ref name="mdml-fullname"/>
+        <optional>
+          <ref name="mdml-email"/>
+        </optional>
+        <optional>
+          <ref name="mdml-homepage"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="mdml-organization" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="organization" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="userid"/>
+      </optional>
+      <interleave>
+        <ref name="mdml-fullname"/>
+        <ref name="mdml-shortname"/>
+        <optional>
+          <ref name="mdml-email"/>
+        </optional>
+        <optional>
+          <ref name="mdml-homepage"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="mdml-shortname" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="shortname" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-roles" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="roles" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="mdml-role"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-role" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="role" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="type"/>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-honorific" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="honorific" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-firstname" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="firstname" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-othername" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="othername" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-surname" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="surname" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-lineage" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="lineage" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-fullname" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="fullname" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-email" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="email" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-license" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="license" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="url"/>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-extended-attribution" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="extended-attribution" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="link-group"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-keywordlist" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="keywordlist" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="mdml-keyword"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-keyword" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="keyword" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-subjectlist" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="subjectlist" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="mdml-subject"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-subject" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="subject" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="source"/>
+      </optional>
+      <optional>
+        <attribute name="key"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-education-levellist" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="education-levellist" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="mdml-education-level"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-education-level" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="education-level" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="source"/>
+      </optional>
+      <optional>
+        <attribute name="key"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-col-homepage" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="homepage" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-institution" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="institution" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-course-code" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="course-code" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-instructor" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="instructor" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-derived-from" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="derived-from" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="implementation" ns="http://cnx.rice.edu/system-info"/>
+      </optional>
+      <choice>
+        <attribute name="url"/>
+        <group>
+          <attribute name="document"/>
+          <optional>
+            <attribute name="version"/>
+          </optional>
+          <optional>
+            <attribute name="repository"/>
+          </optional>
+        </group>
+      </choice>
+      <zeroOrMore>
+        <ref name="mdml-derived-from"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mdml-version-history" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="version-history" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="url"/>
+    </element>
+  </define>
+  <define name="mdml-ancillary" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="ancillary" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="url"/>
+    </element>
+  </define>
+  <define name="mdml-abstract" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="abstract" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="cnxml-abstract-para"/>
+          <oneOrMore>
+            <choice>
+              <ref name="cnxml-abstract-emphasis"/>
+              <ref name="cnxml-abstract-term"/>
+              <ref name="cnxml-abstract-foreign"/>
+              <ref name="cnxml-abstract-cite"/>
+              <ref name="cnxml-abstract-span"/>
+              <ref name="cnxml-abstract-sup"/>
+              <ref name="cnxml-abstract-sub"/>
+              <ref name="cnxml-abstract-code"/>
+              <notAllowed/>
+              <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+              <text/>
+              <ref name="cnxml-abstract-quote"/>
+              <ref name="cnxml-abstract-preformat"/>
+              <ref name="cnxml-abstract-list"/>
+            </choice>
+          </oneOrMore>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mdml-language" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="language" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="mdml-objectives" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="objectives" ns="http://cnx.rice.edu/mdml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <!--the rest-->
+  <!--ending ../../../../mdml/schema/rng/0.5/mdml-defs.rng-->
+  <!--starting ../../../../qml/schema/rng/1.0/qml-defs.rng-->
+  <!--included elements-->
+  <define name="qml.problemset" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="problemset" ns="http://cnx.rice.edu/qml/1.0">
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="qml.item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="qml.item" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="item" ns="http://cnx.rice.edu/qml/1.0">
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <attribute name="type">
+        <choice>
+          <value>single-response</value>
+          <value>multiple-response</value>
+          <value>text-response</value>
+          <value>ordered-response</value>
+        </choice>
+      </attribute>
+      <ref name="qml.question"/>
+      <zeroOrMore>
+        <ref name="qml.resource"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="qml.answer"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="qml.hint"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="qml.feedback"/>
+      </optional>
+      <optional>
+        <ref name="qml.key"/>
+      </optional>
+    </element>
+  </define>
+  <define name="qml.question" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="question" ns="http://cnx.rice.edu/qml/1.0">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="block-media"/>
+          <ref name="inline-media"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="qml.resource" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="resource" ns="http://cnx.rice.edu/qml/1.0">
+      <attribute name="uri"/>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="qml.answer" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="answer" ns="http://cnx.rice.edu/qml/1.0">
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="qml.response"/>
+      </optional>
+      <optional>
+        <ref name="qml.feedback"/>
+        <optional>
+          <ref name="qml.feedback"/>
+        </optional>
+      </optional>
+    </element>
+  </define>
+  <define name="qml.response" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="response" ns="http://cnx.rice.edu/qml/1.0">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="block-media"/>
+          <ref name="inline-media"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="qml.feedback" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="feedback" ns="http://cnx.rice.edu/qml/1.0">
+      <optional>
+        <attribute name="correct">
+          <choice>
+            <value>yes</value>
+            <value>no</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="block-media"/>
+          <ref name="inline-media"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="qml.hint" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="hint" ns="http://cnx.rice.edu/qml/1.0">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="block-media"/>
+          <ref name="inline-media"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="qml.key" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="key" ns="http://cnx.rice.edu/qml/1.0">
+      <optional>
+        <attribute name="answer">
+          <text/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="section"/>
+          <ref name="block-media"/>
+          <ref name="inline-media"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!--the rest-->
+  <!--ending ../../../../qml/schema/rng/1.0/qml-defs.rng-->
+  <!--starting cnxml-defs.rng-->
+  <!--included elements-->
+  <!--
+    Attribute Definitions
+-->
+  <!-- We enumerate supported values, but any text values are accepted. -->
+  <div/>
+  <!-- Attributes pattern for 'link' element.  Require at least one
+       attribute that points to a link target: either @url, or at
+       least one of the old cnxn-style linking attributes (@document,
+       @targetid, or @resource).  It takes a little effort to make
+       this pattern unambiguous.  -->
+  <!-- For linking elements other than 'link'.  Here we can afford to
+       make each attribute optional, so no problems with ambiguity.  -->
+  <div/>
+  <!--
+    Content Classes
+-->
+  <!--
+    Shared Content Models
+-->
+  <!--
+    Element Definitions
+-->
+  <define name="anyElement" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element ns="http://cnx.rice.edu/cnxml">
+      <anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="document" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="document" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <!-- Rename this object-id -->
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <ref name="document-title"/>
+      <attribute name="cnxml-version">
+        <value>0.8</value>
+      </attribute>
+      <attribute name="module-id"/>
+      <optional>
+        <ref name="metadata"/>
+      </optional>
+      <optional>
+        <ref name="featured-links"/>
+      </optional>
+      <ref name="content"/>
+      <optional>
+        <ref name="glossary"/>
+      </optional>
+      <optional>
+        <externalRef href="../../../../bibtexml/schema/rng/1.0/bibtexml.rng"/>
+      </optional>
+    </element>
+  </define>
+  <define name="metadata" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="metadata" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <interleave>
+        <empty/>
+        <attribute name="mdml-version">
+          <value>0.5</value>
+        </attribute>
+      </interleave>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <interleave>
+        <ref name="mdml-content-id"/>
+        <ref name="mdml-repository"/>
+        <optional>
+          <ref name="mdml-content-url"/>
+        </optional>
+        <ref name="mdml-title"/>
+        <optional>
+          <ref name="mdml-short-title"/>
+        </optional>
+        <optional>
+          <ref name="mdml-subtitle"/>
+        </optional>
+        <ref name="mdml-version"/>
+        <ref name="mdml-created"/>
+        <ref name="mdml-revised"/>
+        <ref name="mdml-actors"/>
+        <ref name="mdml-roles"/>
+        <ref name="mdml-license"/>
+        <optional>
+          <ref name="mdml-extended-attribution"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="mdml-derived-from"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="mdml-keywordlist"/>
+        </optional>
+        <optional>
+          <ref name="mdml-subjectlist"/>
+        </optional>
+        <optional>
+          <ref name="mdml-education-levellist"/>
+        </optional>
+        <optional>
+          <ref name="mdml-abstract"/>
+        </optional>
+        <ref name="mdml-language"/>
+        <optional>
+          <ref name="mdml-objectives"/>
+        </optional>
+        <optional>
+          <ref name="mdml-col-homepage"/>
+        </optional>
+        <optional>
+          <ref name="mdml-institution"/>
+        </optional>
+        <optional>
+          <ref name="mdml-course-code"/>
+        </optional>
+        <optional>
+          <ref name="mdml-instructor"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="featured-links" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="featured-links" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="link-group"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="link-group" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="link-group" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <attribute name="type">
+        <choice>
+          <value>prerequisite</value>
+          <value>example</value>
+          <value>supplemental</value>
+          <text/>
+        </choice>
+      </attribute>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <oneOrMore>
+        <ref name="link"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="content" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="content" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <choice>
+        <oneOrMore>
+          <choice>
+            <ref name="section"/>
+            <ref name="div"/>
+            <ref name="definition"/>
+            <ref name="example"/>
+            <ref name="figure"/>
+            <ref name="block-code"/>
+            <ref name="block-preformat"/>
+            <ref name="block-quote"/>
+            <ref name="block-note"/>
+            <ref name="block-media"/>
+            <ref name="bulleted-block-list"/>
+            <ref name="enumerated-block-list"/>
+            <ref name="labeled-item-block-list"/>
+            <ref name="table"/>
+            <ref name="rule"/>
+            <ref name="equation"/>
+            <ref name="exercise"/>
+            <ref name="para"/>
+          </choice>
+        </oneOrMore>
+        <ref name="qml.problemset"/>
+      </choice>
+    </element>
+  </define>
+  <define name="glossary" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="glossary" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="definition"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="section" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="section" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="section"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+          <ref name="para"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="div" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="div" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="block-preformat" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="preformat" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="block">
+          <choice>
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="inline-preformat" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="preformat" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="para" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="para" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="title" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="title" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="document-title" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="title" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <define name="label" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="label" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="newline" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="newline" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="count" a:defaultValue="1">
+          <data type="integer">
+            <param name="minInclusive">1</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="effect">
+          <choice>
+            <value>bold</value>
+            <value>italics</value>
+            <value>underline</value>
+            <value>normal</value>
+            <value>smallcaps</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="space" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="space" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="count" a:defaultValue="1">
+          <data type="integer">
+            <param name="minInclusive">1</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="effect">
+          <choice>
+            <value>bold</value>
+            <value>italics</value>
+            <value>underline</value>
+            <value>normal</value>
+            <value>smallcaps</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="span" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="span" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="effect">
+          <choice>
+            <value>bold</value>
+            <value>italics</value>
+            <value>underline</value>
+            <value>normal</value>
+            <value>smallcaps</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="cite" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="cite" ns="http://cnx.rice.edu/cnxml">
+      <group>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="window" a:defaultValue="replace">
+            <choice>
+              <value>replace</value>
+              <value>new</value>
+            </choice>
+          </attribute>
+        </optional>
+        <choice>
+          <optional>
+            <attribute name="url"/>
+          </optional>
+          <group>
+            <optional>
+              <attribute name="document"/>
+            </optional>
+            <optional>
+              <attribute name="version"/>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+        </choice>
+      </group>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="cite-title" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="cite-title" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="pub-type">
+          <choice>
+            <value>article</value>
+            <value>book</value>
+            <value>booklet</value>
+            <value>conference</value>
+            <value>inbook</value>
+            <value>incollection</value>
+            <value>inproceedings</value>
+            <value>manual</value>
+            <value>mastersthesis</value>
+            <value>misc</value>
+            <value>phdthesis</value>
+            <value>proceedings</value>
+            <value>techreport</value>
+            <value>unpublished</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="link" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="link" ns="http://cnx.rice.edu/cnxml">
+      <group>
+        <optional>
+          <attribute name="strength">
+            <choice>
+              <value>1</value>
+              <value>2</value>
+              <value>3</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="window" a:defaultValue="replace">
+            <choice>
+              <value>replace</value>
+              <value>new</value>
+            </choice>
+          </attribute>
+        </optional>
+        <choice>
+          <attribute name="url"/>
+          <group>
+            <attribute name="document"/>
+            <attribute name="version"/>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+          <group>
+            <attribute name="document"/>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+          <group>
+            <attribute name="version"/>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+          <group>
+            <choice>
+              <attribute name="target-id"/>
+              <attribute name="resource"/>
+            </choice>
+          </group>
+        </choice>
+      </group>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="emphasis" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="emphasis" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="effect">
+          <choice>
+            <value>bold</value>
+            <value>italics</value>
+            <value>underline</value>
+            <value>normal</value>
+            <value>smallcaps</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="term" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="term" ns="http://cnx.rice.edu/cnxml">
+      <group>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="window" a:defaultValue="replace">
+            <choice>
+              <value>replace</value>
+              <value>new</value>
+            </choice>
+          </attribute>
+        </optional>
+        <choice>
+          <optional>
+            <attribute name="url"/>
+          </optional>
+          <group>
+            <optional>
+              <attribute name="document"/>
+            </optional>
+            <optional>
+              <attribute name="version"/>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+        </choice>
+      </group>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sub" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="sub" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="sup" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="sup" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="block-quote" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="quote" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="block">
+          <choice>
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <group>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="window" a:defaultValue="replace">
+            <choice>
+              <value>replace</value>
+              <value>new</value>
+            </choice>
+          </attribute>
+        </optional>
+        <choice>
+          <optional>
+            <attribute name="url"/>
+          </optional>
+          <group>
+            <optional>
+              <attribute name="document"/>
+            </optional>
+            <optional>
+              <attribute name="version"/>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+        </choice>
+      </group>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="inline-quote" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="quote" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <group>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="window" a:defaultValue="replace">
+            <choice>
+              <value>replace</value>
+              <value>new</value>
+            </choice>
+          </attribute>
+        </optional>
+        <choice>
+          <optional>
+            <attribute name="url"/>
+          </optional>
+          <group>
+            <optional>
+              <attribute name="document"/>
+            </optional>
+            <optional>
+              <attribute name="version"/>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+        </choice>
+      </group>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="foreign" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="foreign" ns="http://cnx.rice.edu/cnxml">
+      <group>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="window" a:defaultValue="replace">
+            <choice>
+              <value>replace</value>
+              <value>new</value>
+            </choice>
+          </attribute>
+        </optional>
+        <choice>
+          <optional>
+            <attribute name="url"/>
+          </optional>
+          <group>
+            <optional>
+              <attribute name="document"/>
+            </optional>
+            <optional>
+              <attribute name="version"/>
+            </optional>
+            <optional>
+              <choice>
+                <attribute name="target-id"/>
+                <attribute name="resource"/>
+              </choice>
+            </optional>
+          </group>
+        </choice>
+      </group>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="footnote" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="footnote" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <!-- FIXME: Do we want to continue to permit 'media' or text in 'equation'? -->
+  <define name="equation" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="equation" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <choice>
+        <ref name="block-media"/>
+        <ref name="inline-media"/>
+        <text/>
+        <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+      </choice>
+    </element>
+  </define>
+  <define name="block-note" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="note" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="block">
+          <choice>
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type" a:defaultValue="note">
+          <choice>
+            <value>note</value>
+            <value>aside</value>
+            <value>warning</value>
+            <value>tip</value>
+            <value>important</value>
+            <data type="token">
+              <except>
+                <data type="token">
+                  <param name="pattern">[fF][oO][oO][tT][nN][oO][tT][eE]</param>
+                </data>
+              </except>
+            </data>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="inline-note" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="note" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type" a:defaultValue="note">
+          <choice>
+            <value>note</value>
+            <value>aside</value>
+            <value>warning</value>
+            <value>tip</value>
+            <value>important</value>
+            <data type="token">
+              <except>
+                <data type="token">
+                  <param name="pattern">[fF][oO][oO][tT][nN][oO][tT][eE]</param>
+                </data>
+              </except>
+            </data>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="bulleted-block-list" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="list-type" a:defaultValue="bulleted">
+          <value>bulleted</value>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mark-suffix" a:defaultValue=""/>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="bullet-style" a:defaultValue="bullet">
+          <choice>
+            <value>bullet</value>
+            <value>open-circle</value>
+            <value>pilcrow</value>
+            <value>rpilcrow</value>
+            <value>asterisk</value>
+            <value>dash</value>
+            <value>section</value>
+            <value>none</value>
+            <text/>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark-prefix"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="block">
+          <choice>
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="item-sep"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="block-list-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="bulleted-inline-list" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="list-type" a:defaultValue="bulleted">
+          <value>bulleted</value>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mark-suffix" a:defaultValue=""/>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="bullet-style" a:defaultValue="bullet">
+          <choice>
+            <value>bullet</value>
+            <value>open-circle</value>
+            <value>pilcrow</value>
+            <value>rpilcrow</value>
+            <value>asterisk</value>
+            <value>dash</value>
+            <value>section</value>
+            <value>none</value>
+            <text/>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark-prefix"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="item-sep" a:defaultValue=";"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="inline-list-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="enumerated-block-list" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mark-suffix" a:defaultValue="."/>
+      </optional>
+      <attribute name="list-type">
+        <value>enumerated</value>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="number-style" a:defaultValue="arabic">
+          <choice>
+            <value>arabic</value>
+            <value>upper-alpha</value>
+            <value>lower-alpha</value>
+            <value>upper-roman</value>
+            <value>lower-roman</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="start-value" a:defaultValue="1">
+          <data type="integer">
+            <param name="minInclusive">1</param>
+          </data>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark-prefix"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="block">
+          <choice>
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="item-sep"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="block-list-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="enumerated-inline-list" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mark-suffix" a:defaultValue="."/>
+      </optional>
+      <attribute name="list-type">
+        <value>enumerated</value>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="number-style" a:defaultValue="arabic">
+          <choice>
+            <value>arabic</value>
+            <value>upper-alpha</value>
+            <value>lower-alpha</value>
+            <value>upper-roman</value>
+            <value>lower-roman</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="start-value" a:defaultValue="1">
+          <data type="integer">
+            <param name="minInclusive">1</param>
+          </data>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark-prefix"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="item-sep" a:defaultValue=";"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="inline-list-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="labeled-item-block-list" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mark-suffix" a:defaultValue=":"/>
+      </optional>
+      <attribute name="list-type">
+        <value>labeled-item</value>
+      </attribute>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark-prefix"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="block">
+          <choice>
+            <value>block</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="item-sep"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="block-list-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="labeled-item-inline-list" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="list" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mark-suffix" a:defaultValue=":"/>
+      </optional>
+      <attribute name="list-type">
+        <value>labeled-item</value>
+      </attribute>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="mark-prefix"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="item-sep" a:defaultValue=";"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="inline-list-item"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="block-list-item" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="item" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="inline-list-item" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="item" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="inline-code" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="code" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="display" a:defaultValue="inline">
+          <choice>
+            <value>inline</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="lang"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="block-code" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="code" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="display">
+        <choice>
+          <value>block</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="lang"/>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </oneOrMore>
+      <optional>
+        <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+  <!-- NOTE: I have removed 'table' and 'code' as possible content for
+     'figure', but this decision can be revisited. -->
+  <define name="figure" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="figure" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="orient" a:defaultValue="horizontal">
+          <choice>
+            <value>horizontal</value>
+            <value>vertical</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <choice>
+        <ref name="block-media"/>
+        <ref name="inline-media"/>
+        <ref name="table"/>
+        <ref name="inline-code"/>
+        <ref name="block-code"/>
+        <group>
+          <ref name="subfigure"/>
+          <oneOrMore>
+            <ref name="subfigure"/>
+          </oneOrMore>
+        </group>
+      </choice>
+      <optional>
+        <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+  <define name="subfigure" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="subfigure" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <choice>
+        <ref name="block-media"/>
+        <ref name="inline-media"/>
+        <ref name="table"/>
+        <ref name="inline-code"/>
+        <ref name="block-code"/>
+      </choice>
+      <optional>
+        <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+  <define name="caption" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="caption" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="inline-media" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="media" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="display">
+          <choice>
+            <value>inline</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <attribute name="alt"/>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <choice>
+        <ref name="object"/>
+        <ref name="image"/>
+        <ref name="audio"/>
+        <ref name="video"/>
+        <ref name="java-applet"/>
+        <ref name="flash"/>
+        <ref name="labview"/>
+        <ref name="text"/>
+        <ref name="download"/>
+      </choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="block-media" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="media" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="display">
+          <choice>
+            <value>block</value>
+            <value>inline</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <attribute name="alt"/>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <choice>
+        <ref name="object"/>
+        <ref name="image"/>
+        <ref name="audio"/>
+        <ref name="video"/>
+        <ref name="java-applet"/>
+        <ref name="flash"/>
+        <ref name="labview"/>
+        <ref name="text"/>
+        <ref name="download"/>
+      </choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="nodisplay-media" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="media" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="display">
+        <value>none</value>
+      </attribute>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <attribute name="alt"/>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <choice>
+        <ref name="object"/>
+        <ref name="image"/>
+        <ref name="audio"/>
+        <ref name="video"/>
+        <ref name="java-applet"/>
+        <ref name="flash"/>
+        <ref name="labview"/>
+        <ref name="text"/>
+        <ref name="download"/>
+      </choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="longdesc-element" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="longdesc" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="param" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="param" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <attribute name="name"/>
+      <attribute name="value"/>
+    </element>
+  </define>
+  <!-- @src must be handled per-element -->
+  <define name="object" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="object" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+    </element>
+  </define>
+  <define name="image" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="image" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+      <optional>
+        <attribute name="print-width"/>
+      </optional>
+      <optional>
+        <attribute name="thumbnail"/>
+      </optional>
+    </element>
+  </define>
+  <define name="audio" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="audio" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+      <optional>
+        <attribute name="standby">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="autoplay" a:defaultValue="false">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="loop" a:defaultValue="false">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="controller" a:defaultValue="false">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="volume" a:defaultValue="50">
+          <data type="integer">
+            <param name="minInclusive">1</param>
+            <param name="maxInclusive">100</param>
+          </data>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="video" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="video" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+      <optional>
+        <attribute name="standby">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="autoplay" a:defaultValue="false">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="loop" a:defaultValue="false">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="controller" a:defaultValue="false">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="volume" a:defaultValue="50">
+          <data type="integer">
+            <param name="minInclusive">1</param>
+            <param name="maxInclusive">100</param>
+          </data>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="java-applet" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="java-applet" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <optional>
+        <attribute name="src"/>
+      </optional>
+      <optional>
+        <attribute name="codebase"/>
+      </optional>
+      <attribute name="code"/>
+      <optional>
+        <attribute name="archive"/>
+      </optional>
+      <optional>
+        <attribute name="name"/>
+      </optional>
+    </element>
+  </define>
+  <define name="flash" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="flash" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+      <optional>
+        <attribute name="wmode">
+          <choice>
+            <value>window</value>
+            <value>opaque</value>
+            <value>transparent</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="loop" a:defaultValue="false">
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </attribute>
+        </optional>
+      </optional>
+      <optional>
+        <attribute name="quality">
+          <choice>
+            <value>low</value>
+            <value>autolow</value>
+            <value>autohigh</value>
+            <value>medium</value>
+            <value>high</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <optional>
+          <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="scale" a:defaultValue="default">
+            <choice>
+              <value>default</value>
+              <value>noorder</value>
+              <value>exactfit</value>
+            </choice>
+          </attribute>
+        </optional>
+      </optional>
+      <optional>
+        <attribute name="bgcolor">
+          <data type="token">
+            <param name="pattern">#[a-fA-F0-9]{6}</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="flash-vars">
+          <text/>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="labview" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="labview" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+      <attribute name="viname"/>
+      <attribute name="version">
+        <choice>
+          <value>7.0</value>
+          <value>8.0</value>
+          <value>8.2</value>
+        </choice>
+      </attribute>
+    </element>
+  </define>
+  <define name="text" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="text" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <optional>
+        <attribute name="mime-type"/>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <optional>
+        <attribute name="src"/>
+      </optional>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="download" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="download" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="height"/>
+      </optional>
+      <optional>
+        <attribute name="width"/>
+      </optional>
+      <attribute name="mime-type"/>
+      <optional>
+        <attribute name="for">
+          <choice>
+            <value>online</value>
+            <value>pdf</value>
+            <data type="NMTOKEN"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <choice>
+          <attribute name="longdesc"/>
+          <ref name="longdesc-element"/>
+        </choice>
+      </optional>
+      <zeroOrMore>
+        <ref name="param"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="object"/>
+          <ref name="image"/>
+          <ref name="audio"/>
+          <ref name="video"/>
+          <ref name="java-applet"/>
+          <ref name="flash"/>
+          <ref name="labview"/>
+          <ref name="text"/>
+          <ref name="download"/>
+        </choice>
+      </zeroOrMore>
+      <attribute name="src"/>
+    </element>
+  </define>
+  <define name="example" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="example" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="section"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+          <ref name="para"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="exercise" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="exercise" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="print-placement">
+          <choice>
+            <value>here</value>
+            <value>end</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <choice>
+        <group>
+          <optional>
+            <ref name="label"/>
+          </optional>
+          <optional>
+            <ref name="title"/>
+          </optional>
+          <ref name="problem"/>
+          <zeroOrMore>
+            <ref name="solution"/>
+          </zeroOrMore>
+          <optional>
+            <ref name="commentary"/>
+          </optional>
+        </group>
+        <ref name="qml.item"/>
+      </choice>
+    </element>
+  </define>
+  <define name="problem" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="problem" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="section"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+          <ref name="para"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="solution" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="solution" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="print-placement">
+          <choice>
+            <value>here</value>
+            <value>end</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="section"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+          <ref name="para"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="commentary" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="commentary" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="definition" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="definition" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="term"/>
+      <choice>
+        <ref name="seealso"/>
+        <group>
+          <oneOrMore>
+            <ref name="meaning"/>
+            <zeroOrMore>
+              <ref name="example"/>
+            </zeroOrMore>
+          </oneOrMore>
+          <optional>
+            <ref name="seealso"/>
+          </optional>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <define name="meaning" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="meaning" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="seealso" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="seealso" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type">
+          <choice>
+            <value>related-term</value>
+            <value>narrower-term</value>
+            <value>broader-term</value>
+            <value>use-for</value>
+            <value>use</value>
+            <text/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <oneOrMore>
+        <ref name="term"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="rule" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="rule" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type" a:defaultValue="rule">
+          <choice>
+            <value>rule</value>
+            <value>theorem</value>
+            <value>lemma</value>
+            <value>corollary</value>
+            <value>law</value>
+            <value>proposition</value>
+            <text/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="statement"/>
+      </oneOrMore>
+      <zeroOrMore>
+        <choice>
+          <ref name="proof"/>
+          <ref name="example"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="statement" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="statement" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="section"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+          <ref name="para"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="proof" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="proof" ns="http://cnx.rice.edu/cnxml">
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="section"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+          <ref name="para"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <!--
+    CALS Table Definitions
+ -->
+  <define name="table" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="table" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="frame">
+          <choice>
+            <value>top</value>
+            <value>bottom</value>
+            <value>topbot</value>
+            <value>all</value>
+            <value>sides</value>
+            <value>none</value>
+          </choice>
+        </attribute>
+      </optional>
+      <attribute name="summary"/>
+      <optional>
+        <attribute name="colsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+      <optional>
+        <attribute name="tabstyle"/>
+      </optional>
+      <optional>
+        <attribute name="tocentry">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="shortentry">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="orient">
+          <choice>
+            <value>port</value>
+            <value>land</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="pgwide">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <optional>
+        <ref name="title"/>
+      </optional>
+      <oneOrMore>
+        <ref name="tgroup"/>
+      </oneOrMore>
+      <optional>
+        <ref name="caption"/>
+      </optional>
+    </element>
+  </define>
+  <define name="tgroup" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="tgroup" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="cols"/>
+      <optional>
+        <attribute name="tgroupstyle">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="colsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="align">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+            <value>center</value>
+            <value>justify</value>
+            <value>char</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="char"/>
+      </optional>
+      <optional>
+        <attribute name="charoff"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <ref name="colspec"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="spanspec"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="thead"/>
+      </optional>
+      <optional>
+        <ref name="tfoot"/>
+      </optional>
+      <ref name="tbody"/>
+    </element>
+  </define>
+  <define name="colspec" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="colspec" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="colnum"/>
+      </optional>
+      <optional>
+        <attribute name="colname"/>
+      </optional>
+      <optional>
+        <attribute name="colwidth"/>
+      </optional>
+      <optional>
+        <attribute name="colsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="align">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+            <value>center</value>
+            <value>justify</value>
+            <value>char</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="char"/>
+      </optional>
+      <optional>
+        <attribute name="charoff"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="spanspec" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="spanspec" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="namest"/>
+      </optional>
+      <optional>
+        <attribute name="nameend"/>
+      </optional>
+      <attribute name="spanname"/>
+      <optional>
+        <attribute name="colwidth"/>
+      </optional>
+      <optional>
+        <attribute name="colsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="align">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+            <value>center</value>
+            <value>justify</value>
+            <value>char</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="char"/>
+      </optional>
+      <optional>
+        <attribute name="charoff"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+    </element>
+  </define>
+  <define name="thead" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="thead" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="valign">
+          <choice>
+            <value>top</value>
+            <value>middle</value>
+            <value>bottom</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <ref name="colspec"/>
+      </zeroOrMore>
+      <oneOrMore>
+        <ref name="row"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="tfoot" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="tfoot" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="valign">
+          <choice>
+            <value>top</value>
+            <value>middle</value>
+            <value>bottom</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <ref name="colspec"/>
+      </zeroOrMore>
+      <oneOrMore>
+        <ref name="row"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="tbody" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="tbody" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="valign">
+          <choice>
+            <value>top</value>
+            <value>middle</value>
+            <value>bottom</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <ref name="row"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="row" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="row" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="valign">
+          <choice>
+            <value>top</value>
+            <value>middle</value>
+            <value>bottom</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <ref name="entry"/>
+          <ref name="entrytbl"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="entrytbl" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="entrytbl" ns="http://cnx.rice.edu/cnxml">
+      <attribute name="cols"/>
+      <optional>
+        <attribute name="tgroupstyle">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="colname"/>
+      </optional>
+      <optional>
+        <attribute name="spanname"/>
+      </optional>
+      <optional>
+        <attribute name="namest"/>
+      </optional>
+      <optional>
+        <attribute name="nameend"/>
+      </optional>
+      <optional>
+        <attribute name="colsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="align">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+            <value>center</value>
+            <value>justify</value>
+            <value>char</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="char"/>
+      </optional>
+      <optional>
+        <attribute name="charoff"/>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <ref name="colspec"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="spanspec"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="thead"/>
+      </optional>
+      <ref name="tbody"/>
+    </element>
+  </define>
+  <define name="entry" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <element name="entry" ns="http://cnx.rice.edu/cnxml">
+      <optional>
+        <attribute name="colname"/>
+      </optional>
+      <optional>
+        <attribute name="namest"/>
+      </optional>
+      <optional>
+        <attribute name="nameend"/>
+      </optional>
+      <optional>
+        <attribute name="spanname"/>
+      </optional>
+      <optional>
+        <attribute name="morerows"/>
+      </optional>
+      <optional>
+        <attribute name="colsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowsep">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="align">
+          <choice>
+            <value>left</value>
+            <value>right</value>
+            <value>center</value>
+            <value>justify</value>
+            <value>char</value>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="char"/>
+      </optional>
+      <optional>
+        <attribute name="charoff"/>
+      </optional>
+      <optional>
+        <attribute name="rotate">
+          <data type="integer">
+            <param name="minInclusive">0</param>
+          </data>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="valign">
+          <choice>
+            <value>top</value>
+            <value>middle</value>
+            <value>bottom</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <attribute>
+          <anyName>
+            <except>
+              <nsName ns=""/>
+              <nsName ns="http://cnx.rice.edu/cnxml"/>
+              <nsName ns="http://cnx.rice.edu/collxml"/>
+              <nsName ns="http://cnx.rice.edu/system-info"/>
+              <name>xml:lang</name>
+            </except>
+          </anyName>
+        </attribute>
+      </zeroOrMore>
+      <optional>
+        <attribute name="xml:lang"/>
+      </optional>
+      <optional>
+        <attribute name="class">
+          <data type="token"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="id">
+          <data type="ID"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <ref name="para"/>
+          <text/>
+          <externalRef href="../../../../mathml/schema/rng/3.0/mathml3.rng"/>
+          <ref name="span"/>
+          <ref name="term"/>
+          <ref name="cite"/>
+          <ref name="cite-title"/>
+          <ref name="foreign"/>
+          <ref name="emphasis"/>
+          <ref name="sub"/>
+          <ref name="sup"/>
+          <ref name="inline-code"/>
+          <ref name="inline-preformat"/>
+          <ref name="inline-quote"/>
+          <ref name="inline-note"/>
+          <ref name="bulleted-inline-list"/>
+          <ref name="enumerated-inline-list"/>
+          <ref name="labeled-item-inline-list"/>
+          <ref name="inline-media"/>
+          <ref name="footnote"/>
+          <ref name="link"/>
+          <ref name="newline"/>
+          <ref name="space"/>
+          <ref name="div"/>
+          <ref name="definition"/>
+          <ref name="example"/>
+          <ref name="figure"/>
+          <ref name="block-code"/>
+          <ref name="block-preformat"/>
+          <ref name="block-quote"/>
+          <ref name="block-note"/>
+          <ref name="block-media"/>
+          <ref name="bulleted-block-list"/>
+          <ref name="enumerated-block-list"/>
+          <ref name="labeled-item-block-list"/>
+          <ref name="table"/>
+          <ref name="rule"/>
+          <ref name="equation"/>
+          <ref name="exercise"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!--the rest-->
+  <!--ending cnxml-defs.rng-->
+  <!--the rest-->
+  <!--ending cnxml-common-jing.rng-->
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/0.8/cnxml.rng
+++ b/cnxml/xml/cnxml/schema/rng/0.8/cnxml.rng
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <start>
+    <choice>
+      <ref name="document"/>
+    </choice>
+  </start>
+
+  <include href="cnxml-common.rng"/>
+
+</grammar>

--- a/cnxml/xml/cnxml/schema/rng/any/cnxml-jing.rng
+++ b/cnxml/xml/cnxml/schema/rng/any/cnxml-jing.rng
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         ns="http://cnx.rice.edu/cnxml">
+
+  <start>
+    <choice>
+      <ref name="document-0.7"/>
+      <ref name="document-0.8"/>
+    </choice>
+  </start>
+
+  <define name="document-0.7">
+    <externalRef href="../0.7/cnxml-jing.rng"/>
+  </define>
+
+  <define name="document-0.8">
+    <externalRef href="../0.8/cnxml-jing.rng"/>
+  </define>
+
+</grammar>

--- a/cnxml/xml/mathml/catalog.sgml
+++ b/cnxml/xml/mathml/catalog.sgml
@@ -10,3 +10,5 @@ OVERRIDE YES
 -- MathML --
 PUBLIC "-//W3C//DTD MathML 2.0//EN"                                             /usr/share/xml/mathml/schema/dtd/2.0/mathml2.dtd
 PUBLIC "-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"                    /usr/share/xml/mathml/schema/dtd/2.0/mathml2-qname-1.mod
+PUBLIC "-//W3C//DTD MathML 3.0//EN"                                             /usr/share/xml/mathml/schema/dtd/3.0/mathml3.dtd
+PUBLIC "-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN"                    /usr/share/xml/mathml/schema/dtd/3.0/mathml3-qname.mod

--- a/cnxml/xml/mathml/catalog.xml
+++ b/cnxml/xml/mathml/catalog.xml
@@ -5,7 +5,9 @@
   <!-- MathML Entities -->
   <public publicId="-//W3C//DTD MathML 2.0//EN" uri="schema/dtd/2.0/mathml2.dtd"/>
   <public publicId="-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"  uri="schema/dtd/2.0/mathml2-qname-1.mod"/>
-  
+  <public publicId="-//W3C//DTD MathML 3.0//EN" uri="schema/dtd/3.0/mathml3.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN" uri="schema/dtd/3.0/mathml3-qname.mod"/>
+
   <!-- Characters entities for MathML -->
   <public publicId="-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN" uri="schema/dtd/2.0/isoamsa.ent" />
   <public publicId="-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN" uri="schema/dtd/2.0/isoamsb.ent" />
@@ -28,7 +30,8 @@
   <public publicId="-//W3C//ENTITIES Publishing for MathML 2.0//EN" uri="schema/dtd/2.0/isopub.ent" />
   <public publicId="-//W3C//ENTITIES Extra for MathML 2.0//EN" uri="schema/dtd/2.0/mmlextra.ent" />
   <public publicId="-//W3C//ENTITIES Aiases for MathML 2.0//EN" uri="schema/dtd/2.0/mmlalias.ent" />
-  
+  <public publicId="-//W3C//ENTITIES HTML MathML Set//EN//XML" uri="schema/dtd/3.0/htmlmathml-f.ent"/>
+
   <!-- SYSTEM Rewrite rules to access local copies -->
   <rewriteSystem systemIdStartString="http://www.w3.org/Math/DTD/mathml2" rewritePrefix="schema/dtd/2.0" />
   <rewriteSystem systemIdStartString="http://cnx.rice.edu/technology/mathml" rewritePrefix="." />

--- a/cnxml/xml/mathml/schema/dtd/3.0/htmlmathml-f.ent
+++ b/cnxml/xml/mathml/schema/dtd/3.0/htmlmathml-f.ent
@@ -1,0 +1,2164 @@
+
+<!-- 
+     Copyright 1998 - 2011 W3C.
+
+     Use and distribution of this code are permitted under the terms of
+     either of the following two licences:
+
+     1) W3C Software Notice and License.
+        http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html
+
+
+     2) The license used for the WHATWG HTML specification,
+        which states, in full:
+            You are granted a license to use, reproduce and create derivative
+            works of this document.
+
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+ 
+       Public identifier: -//W3C//ENTITIES HTML MathML Set//EN//XML
+       System identifier: http://www.w3.org/2003/entities/2007/htmlmathml-f.ent
+
+     The public identifier should always be used verbatim.
+     The system identifier may be changed to suit local requirements.
+
+     Typical invocation:
+
+       <!ENTITY % htmlmathml-f PUBLIC
+         "-//W3C//ENTITIES HTML MathML Set//EN//XML"
+         "http://www.w3.org/2003/entities/2007/htmlmathml-f.ent"
+       >
+       %htmlmathml-f;
+
+
+
+-->
+
+<!ENTITY AElig            "&#x000C6;" ><!--LATIN CAPITAL LETTER AE -->
+<!ENTITY AMP              "&#38;#38;" ><!--AMPERSAND -->
+<!ENTITY Aacute           "&#x000C1;" ><!--LATIN CAPITAL LETTER A WITH ACUTE -->
+<!ENTITY Abreve           "&#x00102;" ><!--LATIN CAPITAL LETTER A WITH BREVE -->
+<!ENTITY Acirc            "&#x000C2;" ><!--LATIN CAPITAL LETTER A WITH CIRCUMFLEX -->
+<!ENTITY Acy              "&#x00410;" ><!--CYRILLIC CAPITAL LETTER A -->
+<!ENTITY Afr              "&#x1D504;" ><!--MATHEMATICAL FRAKTUR CAPITAL A -->
+<!ENTITY Agrave           "&#x000C0;" ><!--LATIN CAPITAL LETTER A WITH GRAVE -->
+<!ENTITY Alpha            "&#x00391;" ><!--GREEK CAPITAL LETTER ALPHA -->
+<!ENTITY Amacr            "&#x00100;" ><!--LATIN CAPITAL LETTER A WITH MACRON -->
+<!ENTITY And              "&#x02A53;" ><!--DOUBLE LOGICAL AND -->
+<!ENTITY Aogon            "&#x00104;" ><!--LATIN CAPITAL LETTER A WITH OGONEK -->
+<!ENTITY Aopf             "&#x1D538;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL A -->
+<!ENTITY ApplyFunction    "&#x02061;" ><!--FUNCTION APPLICATION -->
+<!ENTITY Aring            "&#x000C5;" ><!--LATIN CAPITAL LETTER A WITH RING ABOVE -->
+<!ENTITY Ascr             "&#x1D49C;" ><!--MATHEMATICAL SCRIPT CAPITAL A -->
+<!ENTITY Assign           "&#x02254;" ><!--COLON EQUALS -->
+<!ENTITY Atilde           "&#x000C3;" ><!--LATIN CAPITAL LETTER A WITH TILDE -->
+<!ENTITY Auml             "&#x000C4;" ><!--LATIN CAPITAL LETTER A WITH DIAERESIS -->
+<!ENTITY Backslash        "&#x02216;" ><!--SET MINUS -->
+<!ENTITY Barv             "&#x02AE7;" ><!--SHORT DOWN TACK WITH OVERBAR -->
+<!ENTITY Barwed           "&#x02306;" ><!--PERSPECTIVE -->
+<!ENTITY Bcy              "&#x00411;" ><!--CYRILLIC CAPITAL LETTER BE -->
+<!ENTITY Because          "&#x02235;" ><!--BECAUSE -->
+<!ENTITY Bernoullis       "&#x0212C;" ><!--SCRIPT CAPITAL B -->
+<!ENTITY Beta             "&#x00392;" ><!--GREEK CAPITAL LETTER BETA -->
+<!ENTITY Bfr              "&#x1D505;" ><!--MATHEMATICAL FRAKTUR CAPITAL B -->
+<!ENTITY Bopf             "&#x1D539;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL B -->
+<!ENTITY Breve            "&#x002D8;" ><!--BREVE -->
+<!ENTITY Bscr             "&#x0212C;" ><!--SCRIPT CAPITAL B -->
+<!ENTITY Bumpeq           "&#x0224E;" ><!--GEOMETRICALLY EQUIVALENT TO -->
+<!ENTITY CHcy             "&#x00427;" ><!--CYRILLIC CAPITAL LETTER CHE -->
+<!ENTITY COPY             "&#x000A9;" ><!--COPYRIGHT SIGN -->
+<!ENTITY Cacute           "&#x00106;" ><!--LATIN CAPITAL LETTER C WITH ACUTE -->
+<!ENTITY Cap              "&#x022D2;" ><!--DOUBLE INTERSECTION -->
+<!ENTITY CapitalDifferentialD "&#x02145;" ><!--DOUBLE-STRUCK ITALIC CAPITAL D -->
+<!ENTITY Cayleys          "&#x0212D;" ><!--BLACK-LETTER CAPITAL C -->
+<!ENTITY Ccaron           "&#x0010C;" ><!--LATIN CAPITAL LETTER C WITH CARON -->
+<!ENTITY Ccedil           "&#x000C7;" ><!--LATIN CAPITAL LETTER C WITH CEDILLA -->
+<!ENTITY Ccirc            "&#x00108;" ><!--LATIN CAPITAL LETTER C WITH CIRCUMFLEX -->
+<!ENTITY Cconint          "&#x02230;" ><!--VOLUME INTEGRAL -->
+<!ENTITY Cdot             "&#x0010A;" ><!--LATIN CAPITAL LETTER C WITH DOT ABOVE -->
+<!ENTITY Cedilla          "&#x000B8;" ><!--CEDILLA -->
+<!ENTITY CenterDot        "&#x000B7;" ><!--MIDDLE DOT -->
+<!ENTITY Cfr              "&#x0212D;" ><!--BLACK-LETTER CAPITAL C -->
+<!ENTITY Chi              "&#x003A7;" ><!--GREEK CAPITAL LETTER CHI -->
+<!ENTITY CircleDot        "&#x02299;" ><!--CIRCLED DOT OPERATOR -->
+<!ENTITY CircleMinus      "&#x02296;" ><!--CIRCLED MINUS -->
+<!ENTITY CirclePlus       "&#x02295;" ><!--CIRCLED PLUS -->
+<!ENTITY CircleTimes      "&#x02297;" ><!--CIRCLED TIMES -->
+<!ENTITY ClockwiseContourIntegral "&#x02232;" ><!--CLOCKWISE CONTOUR INTEGRAL -->
+<!ENTITY CloseCurlyDoubleQuote "&#x0201D;" ><!--RIGHT DOUBLE QUOTATION MARK -->
+<!ENTITY CloseCurlyQuote  "&#x02019;" ><!--RIGHT SINGLE QUOTATION MARK -->
+<!ENTITY Colon            "&#x02237;" ><!--PROPORTION -->
+<!ENTITY Colone           "&#x02A74;" ><!--DOUBLE COLON EQUAL -->
+<!ENTITY Congruent        "&#x02261;" ><!--IDENTICAL TO -->
+<!ENTITY Conint           "&#x0222F;" ><!--SURFACE INTEGRAL -->
+<!ENTITY ContourIntegral  "&#x0222E;" ><!--CONTOUR INTEGRAL -->
+<!ENTITY Copf             "&#x02102;" ><!--DOUBLE-STRUCK CAPITAL C -->
+<!ENTITY Coproduct        "&#x02210;" ><!--N-ARY COPRODUCT -->
+<!ENTITY CounterClockwiseContourIntegral "&#x02233;" ><!--ANTICLOCKWISE CONTOUR INTEGRAL -->
+<!ENTITY Cross            "&#x02A2F;" ><!--VECTOR OR CROSS PRODUCT -->
+<!ENTITY Cscr             "&#x1D49E;" ><!--MATHEMATICAL SCRIPT CAPITAL C -->
+<!ENTITY Cup              "&#x022D3;" ><!--DOUBLE UNION -->
+<!ENTITY CupCap           "&#x0224D;" ><!--EQUIVALENT TO -->
+<!ENTITY DD               "&#x02145;" ><!--DOUBLE-STRUCK ITALIC CAPITAL D -->
+<!ENTITY DDotrahd         "&#x02911;" ><!--RIGHTWARDS ARROW WITH DOTTED STEM -->
+<!ENTITY DJcy             "&#x00402;" ><!--CYRILLIC CAPITAL LETTER DJE -->
+<!ENTITY DScy             "&#x00405;" ><!--CYRILLIC CAPITAL LETTER DZE -->
+<!ENTITY DZcy             "&#x0040F;" ><!--CYRILLIC CAPITAL LETTER DZHE -->
+<!ENTITY Dagger           "&#x02021;" ><!--DOUBLE DAGGER -->
+<!ENTITY Darr             "&#x021A1;" ><!--DOWNWARDS TWO HEADED ARROW -->
+<!ENTITY Dashv            "&#x02AE4;" ><!--VERTICAL BAR DOUBLE LEFT TURNSTILE -->
+<!ENTITY Dcaron           "&#x0010E;" ><!--LATIN CAPITAL LETTER D WITH CARON -->
+<!ENTITY Dcy              "&#x00414;" ><!--CYRILLIC CAPITAL LETTER DE -->
+<!ENTITY Del              "&#x02207;" ><!--NABLA -->
+<!ENTITY Delta            "&#x00394;" ><!--GREEK CAPITAL LETTER DELTA -->
+<!ENTITY Dfr              "&#x1D507;" ><!--MATHEMATICAL FRAKTUR CAPITAL D -->
+<!ENTITY DiacriticalAcute "&#x000B4;" ><!--ACUTE ACCENT -->
+<!ENTITY DiacriticalDot   "&#x002D9;" ><!--DOT ABOVE -->
+<!ENTITY DiacriticalDoubleAcute "&#x002DD;" ><!--DOUBLE ACUTE ACCENT -->
+<!ENTITY DiacriticalGrave "&#x00060;" ><!--GRAVE ACCENT -->
+<!ENTITY DiacriticalTilde "&#x002DC;" ><!--SMALL TILDE -->
+<!ENTITY Diamond          "&#x022C4;" ><!--DIAMOND OPERATOR -->
+<!ENTITY DifferentialD    "&#x02146;" ><!--DOUBLE-STRUCK ITALIC SMALL D -->
+<!ENTITY Dopf             "&#x1D53B;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL D -->
+<!ENTITY Dot              "&#x000A8;" ><!--DIAERESIS -->
+<!ENTITY DotDot           " &#x020DC;" ><!--COMBINING FOUR DOTS ABOVE -->
+<!ENTITY DotEqual         "&#x02250;" ><!--APPROACHES THE LIMIT -->
+<!ENTITY DoubleContourIntegral "&#x0222F;" ><!--SURFACE INTEGRAL -->
+<!ENTITY DoubleDot        "&#x000A8;" ><!--DIAERESIS -->
+<!ENTITY DoubleDownArrow  "&#x021D3;" ><!--DOWNWARDS DOUBLE ARROW -->
+<!ENTITY DoubleLeftArrow  "&#x021D0;" ><!--LEFTWARDS DOUBLE ARROW -->
+<!ENTITY DoubleLeftRightArrow "&#x021D4;" ><!--LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY DoubleLeftTee    "&#x02AE4;" ><!--VERTICAL BAR DOUBLE LEFT TURNSTILE -->
+<!ENTITY DoubleLongLeftArrow "&#x027F8;" ><!--LONG LEFTWARDS DOUBLE ARROW -->
+<!ENTITY DoubleLongLeftRightArrow "&#x027FA;" ><!--LONG LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY DoubleLongRightArrow "&#x027F9;" ><!--LONG RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY DoubleRightArrow "&#x021D2;" ><!--RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY DoubleRightTee   "&#x022A8;" ><!--TRUE -->
+<!ENTITY DoubleUpArrow    "&#x021D1;" ><!--UPWARDS DOUBLE ARROW -->
+<!ENTITY DoubleUpDownArrow "&#x021D5;" ><!--UP DOWN DOUBLE ARROW -->
+<!ENTITY DoubleVerticalBar "&#x02225;" ><!--PARALLEL TO -->
+<!ENTITY DownArrow        "&#x02193;" ><!--DOWNWARDS ARROW -->
+<!ENTITY DownArrowBar     "&#x02913;" ><!--DOWNWARDS ARROW TO BAR -->
+<!ENTITY DownArrowUpArrow "&#x021F5;" ><!--DOWNWARDS ARROW LEFTWARDS OF UPWARDS ARROW -->
+<!ENTITY DownBreve        " &#x00311;" ><!--COMBINING INVERTED BREVE -->
+<!ENTITY DownLeftRightVector "&#x02950;" ><!--LEFT BARB DOWN RIGHT BARB DOWN HARPOON -->
+<!ENTITY DownLeftTeeVector "&#x0295E;" ><!--LEFTWARDS HARPOON WITH BARB DOWN FROM BAR -->
+<!ENTITY DownLeftVector   "&#x021BD;" ><!--LEFTWARDS HARPOON WITH BARB DOWNWARDS -->
+<!ENTITY DownLeftVectorBar "&#x02956;" ><!--LEFTWARDS HARPOON WITH BARB DOWN TO BAR -->
+<!ENTITY DownRightTeeVector "&#x0295F;" ><!--RIGHTWARDS HARPOON WITH BARB DOWN FROM BAR -->
+<!ENTITY DownRightVector  "&#x021C1;" ><!--RIGHTWARDS HARPOON WITH BARB DOWNWARDS -->
+<!ENTITY DownRightVectorBar "&#x02957;" ><!--RIGHTWARDS HARPOON WITH BARB DOWN TO BAR -->
+<!ENTITY DownTee          "&#x022A4;" ><!--DOWN TACK -->
+<!ENTITY DownTeeArrow     "&#x021A7;" ><!--DOWNWARDS ARROW FROM BAR -->
+<!ENTITY Downarrow        "&#x021D3;" ><!--DOWNWARDS DOUBLE ARROW -->
+<!ENTITY Dscr             "&#x1D49F;" ><!--MATHEMATICAL SCRIPT CAPITAL D -->
+<!ENTITY Dstrok           "&#x00110;" ><!--LATIN CAPITAL LETTER D WITH STROKE -->
+<!ENTITY ENG              "&#x0014A;" ><!--LATIN CAPITAL LETTER ENG -->
+<!ENTITY ETH              "&#x000D0;" ><!--LATIN CAPITAL LETTER ETH -->
+<!ENTITY Eacute           "&#x000C9;" ><!--LATIN CAPITAL LETTER E WITH ACUTE -->
+<!ENTITY Ecaron           "&#x0011A;" ><!--LATIN CAPITAL LETTER E WITH CARON -->
+<!ENTITY Ecirc            "&#x000CA;" ><!--LATIN CAPITAL LETTER E WITH CIRCUMFLEX -->
+<!ENTITY Ecy              "&#x0042D;" ><!--CYRILLIC CAPITAL LETTER E -->
+<!ENTITY Edot             "&#x00116;" ><!--LATIN CAPITAL LETTER E WITH DOT ABOVE -->
+<!ENTITY Efr              "&#x1D508;" ><!--MATHEMATICAL FRAKTUR CAPITAL E -->
+<!ENTITY Egrave           "&#x000C8;" ><!--LATIN CAPITAL LETTER E WITH GRAVE -->
+<!ENTITY Element          "&#x02208;" ><!--ELEMENT OF -->
+<!ENTITY Emacr            "&#x00112;" ><!--LATIN CAPITAL LETTER E WITH MACRON -->
+<!ENTITY EmptySmallSquare "&#x025FB;" ><!--WHITE MEDIUM SQUARE -->
+<!ENTITY EmptyVerySmallSquare "&#x025AB;" ><!--WHITE SMALL SQUARE -->
+<!ENTITY Eogon            "&#x00118;" ><!--LATIN CAPITAL LETTER E WITH OGONEK -->
+<!ENTITY Eopf             "&#x1D53C;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL E -->
+<!ENTITY Epsilon          "&#x00395;" ><!--GREEK CAPITAL LETTER EPSILON -->
+<!ENTITY Equal            "&#x02A75;" ><!--TWO CONSECUTIVE EQUALS SIGNS -->
+<!ENTITY EqualTilde       "&#x02242;" ><!--MINUS TILDE -->
+<!ENTITY Equilibrium      "&#x021CC;" ><!--RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON -->
+<!ENTITY Escr             "&#x02130;" ><!--SCRIPT CAPITAL E -->
+<!ENTITY Esim             "&#x02A73;" ><!--EQUALS SIGN ABOVE TILDE OPERATOR -->
+<!ENTITY Eta              "&#x00397;" ><!--GREEK CAPITAL LETTER ETA -->
+<!ENTITY Euml             "&#x000CB;" ><!--LATIN CAPITAL LETTER E WITH DIAERESIS -->
+<!ENTITY Exists           "&#x02203;" ><!--THERE EXISTS -->
+<!ENTITY ExponentialE     "&#x02147;" ><!--DOUBLE-STRUCK ITALIC SMALL E -->
+<!ENTITY Fcy              "&#x00424;" ><!--CYRILLIC CAPITAL LETTER EF -->
+<!ENTITY Ffr              "&#x1D509;" ><!--MATHEMATICAL FRAKTUR CAPITAL F -->
+<!ENTITY FilledSmallSquare "&#x025FC;" ><!--BLACK MEDIUM SQUARE -->
+<!ENTITY FilledVerySmallSquare "&#x025AA;" ><!--BLACK SMALL SQUARE -->
+<!ENTITY Fopf             "&#x1D53D;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL F -->
+<!ENTITY ForAll           "&#x02200;" ><!--FOR ALL -->
+<!ENTITY Fouriertrf       "&#x02131;" ><!--SCRIPT CAPITAL F -->
+<!ENTITY Fscr             "&#x02131;" ><!--SCRIPT CAPITAL F -->
+<!ENTITY GJcy             "&#x00403;" ><!--CYRILLIC CAPITAL LETTER GJE -->
+<!ENTITY GT               "&#x0003E;" ><!--GREATER-THAN SIGN -->
+<!ENTITY Gamma            "&#x00393;" ><!--GREEK CAPITAL LETTER GAMMA -->
+<!ENTITY Gammad           "&#x003DC;" ><!--GREEK LETTER DIGAMMA -->
+<!ENTITY Gbreve           "&#x0011E;" ><!--LATIN CAPITAL LETTER G WITH BREVE -->
+<!ENTITY Gcedil           "&#x00122;" ><!--LATIN CAPITAL LETTER G WITH CEDILLA -->
+<!ENTITY Gcirc            "&#x0011C;" ><!--LATIN CAPITAL LETTER G WITH CIRCUMFLEX -->
+<!ENTITY Gcy              "&#x00413;" ><!--CYRILLIC CAPITAL LETTER GHE -->
+<!ENTITY Gdot             "&#x00120;" ><!--LATIN CAPITAL LETTER G WITH DOT ABOVE -->
+<!ENTITY Gfr              "&#x1D50A;" ><!--MATHEMATICAL FRAKTUR CAPITAL G -->
+<!ENTITY Gg               "&#x022D9;" ><!--VERY MUCH GREATER-THAN -->
+<!ENTITY Gopf             "&#x1D53E;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL G -->
+<!ENTITY GreaterEqual     "&#x02265;" ><!--GREATER-THAN OR EQUAL TO -->
+<!ENTITY GreaterEqualLess "&#x022DB;" ><!--GREATER-THAN EQUAL TO OR LESS-THAN -->
+<!ENTITY GreaterFullEqual "&#x02267;" ><!--GREATER-THAN OVER EQUAL TO -->
+<!ENTITY GreaterGreater   "&#x02AA2;" ><!--DOUBLE NESTED GREATER-THAN -->
+<!ENTITY GreaterLess      "&#x02277;" ><!--GREATER-THAN OR LESS-THAN -->
+<!ENTITY GreaterSlantEqual "&#x02A7E;" ><!--GREATER-THAN OR SLANTED EQUAL TO -->
+<!ENTITY GreaterTilde     "&#x02273;" ><!--GREATER-THAN OR EQUIVALENT TO -->
+<!ENTITY Gscr             "&#x1D4A2;" ><!--MATHEMATICAL SCRIPT CAPITAL G -->
+<!ENTITY Gt               "&#x0226B;" ><!--MUCH GREATER-THAN -->
+<!ENTITY HARDcy           "&#x0042A;" ><!--CYRILLIC CAPITAL LETTER HARD SIGN -->
+<!ENTITY Hacek            "&#x002C7;" ><!--CARON -->
+<!ENTITY Hat              "&#x0005E;" ><!--CIRCUMFLEX ACCENT -->
+<!ENTITY Hcirc            "&#x00124;" ><!--LATIN CAPITAL LETTER H WITH CIRCUMFLEX -->
+<!ENTITY Hfr              "&#x0210C;" ><!--BLACK-LETTER CAPITAL H -->
+<!ENTITY HilbertSpace     "&#x0210B;" ><!--SCRIPT CAPITAL H -->
+<!ENTITY Hopf             "&#x0210D;" ><!--DOUBLE-STRUCK CAPITAL H -->
+<!ENTITY HorizontalLine   "&#x02500;" ><!--BOX DRAWINGS LIGHT HORIZONTAL -->
+<!ENTITY Hscr             "&#x0210B;" ><!--SCRIPT CAPITAL H -->
+<!ENTITY Hstrok           "&#x00126;" ><!--LATIN CAPITAL LETTER H WITH STROKE -->
+<!ENTITY HumpDownHump     "&#x0224E;" ><!--GEOMETRICALLY EQUIVALENT TO -->
+<!ENTITY HumpEqual        "&#x0224F;" ><!--DIFFERENCE BETWEEN -->
+<!ENTITY IEcy             "&#x00415;" ><!--CYRILLIC CAPITAL LETTER IE -->
+<!ENTITY IJlig            "&#x00132;" ><!--LATIN CAPITAL LIGATURE IJ -->
+<!ENTITY IOcy             "&#x00401;" ><!--CYRILLIC CAPITAL LETTER IO -->
+<!ENTITY Iacute           "&#x000CD;" ><!--LATIN CAPITAL LETTER I WITH ACUTE -->
+<!ENTITY Icirc            "&#x000CE;" ><!--LATIN CAPITAL LETTER I WITH CIRCUMFLEX -->
+<!ENTITY Icy              "&#x00418;" ><!--CYRILLIC CAPITAL LETTER I -->
+<!ENTITY Idot             "&#x00130;" ><!--LATIN CAPITAL LETTER I WITH DOT ABOVE -->
+<!ENTITY Ifr              "&#x02111;" ><!--BLACK-LETTER CAPITAL I -->
+<!ENTITY Igrave           "&#x000CC;" ><!--LATIN CAPITAL LETTER I WITH GRAVE -->
+<!ENTITY Im               "&#x02111;" ><!--BLACK-LETTER CAPITAL I -->
+<!ENTITY Imacr            "&#x0012A;" ><!--LATIN CAPITAL LETTER I WITH MACRON -->
+<!ENTITY ImaginaryI       "&#x02148;" ><!--DOUBLE-STRUCK ITALIC SMALL I -->
+<!ENTITY Implies          "&#x021D2;" ><!--RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY Int              "&#x0222C;" ><!--DOUBLE INTEGRAL -->
+<!ENTITY Integral         "&#x0222B;" ><!--INTEGRAL -->
+<!ENTITY Intersection     "&#x022C2;" ><!--N-ARY INTERSECTION -->
+<!ENTITY InvisibleComma   "&#x02063;" ><!--INVISIBLE SEPARATOR -->
+<!ENTITY InvisibleTimes   "&#x02062;" ><!--INVISIBLE TIMES -->
+<!ENTITY Iogon            "&#x0012E;" ><!--LATIN CAPITAL LETTER I WITH OGONEK -->
+<!ENTITY Iopf             "&#x1D540;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL I -->
+<!ENTITY Iota             "&#x00399;" ><!--GREEK CAPITAL LETTER IOTA -->
+<!ENTITY Iscr             "&#x02110;" ><!--SCRIPT CAPITAL I -->
+<!ENTITY Itilde           "&#x00128;" ><!--LATIN CAPITAL LETTER I WITH TILDE -->
+<!ENTITY Iukcy            "&#x00406;" ><!--CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I -->
+<!ENTITY Iuml             "&#x000CF;" ><!--LATIN CAPITAL LETTER I WITH DIAERESIS -->
+<!ENTITY Jcirc            "&#x00134;" ><!--LATIN CAPITAL LETTER J WITH CIRCUMFLEX -->
+<!ENTITY Jcy              "&#x00419;" ><!--CYRILLIC CAPITAL LETTER SHORT I -->
+<!ENTITY Jfr              "&#x1D50D;" ><!--MATHEMATICAL FRAKTUR CAPITAL J -->
+<!ENTITY Jopf             "&#x1D541;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL J -->
+<!ENTITY Jscr             "&#x1D4A5;" ><!--MATHEMATICAL SCRIPT CAPITAL J -->
+<!ENTITY Jsercy           "&#x00408;" ><!--CYRILLIC CAPITAL LETTER JE -->
+<!ENTITY Jukcy            "&#x00404;" ><!--CYRILLIC CAPITAL LETTER UKRAINIAN IE -->
+<!ENTITY KHcy             "&#x00425;" ><!--CYRILLIC CAPITAL LETTER HA -->
+<!ENTITY KJcy             "&#x0040C;" ><!--CYRILLIC CAPITAL LETTER KJE -->
+<!ENTITY Kappa            "&#x0039A;" ><!--GREEK CAPITAL LETTER KAPPA -->
+<!ENTITY Kcedil           "&#x00136;" ><!--LATIN CAPITAL LETTER K WITH CEDILLA -->
+<!ENTITY Kcy              "&#x0041A;" ><!--CYRILLIC CAPITAL LETTER KA -->
+<!ENTITY Kfr              "&#x1D50E;" ><!--MATHEMATICAL FRAKTUR CAPITAL K -->
+<!ENTITY Kopf             "&#x1D542;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL K -->
+<!ENTITY Kscr             "&#x1D4A6;" ><!--MATHEMATICAL SCRIPT CAPITAL K -->
+<!ENTITY LJcy             "&#x00409;" ><!--CYRILLIC CAPITAL LETTER LJE -->
+<!ENTITY LT               "&#38;#60;" ><!--LESS-THAN SIGN -->
+<!ENTITY Lacute           "&#x00139;" ><!--LATIN CAPITAL LETTER L WITH ACUTE -->
+<!ENTITY Lambda           "&#x0039B;" ><!--GREEK CAPITAL LETTER LAMDA -->
+<!ENTITY Lang             "&#x027EA;" ><!--MATHEMATICAL LEFT DOUBLE ANGLE BRACKET -->
+<!ENTITY Laplacetrf       "&#x02112;" ><!--SCRIPT CAPITAL L -->
+<!ENTITY Larr             "&#x0219E;" ><!--LEFTWARDS TWO HEADED ARROW -->
+<!ENTITY Lcaron           "&#x0013D;" ><!--LATIN CAPITAL LETTER L WITH CARON -->
+<!ENTITY Lcedil           "&#x0013B;" ><!--LATIN CAPITAL LETTER L WITH CEDILLA -->
+<!ENTITY Lcy              "&#x0041B;" ><!--CYRILLIC CAPITAL LETTER EL -->
+<!ENTITY LeftAngleBracket "&#x027E8;" ><!--MATHEMATICAL LEFT ANGLE BRACKET -->
+<!ENTITY LeftArrow        "&#x02190;" ><!--LEFTWARDS ARROW -->
+<!ENTITY LeftArrowBar     "&#x021E4;" ><!--LEFTWARDS ARROW TO BAR -->
+<!ENTITY LeftArrowRightArrow "&#x021C6;" ><!--LEFTWARDS ARROW OVER RIGHTWARDS ARROW -->
+<!ENTITY LeftCeiling      "&#x02308;" ><!--LEFT CEILING -->
+<!ENTITY LeftDoubleBracket "&#x027E6;" ><!--MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
+<!ENTITY LeftDownTeeVector "&#x02961;" ><!--DOWNWARDS HARPOON WITH BARB LEFT FROM BAR -->
+<!ENTITY LeftDownVector   "&#x021C3;" ><!--DOWNWARDS HARPOON WITH BARB LEFTWARDS -->
+<!ENTITY LeftDownVectorBar "&#x02959;" ><!--DOWNWARDS HARPOON WITH BARB LEFT TO BAR -->
+<!ENTITY LeftFloor        "&#x0230A;" ><!--LEFT FLOOR -->
+<!ENTITY LeftRightArrow   "&#x02194;" ><!--LEFT RIGHT ARROW -->
+<!ENTITY LeftRightVector  "&#x0294E;" ><!--LEFT BARB UP RIGHT BARB UP HARPOON -->
+<!ENTITY LeftTee          "&#x022A3;" ><!--LEFT TACK -->
+<!ENTITY LeftTeeArrow     "&#x021A4;" ><!--LEFTWARDS ARROW FROM BAR -->
+<!ENTITY LeftTeeVector    "&#x0295A;" ><!--LEFTWARDS HARPOON WITH BARB UP FROM BAR -->
+<!ENTITY LeftTriangle     "&#x022B2;" ><!--NORMAL SUBGROUP OF -->
+<!ENTITY LeftTriangleBar  "&#x029CF;" ><!--LEFT TRIANGLE BESIDE VERTICAL BAR -->
+<!ENTITY LeftTriangleEqual "&#x022B4;" ><!--NORMAL SUBGROUP OF OR EQUAL TO -->
+<!ENTITY LeftUpDownVector "&#x02951;" ><!--UP BARB LEFT DOWN BARB LEFT HARPOON -->
+<!ENTITY LeftUpTeeVector  "&#x02960;" ><!--UPWARDS HARPOON WITH BARB LEFT FROM BAR -->
+<!ENTITY LeftUpVector     "&#x021BF;" ><!--UPWARDS HARPOON WITH BARB LEFTWARDS -->
+<!ENTITY LeftUpVectorBar  "&#x02958;" ><!--UPWARDS HARPOON WITH BARB LEFT TO BAR -->
+<!ENTITY LeftVector       "&#x021BC;" ><!--LEFTWARDS HARPOON WITH BARB UPWARDS -->
+<!ENTITY LeftVectorBar    "&#x02952;" ><!--LEFTWARDS HARPOON WITH BARB UP TO BAR -->
+<!ENTITY Leftarrow        "&#x021D0;" ><!--LEFTWARDS DOUBLE ARROW -->
+<!ENTITY Leftrightarrow   "&#x021D4;" ><!--LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY LessEqualGreater "&#x022DA;" ><!--LESS-THAN EQUAL TO OR GREATER-THAN -->
+<!ENTITY LessFullEqual    "&#x02266;" ><!--LESS-THAN OVER EQUAL TO -->
+<!ENTITY LessGreater      "&#x02276;" ><!--LESS-THAN OR GREATER-THAN -->
+<!ENTITY LessLess         "&#x02AA1;" ><!--DOUBLE NESTED LESS-THAN -->
+<!ENTITY LessSlantEqual   "&#x02A7D;" ><!--LESS-THAN OR SLANTED EQUAL TO -->
+<!ENTITY LessTilde        "&#x02272;" ><!--LESS-THAN OR EQUIVALENT TO -->
+<!ENTITY Lfr              "&#x1D50F;" ><!--MATHEMATICAL FRAKTUR CAPITAL L -->
+<!ENTITY Ll               "&#x022D8;" ><!--VERY MUCH LESS-THAN -->
+<!ENTITY Lleftarrow       "&#x021DA;" ><!--LEFTWARDS TRIPLE ARROW -->
+<!ENTITY Lmidot           "&#x0013F;" ><!--LATIN CAPITAL LETTER L WITH MIDDLE DOT -->
+<!ENTITY LongLeftArrow    "&#x027F5;" ><!--LONG LEFTWARDS ARROW -->
+<!ENTITY LongLeftRightArrow "&#x027F7;" ><!--LONG LEFT RIGHT ARROW -->
+<!ENTITY LongRightArrow   "&#x027F6;" ><!--LONG RIGHTWARDS ARROW -->
+<!ENTITY Longleftarrow    "&#x027F8;" ><!--LONG LEFTWARDS DOUBLE ARROW -->
+<!ENTITY Longleftrightarrow "&#x027FA;" ><!--LONG LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY Longrightarrow   "&#x027F9;" ><!--LONG RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY Lopf             "&#x1D543;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL L -->
+<!ENTITY LowerLeftArrow   "&#x02199;" ><!--SOUTH WEST ARROW -->
+<!ENTITY LowerRightArrow  "&#x02198;" ><!--SOUTH EAST ARROW -->
+<!ENTITY Lscr             "&#x02112;" ><!--SCRIPT CAPITAL L -->
+<!ENTITY Lsh              "&#x021B0;" ><!--UPWARDS ARROW WITH TIP LEFTWARDS -->
+<!ENTITY Lstrok           "&#x00141;" ><!--LATIN CAPITAL LETTER L WITH STROKE -->
+<!ENTITY Lt               "&#x0226A;" ><!--MUCH LESS-THAN -->
+<!ENTITY Map              "&#x02905;" ><!--RIGHTWARDS TWO-HEADED ARROW FROM BAR -->
+<!ENTITY Mcy              "&#x0041C;" ><!--CYRILLIC CAPITAL LETTER EM -->
+<!ENTITY MediumSpace      "&#x0205F;" ><!--MEDIUM MATHEMATICAL SPACE -->
+<!ENTITY Mellintrf        "&#x02133;" ><!--SCRIPT CAPITAL M -->
+<!ENTITY Mfr              "&#x1D510;" ><!--MATHEMATICAL FRAKTUR CAPITAL M -->
+<!ENTITY MinusPlus        "&#x02213;" ><!--MINUS-OR-PLUS SIGN -->
+<!ENTITY Mopf             "&#x1D544;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL M -->
+<!ENTITY Mscr             "&#x02133;" ><!--SCRIPT CAPITAL M -->
+<!ENTITY Mu               "&#x0039C;" ><!--GREEK CAPITAL LETTER MU -->
+<!ENTITY NJcy             "&#x0040A;" ><!--CYRILLIC CAPITAL LETTER NJE -->
+<!ENTITY Nacute           "&#x00143;" ><!--LATIN CAPITAL LETTER N WITH ACUTE -->
+<!ENTITY Ncaron           "&#x00147;" ><!--LATIN CAPITAL LETTER N WITH CARON -->
+<!ENTITY Ncedil           "&#x00145;" ><!--LATIN CAPITAL LETTER N WITH CEDILLA -->
+<!ENTITY Ncy              "&#x0041D;" ><!--CYRILLIC CAPITAL LETTER EN -->
+<!ENTITY NegativeMediumSpace "&#x0200B;" ><!--ZERO WIDTH SPACE -->
+<!ENTITY NegativeThickSpace "&#x0200B;" ><!--ZERO WIDTH SPACE -->
+<!ENTITY NegativeThinSpace "&#x0200B;" ><!--ZERO WIDTH SPACE -->
+<!ENTITY NegativeVeryThinSpace "&#x0200B;" ><!--ZERO WIDTH SPACE -->
+<!ENTITY NestedGreaterGreater "&#x0226B;" ><!--MUCH GREATER-THAN -->
+<!ENTITY NestedLessLess   "&#x0226A;" ><!--MUCH LESS-THAN -->
+<!ENTITY NewLine          "&#x0000A;" ><!--LINE FEED (LF) -->
+<!ENTITY Nfr              "&#x1D511;" ><!--MATHEMATICAL FRAKTUR CAPITAL N -->
+<!ENTITY NoBreak          "&#x02060;" ><!--WORD JOINER -->
+<!ENTITY NonBreakingSpace "&#x000A0;" ><!--NO-BREAK SPACE -->
+<!ENTITY Nopf             "&#x02115;" ><!--DOUBLE-STRUCK CAPITAL N -->
+<!ENTITY Not              "&#x02AEC;" ><!--DOUBLE STROKE NOT SIGN -->
+<!ENTITY NotCongruent     "&#x02262;" ><!--NOT IDENTICAL TO -->
+<!ENTITY NotCupCap        "&#x0226D;" ><!--NOT EQUIVALENT TO -->
+<!ENTITY NotDoubleVerticalBar "&#x02226;" ><!--NOT PARALLEL TO -->
+<!ENTITY NotElement       "&#x02209;" ><!--NOT AN ELEMENT OF -->
+<!ENTITY NotEqual         "&#x02260;" ><!--NOT EQUAL TO -->
+<!ENTITY NotEqualTilde    "&#x02242;&#x00338;" ><!--MINUS TILDE with slash -->
+<!ENTITY NotExists        "&#x02204;" ><!--THERE DOES NOT EXIST -->
+<!ENTITY NotGreater       "&#x0226F;" ><!--NOT GREATER-THAN -->
+<!ENTITY NotGreaterEqual  "&#x02271;" ><!--NEITHER GREATER-THAN NOR EQUAL TO -->
+<!ENTITY NotGreaterFullEqual "&#x02267;&#x00338;" ><!--GREATER-THAN OVER EQUAL TO with slash -->
+<!ENTITY NotGreaterGreater "&#x0226B;&#x00338;" ><!--MUCH GREATER THAN with slash -->
+<!ENTITY NotGreaterLess   "&#x02279;" ><!--NEITHER GREATER-THAN NOR LESS-THAN -->
+<!ENTITY NotGreaterSlantEqual "&#x02A7E;&#x00338;" ><!--GREATER-THAN OR SLANTED EQUAL TO with slash -->
+<!ENTITY NotGreaterTilde  "&#x02275;" ><!--NEITHER GREATER-THAN NOR EQUIVALENT TO -->
+<!ENTITY NotHumpDownHump  "&#x0224E;&#x00338;" ><!--GEOMETRICALLY EQUIVALENT TO with slash -->
+<!ENTITY NotHumpEqual     "&#x0224F;&#x00338;" ><!--DIFFERENCE BETWEEN with slash -->
+<!ENTITY NotLeftTriangle  "&#x022EA;" ><!--NOT NORMAL SUBGROUP OF -->
+<!ENTITY NotLeftTriangleBar "&#x029CF;&#x00338;" ><!--LEFT TRIANGLE BESIDE VERTICAL BAR with slash -->
+<!ENTITY NotLeftTriangleEqual "&#x022EC;" ><!--NOT NORMAL SUBGROUP OF OR EQUAL TO -->
+<!ENTITY NotLess          "&#x0226E;" ><!--NOT LESS-THAN -->
+<!ENTITY NotLessEqual     "&#x02270;" ><!--NEITHER LESS-THAN NOR EQUAL TO -->
+<!ENTITY NotLessGreater   "&#x02278;" ><!--NEITHER LESS-THAN NOR GREATER-THAN -->
+<!ENTITY NotLessLess      "&#x0226A;&#x00338;" ><!--MUCH LESS THAN with slash -->
+<!ENTITY NotLessSlantEqual "&#x02A7D;&#x00338;" ><!--LESS-THAN OR SLANTED EQUAL TO with slash -->
+<!ENTITY NotLessTilde     "&#x02274;" ><!--NEITHER LESS-THAN NOR EQUIVALENT TO -->
+<!ENTITY NotNestedGreaterGreater "&#x02AA2;&#x00338;" ><!--DOUBLE NESTED GREATER-THAN with slash -->
+<!ENTITY NotNestedLessLess "&#x02AA1;&#x00338;" ><!--DOUBLE NESTED LESS-THAN with slash -->
+<!ENTITY NotPrecedes      "&#x02280;" ><!--DOES NOT PRECEDE -->
+<!ENTITY NotPrecedesEqual "&#x02AAF;&#x00338;" ><!--PRECEDES ABOVE SINGLE-LINE EQUALS SIGN with slash -->
+<!ENTITY NotPrecedesSlantEqual "&#x022E0;" ><!--DOES NOT PRECEDE OR EQUAL -->
+<!ENTITY NotReverseElement "&#x0220C;" ><!--DOES NOT CONTAIN AS MEMBER -->
+<!ENTITY NotRightTriangle "&#x022EB;" ><!--DOES NOT CONTAIN AS NORMAL SUBGROUP -->
+<!ENTITY NotRightTriangleBar "&#x029D0;&#x00338;" ><!--VERTICAL BAR BESIDE RIGHT TRIANGLE with slash -->
+<!ENTITY NotRightTriangleEqual "&#x022ED;" ><!--DOES NOT CONTAIN AS NORMAL SUBGROUP OR EQUAL -->
+<!ENTITY NotSquareSubset  "&#x0228F;&#x00338;" ><!--SQUARE IMAGE OF with slash -->
+<!ENTITY NotSquareSubsetEqual "&#x022E2;" ><!--NOT SQUARE IMAGE OF OR EQUAL TO -->
+<!ENTITY NotSquareSuperset "&#x02290;&#x00338;" ><!--SQUARE ORIGINAL OF with slash -->
+<!ENTITY NotSquareSupersetEqual "&#x022E3;" ><!--NOT SQUARE ORIGINAL OF OR EQUAL TO -->
+<!ENTITY NotSubset        "&#x02282;&#x020D2;" ><!--SUBSET OF with vertical line -->
+<!ENTITY NotSubsetEqual   "&#x02288;" ><!--NEITHER A SUBSET OF NOR EQUAL TO -->
+<!ENTITY NotSucceeds      "&#x02281;" ><!--DOES NOT SUCCEED -->
+<!ENTITY NotSucceedsEqual "&#x02AB0;&#x00338;" ><!--SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN with slash -->
+<!ENTITY NotSucceedsSlantEqual "&#x022E1;" ><!--DOES NOT SUCCEED OR EQUAL -->
+<!ENTITY NotSucceedsTilde "&#x0227F;&#x00338;" ><!--SUCCEEDS OR EQUIVALENT TO with slash -->
+<!ENTITY NotSuperset      "&#x02283;&#x020D2;" ><!--SUPERSET OF with vertical line -->
+<!ENTITY NotSupersetEqual "&#x02289;" ><!--NEITHER A SUPERSET OF NOR EQUAL TO -->
+<!ENTITY NotTilde         "&#x02241;" ><!--NOT TILDE -->
+<!ENTITY NotTildeEqual    "&#x02244;" ><!--NOT ASYMPTOTICALLY EQUAL TO -->
+<!ENTITY NotTildeFullEqual "&#x02247;" ><!--NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO -->
+<!ENTITY NotTildeTilde    "&#x02249;" ><!--NOT ALMOST EQUAL TO -->
+<!ENTITY NotVerticalBar   "&#x02224;" ><!--DOES NOT DIVIDE -->
+<!ENTITY Nscr             "&#x1D4A9;" ><!--MATHEMATICAL SCRIPT CAPITAL N -->
+<!ENTITY Ntilde           "&#x000D1;" ><!--LATIN CAPITAL LETTER N WITH TILDE -->
+<!ENTITY Nu               "&#x0039D;" ><!--GREEK CAPITAL LETTER NU -->
+<!ENTITY OElig            "&#x00152;" ><!--LATIN CAPITAL LIGATURE OE -->
+<!ENTITY Oacute           "&#x000D3;" ><!--LATIN CAPITAL LETTER O WITH ACUTE -->
+<!ENTITY Ocirc            "&#x000D4;" ><!--LATIN CAPITAL LETTER O WITH CIRCUMFLEX -->
+<!ENTITY Ocy              "&#x0041E;" ><!--CYRILLIC CAPITAL LETTER O -->
+<!ENTITY Odblac           "&#x00150;" ><!--LATIN CAPITAL LETTER O WITH DOUBLE ACUTE -->
+<!ENTITY Ofr              "&#x1D512;" ><!--MATHEMATICAL FRAKTUR CAPITAL O -->
+<!ENTITY Ograve           "&#x000D2;" ><!--LATIN CAPITAL LETTER O WITH GRAVE -->
+<!ENTITY Omacr            "&#x0014C;" ><!--LATIN CAPITAL LETTER O WITH MACRON -->
+<!ENTITY Omega            "&#x003A9;" ><!--GREEK CAPITAL LETTER OMEGA -->
+<!ENTITY Omicron          "&#x0039F;" ><!--GREEK CAPITAL LETTER OMICRON -->
+<!ENTITY Oopf             "&#x1D546;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL O -->
+<!ENTITY OpenCurlyDoubleQuote "&#x0201C;" ><!--LEFT DOUBLE QUOTATION MARK -->
+<!ENTITY OpenCurlyQuote   "&#x02018;" ><!--LEFT SINGLE QUOTATION MARK -->
+<!ENTITY Or               "&#x02A54;" ><!--DOUBLE LOGICAL OR -->
+<!ENTITY Oscr             "&#x1D4AA;" ><!--MATHEMATICAL SCRIPT CAPITAL O -->
+<!ENTITY Oslash           "&#x000D8;" ><!--LATIN CAPITAL LETTER O WITH STROKE -->
+<!ENTITY Otilde           "&#x000D5;" ><!--LATIN CAPITAL LETTER O WITH TILDE -->
+<!ENTITY Otimes           "&#x02A37;" ><!--MULTIPLICATION SIGN IN DOUBLE CIRCLE -->
+<!ENTITY Ouml             "&#x000D6;" ><!--LATIN CAPITAL LETTER O WITH DIAERESIS -->
+<!ENTITY OverBar          "&#x0203E;" ><!--OVERLINE -->
+<!ENTITY OverBrace        "&#x023DE;" ><!--TOP CURLY BRACKET -->
+<!ENTITY OverBracket      "&#x023B4;" ><!--TOP SQUARE BRACKET -->
+<!ENTITY OverParenthesis  "&#x023DC;" ><!--TOP PARENTHESIS -->
+<!ENTITY PartialD         "&#x02202;" ><!--PARTIAL DIFFERENTIAL -->
+<!ENTITY Pcy              "&#x0041F;" ><!--CYRILLIC CAPITAL LETTER PE -->
+<!ENTITY Pfr              "&#x1D513;" ><!--MATHEMATICAL FRAKTUR CAPITAL P -->
+<!ENTITY Phi              "&#x003A6;" ><!--GREEK CAPITAL LETTER PHI -->
+<!ENTITY Pi               "&#x003A0;" ><!--GREEK CAPITAL LETTER PI -->
+<!ENTITY PlusMinus        "&#x000B1;" ><!--PLUS-MINUS SIGN -->
+<!ENTITY Poincareplane    "&#x0210C;" ><!--BLACK-LETTER CAPITAL H -->
+<!ENTITY Popf             "&#x02119;" ><!--DOUBLE-STRUCK CAPITAL P -->
+<!ENTITY Pr               "&#x02ABB;" ><!--DOUBLE PRECEDES -->
+<!ENTITY Precedes         "&#x0227A;" ><!--PRECEDES -->
+<!ENTITY PrecedesEqual    "&#x02AAF;" ><!--PRECEDES ABOVE SINGLE-LINE EQUALS SIGN -->
+<!ENTITY PrecedesSlantEqual "&#x0227C;" ><!--PRECEDES OR EQUAL TO -->
+<!ENTITY PrecedesTilde    "&#x0227E;" ><!--PRECEDES OR EQUIVALENT TO -->
+<!ENTITY Prime            "&#x02033;" ><!--DOUBLE PRIME -->
+<!ENTITY Product          "&#x0220F;" ><!--N-ARY PRODUCT -->
+<!ENTITY Proportion       "&#x02237;" ><!--PROPORTION -->
+<!ENTITY Proportional     "&#x0221D;" ><!--PROPORTIONAL TO -->
+<!ENTITY Pscr             "&#x1D4AB;" ><!--MATHEMATICAL SCRIPT CAPITAL P -->
+<!ENTITY Psi              "&#x003A8;" ><!--GREEK CAPITAL LETTER PSI -->
+<!ENTITY QUOT             "&#x00022;" ><!--QUOTATION MARK -->
+<!ENTITY Qfr              "&#x1D514;" ><!--MATHEMATICAL FRAKTUR CAPITAL Q -->
+<!ENTITY Qopf             "&#x0211A;" ><!--DOUBLE-STRUCK CAPITAL Q -->
+<!ENTITY Qscr             "&#x1D4AC;" ><!--MATHEMATICAL SCRIPT CAPITAL Q -->
+<!ENTITY RBarr            "&#x02910;" ><!--RIGHTWARDS TWO-HEADED TRIPLE DASH ARROW -->
+<!ENTITY REG              "&#x000AE;" ><!--REGISTERED SIGN -->
+<!ENTITY Racute           "&#x00154;" ><!--LATIN CAPITAL LETTER R WITH ACUTE -->
+<!ENTITY Rang             "&#x027EB;" ><!--MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET -->
+<!ENTITY Rarr             "&#x021A0;" ><!--RIGHTWARDS TWO HEADED ARROW -->
+<!ENTITY Rarrtl           "&#x02916;" ><!--RIGHTWARDS TWO-HEADED ARROW WITH TAIL -->
+<!ENTITY Rcaron           "&#x00158;" ><!--LATIN CAPITAL LETTER R WITH CARON -->
+<!ENTITY Rcedil           "&#x00156;" ><!--LATIN CAPITAL LETTER R WITH CEDILLA -->
+<!ENTITY Rcy              "&#x00420;" ><!--CYRILLIC CAPITAL LETTER ER -->
+<!ENTITY Re               "&#x0211C;" ><!--BLACK-LETTER CAPITAL R -->
+<!ENTITY ReverseElement   "&#x0220B;" ><!--CONTAINS AS MEMBER -->
+<!ENTITY ReverseEquilibrium "&#x021CB;" ><!--LEFTWARDS HARPOON OVER RIGHTWARDS HARPOON -->
+<!ENTITY ReverseUpEquilibrium "&#x0296F;" ><!--DOWNWARDS HARPOON WITH BARB LEFT BESIDE UPWARDS HARPOON WITH BARB RIGHT -->
+<!ENTITY Rfr              "&#x0211C;" ><!--BLACK-LETTER CAPITAL R -->
+<!ENTITY Rho              "&#x003A1;" ><!--GREEK CAPITAL LETTER RHO -->
+<!ENTITY RightAngleBracket "&#x027E9;" ><!--MATHEMATICAL RIGHT ANGLE BRACKET -->
+<!ENTITY RightArrow       "&#x02192;" ><!--RIGHTWARDS ARROW -->
+<!ENTITY RightArrowBar    "&#x021E5;" ><!--RIGHTWARDS ARROW TO BAR -->
+<!ENTITY RightArrowLeftArrow "&#x021C4;" ><!--RIGHTWARDS ARROW OVER LEFTWARDS ARROW -->
+<!ENTITY RightCeiling     "&#x02309;" ><!--RIGHT CEILING -->
+<!ENTITY RightDoubleBracket "&#x027E7;" ><!--MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
+<!ENTITY RightDownTeeVector "&#x0295D;" ><!--DOWNWARDS HARPOON WITH BARB RIGHT FROM BAR -->
+<!ENTITY RightDownVector  "&#x021C2;" ><!--DOWNWARDS HARPOON WITH BARB RIGHTWARDS -->
+<!ENTITY RightDownVectorBar "&#x02955;" ><!--DOWNWARDS HARPOON WITH BARB RIGHT TO BAR -->
+<!ENTITY RightFloor       "&#x0230B;" ><!--RIGHT FLOOR -->
+<!ENTITY RightTee         "&#x022A2;" ><!--RIGHT TACK -->
+<!ENTITY RightTeeArrow    "&#x021A6;" ><!--RIGHTWARDS ARROW FROM BAR -->
+<!ENTITY RightTeeVector   "&#x0295B;" ><!--RIGHTWARDS HARPOON WITH BARB UP FROM BAR -->
+<!ENTITY RightTriangle    "&#x022B3;" ><!--CONTAINS AS NORMAL SUBGROUP -->
+<!ENTITY RightTriangleBar "&#x029D0;" ><!--VERTICAL BAR BESIDE RIGHT TRIANGLE -->
+<!ENTITY RightTriangleEqual "&#x022B5;" ><!--CONTAINS AS NORMAL SUBGROUP OR EQUAL TO -->
+<!ENTITY RightUpDownVector "&#x0294F;" ><!--UP BARB RIGHT DOWN BARB RIGHT HARPOON -->
+<!ENTITY RightUpTeeVector "&#x0295C;" ><!--UPWARDS HARPOON WITH BARB RIGHT FROM BAR -->
+<!ENTITY RightUpVector    "&#x021BE;" ><!--UPWARDS HARPOON WITH BARB RIGHTWARDS -->
+<!ENTITY RightUpVectorBar "&#x02954;" ><!--UPWARDS HARPOON WITH BARB RIGHT TO BAR -->
+<!ENTITY RightVector      "&#x021C0;" ><!--RIGHTWARDS HARPOON WITH BARB UPWARDS -->
+<!ENTITY RightVectorBar   "&#x02953;" ><!--RIGHTWARDS HARPOON WITH BARB UP TO BAR -->
+<!ENTITY Rightarrow       "&#x021D2;" ><!--RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY Ropf             "&#x0211D;" ><!--DOUBLE-STRUCK CAPITAL R -->
+<!ENTITY RoundImplies     "&#x02970;" ><!--RIGHT DOUBLE ARROW WITH ROUNDED HEAD -->
+<!ENTITY Rrightarrow      "&#x021DB;" ><!--RIGHTWARDS TRIPLE ARROW -->
+<!ENTITY Rscr             "&#x0211B;" ><!--SCRIPT CAPITAL R -->
+<!ENTITY Rsh              "&#x021B1;" ><!--UPWARDS ARROW WITH TIP RIGHTWARDS -->
+<!ENTITY RuleDelayed      "&#x029F4;" ><!--RULE-DELAYED -->
+<!ENTITY SHCHcy           "&#x00429;" ><!--CYRILLIC CAPITAL LETTER SHCHA -->
+<!ENTITY SHcy             "&#x00428;" ><!--CYRILLIC CAPITAL LETTER SHA -->
+<!ENTITY SOFTcy           "&#x0042C;" ><!--CYRILLIC CAPITAL LETTER SOFT SIGN -->
+<!ENTITY Sacute           "&#x0015A;" ><!--LATIN CAPITAL LETTER S WITH ACUTE -->
+<!ENTITY Sc               "&#x02ABC;" ><!--DOUBLE SUCCEEDS -->
+<!ENTITY Scaron           "&#x00160;" ><!--LATIN CAPITAL LETTER S WITH CARON -->
+<!ENTITY Scedil           "&#x0015E;" ><!--LATIN CAPITAL LETTER S WITH CEDILLA -->
+<!ENTITY Scirc            "&#x0015C;" ><!--LATIN CAPITAL LETTER S WITH CIRCUMFLEX -->
+<!ENTITY Scy              "&#x00421;" ><!--CYRILLIC CAPITAL LETTER ES -->
+<!ENTITY Sfr              "&#x1D516;" ><!--MATHEMATICAL FRAKTUR CAPITAL S -->
+<!ENTITY ShortDownArrow   "&#x02193;" ><!--DOWNWARDS ARROW -->
+<!ENTITY ShortLeftArrow   "&#x02190;" ><!--LEFTWARDS ARROW -->
+<!ENTITY ShortRightArrow  "&#x02192;" ><!--RIGHTWARDS ARROW -->
+<!ENTITY ShortUpArrow     "&#x02191;" ><!--UPWARDS ARROW -->
+<!ENTITY Sigma            "&#x003A3;" ><!--GREEK CAPITAL LETTER SIGMA -->
+<!ENTITY SmallCircle      "&#x02218;" ><!--RING OPERATOR -->
+<!ENTITY Sopf             "&#x1D54A;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL S -->
+<!ENTITY Sqrt             "&#x0221A;" ><!--SQUARE ROOT -->
+<!ENTITY Square           "&#x025A1;" ><!--WHITE SQUARE -->
+<!ENTITY SquareIntersection "&#x02293;" ><!--SQUARE CAP -->
+<!ENTITY SquareSubset     "&#x0228F;" ><!--SQUARE IMAGE OF -->
+<!ENTITY SquareSubsetEqual "&#x02291;" ><!--SQUARE IMAGE OF OR EQUAL TO -->
+<!ENTITY SquareSuperset   "&#x02290;" ><!--SQUARE ORIGINAL OF -->
+<!ENTITY SquareSupersetEqual "&#x02292;" ><!--SQUARE ORIGINAL OF OR EQUAL TO -->
+<!ENTITY SquareUnion      "&#x02294;" ><!--SQUARE CUP -->
+<!ENTITY Sscr             "&#x1D4AE;" ><!--MATHEMATICAL SCRIPT CAPITAL S -->
+<!ENTITY Star             "&#x022C6;" ><!--STAR OPERATOR -->
+<!ENTITY Sub              "&#x022D0;" ><!--DOUBLE SUBSET -->
+<!ENTITY Subset           "&#x022D0;" ><!--DOUBLE SUBSET -->
+<!ENTITY SubsetEqual      "&#x02286;" ><!--SUBSET OF OR EQUAL TO -->
+<!ENTITY Succeeds         "&#x0227B;" ><!--SUCCEEDS -->
+<!ENTITY SucceedsEqual    "&#x02AB0;" ><!--SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN -->
+<!ENTITY SucceedsSlantEqual "&#x0227D;" ><!--SUCCEEDS OR EQUAL TO -->
+<!ENTITY SucceedsTilde    "&#x0227F;" ><!--SUCCEEDS OR EQUIVALENT TO -->
+<!ENTITY SuchThat         "&#x0220B;" ><!--CONTAINS AS MEMBER -->
+<!ENTITY Sum              "&#x02211;" ><!--N-ARY SUMMATION -->
+<!ENTITY Sup              "&#x022D1;" ><!--DOUBLE SUPERSET -->
+<!ENTITY Superset         "&#x02283;" ><!--SUPERSET OF -->
+<!ENTITY SupersetEqual    "&#x02287;" ><!--SUPERSET OF OR EQUAL TO -->
+<!ENTITY Supset           "&#x022D1;" ><!--DOUBLE SUPERSET -->
+<!ENTITY THORN            "&#x000DE;" ><!--LATIN CAPITAL LETTER THORN -->
+<!ENTITY TRADE            "&#x02122;" ><!--TRADE MARK SIGN -->
+<!ENTITY TSHcy            "&#x0040B;" ><!--CYRILLIC CAPITAL LETTER TSHE -->
+<!ENTITY TScy             "&#x00426;" ><!--CYRILLIC CAPITAL LETTER TSE -->
+<!ENTITY Tab              "&#x00009;" ><!--CHARACTER TABULATION -->
+<!ENTITY Tau              "&#x003A4;" ><!--GREEK CAPITAL LETTER TAU -->
+<!ENTITY Tcaron           "&#x00164;" ><!--LATIN CAPITAL LETTER T WITH CARON -->
+<!ENTITY Tcedil           "&#x00162;" ><!--LATIN CAPITAL LETTER T WITH CEDILLA -->
+<!ENTITY Tcy              "&#x00422;" ><!--CYRILLIC CAPITAL LETTER TE -->
+<!ENTITY Tfr              "&#x1D517;" ><!--MATHEMATICAL FRAKTUR CAPITAL T -->
+<!ENTITY Therefore        "&#x02234;" ><!--THEREFORE -->
+<!ENTITY Theta            "&#x00398;" ><!--GREEK CAPITAL LETTER THETA -->
+<!ENTITY ThickSpace       "&#x0205F;&#x0200A;" ><!--space of width 5/18 em -->
+<!ENTITY ThinSpace        "&#x02009;" ><!--THIN SPACE -->
+<!ENTITY Tilde            "&#x0223C;" ><!--TILDE OPERATOR -->
+<!ENTITY TildeEqual       "&#x02243;" ><!--ASYMPTOTICALLY EQUAL TO -->
+<!ENTITY TildeFullEqual   "&#x02245;" ><!--APPROXIMATELY EQUAL TO -->
+<!ENTITY TildeTilde       "&#x02248;" ><!--ALMOST EQUAL TO -->
+<!ENTITY Topf             "&#x1D54B;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL T -->
+<!ENTITY TripleDot        " &#x020DB;" ><!--COMBINING THREE DOTS ABOVE -->
+<!ENTITY Tscr             "&#x1D4AF;" ><!--MATHEMATICAL SCRIPT CAPITAL T -->
+<!ENTITY Tstrok           "&#x00166;" ><!--LATIN CAPITAL LETTER T WITH STROKE -->
+<!ENTITY Uacute           "&#x000DA;" ><!--LATIN CAPITAL LETTER U WITH ACUTE -->
+<!ENTITY Uarr             "&#x0219F;" ><!--UPWARDS TWO HEADED ARROW -->
+<!ENTITY Uarrocir         "&#x02949;" ><!--UPWARDS TWO-HEADED ARROW FROM SMALL CIRCLE -->
+<!ENTITY Ubrcy            "&#x0040E;" ><!--CYRILLIC CAPITAL LETTER SHORT U -->
+<!ENTITY Ubreve           "&#x0016C;" ><!--LATIN CAPITAL LETTER U WITH BREVE -->
+<!ENTITY Ucirc            "&#x000DB;" ><!--LATIN CAPITAL LETTER U WITH CIRCUMFLEX -->
+<!ENTITY Ucy              "&#x00423;" ><!--CYRILLIC CAPITAL LETTER U -->
+<!ENTITY Udblac           "&#x00170;" ><!--LATIN CAPITAL LETTER U WITH DOUBLE ACUTE -->
+<!ENTITY Ufr              "&#x1D518;" ><!--MATHEMATICAL FRAKTUR CAPITAL U -->
+<!ENTITY Ugrave           "&#x000D9;" ><!--LATIN CAPITAL LETTER U WITH GRAVE -->
+<!ENTITY Umacr            "&#x0016A;" ><!--LATIN CAPITAL LETTER U WITH MACRON -->
+<!ENTITY UnderBar         "&#x0005F;" ><!--LOW LINE -->
+<!ENTITY UnderBrace       "&#x023DF;" ><!--BOTTOM CURLY BRACKET -->
+<!ENTITY UnderBracket     "&#x023B5;" ><!--BOTTOM SQUARE BRACKET -->
+<!ENTITY UnderParenthesis "&#x023DD;" ><!--BOTTOM PARENTHESIS -->
+<!ENTITY Union            "&#x022C3;" ><!--N-ARY UNION -->
+<!ENTITY UnionPlus        "&#x0228E;" ><!--MULTISET UNION -->
+<!ENTITY Uogon            "&#x00172;" ><!--LATIN CAPITAL LETTER U WITH OGONEK -->
+<!ENTITY Uopf             "&#x1D54C;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL U -->
+<!ENTITY UpArrow          "&#x02191;" ><!--UPWARDS ARROW -->
+<!ENTITY UpArrowBar       "&#x02912;" ><!--UPWARDS ARROW TO BAR -->
+<!ENTITY UpArrowDownArrow "&#x021C5;" ><!--UPWARDS ARROW LEFTWARDS OF DOWNWARDS ARROW -->
+<!ENTITY UpDownArrow      "&#x02195;" ><!--UP DOWN ARROW -->
+<!ENTITY UpEquilibrium    "&#x0296E;" ><!--UPWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON WITH BARB RIGHT -->
+<!ENTITY UpTee            "&#x022A5;" ><!--UP TACK -->
+<!ENTITY UpTeeArrow       "&#x021A5;" ><!--UPWARDS ARROW FROM BAR -->
+<!ENTITY Uparrow          "&#x021D1;" ><!--UPWARDS DOUBLE ARROW -->
+<!ENTITY Updownarrow      "&#x021D5;" ><!--UP DOWN DOUBLE ARROW -->
+<!ENTITY UpperLeftArrow   "&#x02196;" ><!--NORTH WEST ARROW -->
+<!ENTITY UpperRightArrow  "&#x02197;" ><!--NORTH EAST ARROW -->
+<!ENTITY Upsi             "&#x003D2;" ><!--GREEK UPSILON WITH HOOK SYMBOL -->
+<!ENTITY Upsilon          "&#x003A5;" ><!--GREEK CAPITAL LETTER UPSILON -->
+<!ENTITY Uring            "&#x0016E;" ><!--LATIN CAPITAL LETTER U WITH RING ABOVE -->
+<!ENTITY Uscr             "&#x1D4B0;" ><!--MATHEMATICAL SCRIPT CAPITAL U -->
+<!ENTITY Utilde           "&#x00168;" ><!--LATIN CAPITAL LETTER U WITH TILDE -->
+<!ENTITY Uuml             "&#x000DC;" ><!--LATIN CAPITAL LETTER U WITH DIAERESIS -->
+<!ENTITY VDash            "&#x022AB;" ><!--DOUBLE VERTICAL BAR DOUBLE RIGHT TURNSTILE -->
+<!ENTITY Vbar             "&#x02AEB;" ><!--DOUBLE UP TACK -->
+<!ENTITY Vcy              "&#x00412;" ><!--CYRILLIC CAPITAL LETTER VE -->
+<!ENTITY Vdash            "&#x022A9;" ><!--FORCES -->
+<!ENTITY Vdashl           "&#x02AE6;" ><!--LONG DASH FROM LEFT MEMBER OF DOUBLE VERTICAL -->
+<!ENTITY Vee              "&#x022C1;" ><!--N-ARY LOGICAL OR -->
+<!ENTITY Verbar           "&#x02016;" ><!--DOUBLE VERTICAL LINE -->
+<!ENTITY Vert             "&#x02016;" ><!--DOUBLE VERTICAL LINE -->
+<!ENTITY VerticalBar      "&#x02223;" ><!--DIVIDES -->
+<!ENTITY VerticalLine     "&#x0007C;" ><!--VERTICAL LINE -->
+<!ENTITY VerticalSeparator "&#x02758;" ><!--LIGHT VERTICAL BAR -->
+<!ENTITY VerticalTilde    "&#x02240;" ><!--WREATH PRODUCT -->
+<!ENTITY VeryThinSpace    "&#x0200A;" ><!--HAIR SPACE -->
+<!ENTITY Vfr              "&#x1D519;" ><!--MATHEMATICAL FRAKTUR CAPITAL V -->
+<!ENTITY Vopf             "&#x1D54D;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL V -->
+<!ENTITY Vscr             "&#x1D4B1;" ><!--MATHEMATICAL SCRIPT CAPITAL V -->
+<!ENTITY Vvdash           "&#x022AA;" ><!--TRIPLE VERTICAL BAR RIGHT TURNSTILE -->
+<!ENTITY Wcirc            "&#x00174;" ><!--LATIN CAPITAL LETTER W WITH CIRCUMFLEX -->
+<!ENTITY Wedge            "&#x022C0;" ><!--N-ARY LOGICAL AND -->
+<!ENTITY Wfr              "&#x1D51A;" ><!--MATHEMATICAL FRAKTUR CAPITAL W -->
+<!ENTITY Wopf             "&#x1D54E;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL W -->
+<!ENTITY Wscr             "&#x1D4B2;" ><!--MATHEMATICAL SCRIPT CAPITAL W -->
+<!ENTITY Xfr              "&#x1D51B;" ><!--MATHEMATICAL FRAKTUR CAPITAL X -->
+<!ENTITY Xi               "&#x0039E;" ><!--GREEK CAPITAL LETTER XI -->
+<!ENTITY Xopf             "&#x1D54F;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL X -->
+<!ENTITY Xscr             "&#x1D4B3;" ><!--MATHEMATICAL SCRIPT CAPITAL X -->
+<!ENTITY YAcy             "&#x0042F;" ><!--CYRILLIC CAPITAL LETTER YA -->
+<!ENTITY YIcy             "&#x00407;" ><!--CYRILLIC CAPITAL LETTER YI -->
+<!ENTITY YUcy             "&#x0042E;" ><!--CYRILLIC CAPITAL LETTER YU -->
+<!ENTITY Yacute           "&#x000DD;" ><!--LATIN CAPITAL LETTER Y WITH ACUTE -->
+<!ENTITY Ycirc            "&#x00176;" ><!--LATIN CAPITAL LETTER Y WITH CIRCUMFLEX -->
+<!ENTITY Ycy              "&#x0042B;" ><!--CYRILLIC CAPITAL LETTER YERU -->
+<!ENTITY Yfr              "&#x1D51C;" ><!--MATHEMATICAL FRAKTUR CAPITAL Y -->
+<!ENTITY Yopf             "&#x1D550;" ><!--MATHEMATICAL DOUBLE-STRUCK CAPITAL Y -->
+<!ENTITY Yscr             "&#x1D4B4;" ><!--MATHEMATICAL SCRIPT CAPITAL Y -->
+<!ENTITY Yuml             "&#x00178;" ><!--LATIN CAPITAL LETTER Y WITH DIAERESIS -->
+<!ENTITY ZHcy             "&#x00416;" ><!--CYRILLIC CAPITAL LETTER ZHE -->
+<!ENTITY Zacute           "&#x00179;" ><!--LATIN CAPITAL LETTER Z WITH ACUTE -->
+<!ENTITY Zcaron           "&#x0017D;" ><!--LATIN CAPITAL LETTER Z WITH CARON -->
+<!ENTITY Zcy              "&#x00417;" ><!--CYRILLIC CAPITAL LETTER ZE -->
+<!ENTITY Zdot             "&#x0017B;" ><!--LATIN CAPITAL LETTER Z WITH DOT ABOVE -->
+<!ENTITY ZeroWidthSpace   "&#x0200B;" ><!--ZERO WIDTH SPACE -->
+<!ENTITY Zeta             "&#x00396;" ><!--GREEK CAPITAL LETTER ZETA -->
+<!ENTITY Zfr              "&#x02128;" ><!--BLACK-LETTER CAPITAL Z -->
+<!ENTITY Zopf             "&#x02124;" ><!--DOUBLE-STRUCK CAPITAL Z -->
+<!ENTITY Zscr             "&#x1D4B5;" ><!--MATHEMATICAL SCRIPT CAPITAL Z -->
+<!ENTITY aacute           "&#x000E1;" ><!--LATIN SMALL LETTER A WITH ACUTE -->
+<!ENTITY abreve           "&#x00103;" ><!--LATIN SMALL LETTER A WITH BREVE -->
+<!ENTITY ac               "&#x0223E;" ><!--INVERTED LAZY S -->
+<!ENTITY acE              "&#x0223E;&#x00333;" ><!--INVERTED LAZY S with double underline -->
+<!ENTITY acd              "&#x0223F;" ><!--SINE WAVE -->
+<!ENTITY acirc            "&#x000E2;" ><!--LATIN SMALL LETTER A WITH CIRCUMFLEX -->
+<!ENTITY acute            "&#x000B4;" ><!--ACUTE ACCENT -->
+<!ENTITY acy              "&#x00430;" ><!--CYRILLIC SMALL LETTER A -->
+<!ENTITY aelig            "&#x000E6;" ><!--LATIN SMALL LETTER AE -->
+<!ENTITY af               "&#x02061;" ><!--FUNCTION APPLICATION -->
+<!ENTITY afr              "&#x1D51E;" ><!--MATHEMATICAL FRAKTUR SMALL A -->
+<!ENTITY agrave           "&#x000E0;" ><!--LATIN SMALL LETTER A WITH GRAVE -->
+<!ENTITY alefsym          "&#x02135;" ><!--ALEF SYMBOL -->
+<!ENTITY aleph            "&#x02135;" ><!--ALEF SYMBOL -->
+<!ENTITY alpha            "&#x003B1;" ><!--GREEK SMALL LETTER ALPHA -->
+<!ENTITY amacr            "&#x00101;" ><!--LATIN SMALL LETTER A WITH MACRON -->
+<!ENTITY amalg            "&#x02A3F;" ><!--AMALGAMATION OR COPRODUCT -->
+<!ENTITY amp              "&#38;#38;" ><!--AMPERSAND -->
+<!ENTITY and              "&#x02227;" ><!--LOGICAL AND -->
+<!ENTITY andand           "&#x02A55;" ><!--TWO INTERSECTING LOGICAL AND -->
+<!ENTITY andd             "&#x02A5C;" ><!--LOGICAL AND WITH HORIZONTAL DASH -->
+<!ENTITY andslope         "&#x02A58;" ><!--SLOPING LARGE AND -->
+<!ENTITY andv             "&#x02A5A;" ><!--LOGICAL AND WITH MIDDLE STEM -->
+<!ENTITY ang              "&#x02220;" ><!--ANGLE -->
+<!ENTITY ange             "&#x029A4;" ><!--ANGLE WITH UNDERBAR -->
+<!ENTITY angle            "&#x02220;" ><!--ANGLE -->
+<!ENTITY angmsd           "&#x02221;" ><!--MEASURED ANGLE -->
+<!ENTITY angmsdaa         "&#x029A8;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING UP AND RIGHT -->
+<!ENTITY angmsdab         "&#x029A9;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING UP AND LEFT -->
+<!ENTITY angmsdac         "&#x029AA;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING DOWN AND RIGHT -->
+<!ENTITY angmsdad         "&#x029AB;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING DOWN AND LEFT -->
+<!ENTITY angmsdae         "&#x029AC;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING RIGHT AND UP -->
+<!ENTITY angmsdaf         "&#x029AD;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING LEFT AND UP -->
+<!ENTITY angmsdag         "&#x029AE;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING RIGHT AND DOWN -->
+<!ENTITY angmsdah         "&#x029AF;" ><!--MEASURED ANGLE WITH OPEN ARM ENDING IN ARROW POINTING LEFT AND DOWN -->
+<!ENTITY angrt            "&#x0221F;" ><!--RIGHT ANGLE -->
+<!ENTITY angrtvb          "&#x022BE;" ><!--RIGHT ANGLE WITH ARC -->
+<!ENTITY angrtvbd         "&#x0299D;" ><!--MEASURED RIGHT ANGLE WITH DOT -->
+<!ENTITY angsph           "&#x02222;" ><!--SPHERICAL ANGLE -->
+<!ENTITY angst            "&#x000C5;" ><!--LATIN CAPITAL LETTER A WITH RING ABOVE -->
+<!ENTITY angzarr          "&#x0237C;" ><!--RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW -->
+<!ENTITY aogon            "&#x00105;" ><!--LATIN SMALL LETTER A WITH OGONEK -->
+<!ENTITY aopf             "&#x1D552;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL A -->
+<!ENTITY ap               "&#x02248;" ><!--ALMOST EQUAL TO -->
+<!ENTITY apE              "&#x02A70;" ><!--APPROXIMATELY EQUAL OR EQUAL TO -->
+<!ENTITY apacir           "&#x02A6F;" ><!--ALMOST EQUAL TO WITH CIRCUMFLEX ACCENT -->
+<!ENTITY ape              "&#x0224A;" ><!--ALMOST EQUAL OR EQUAL TO -->
+<!ENTITY apid             "&#x0224B;" ><!--TRIPLE TILDE -->
+<!ENTITY apos             "&#x00027;" ><!--APOSTROPHE -->
+<!ENTITY approx           "&#x02248;" ><!--ALMOST EQUAL TO -->
+<!ENTITY approxeq         "&#x0224A;" ><!--ALMOST EQUAL OR EQUAL TO -->
+<!ENTITY aring            "&#x000E5;" ><!--LATIN SMALL LETTER A WITH RING ABOVE -->
+<!ENTITY ascr             "&#x1D4B6;" ><!--MATHEMATICAL SCRIPT SMALL A -->
+<!ENTITY ast              "&#x0002A;" ><!--ASTERISK -->
+<!ENTITY asymp            "&#x02248;" ><!--ALMOST EQUAL TO -->
+<!ENTITY asympeq          "&#x0224D;" ><!--EQUIVALENT TO -->
+<!ENTITY atilde           "&#x000E3;" ><!--LATIN SMALL LETTER A WITH TILDE -->
+<!ENTITY auml             "&#x000E4;" ><!--LATIN SMALL LETTER A WITH DIAERESIS -->
+<!ENTITY awconint         "&#x02233;" ><!--ANTICLOCKWISE CONTOUR INTEGRAL -->
+<!ENTITY awint            "&#x02A11;" ><!--ANTICLOCKWISE INTEGRATION -->
+<!ENTITY bNot             "&#x02AED;" ><!--REVERSED DOUBLE STROKE NOT SIGN -->
+<!ENTITY backcong         "&#x0224C;" ><!--ALL EQUAL TO -->
+<!ENTITY backepsilon      "&#x003F6;" ><!--GREEK REVERSED LUNATE EPSILON SYMBOL -->
+<!ENTITY backprime        "&#x02035;" ><!--REVERSED PRIME -->
+<!ENTITY backsim          "&#x0223D;" ><!--REVERSED TILDE -->
+<!ENTITY backsimeq        "&#x022CD;" ><!--REVERSED TILDE EQUALS -->
+<!ENTITY barvee           "&#x022BD;" ><!--NOR -->
+<!ENTITY barwed           "&#x02305;" ><!--PROJECTIVE -->
+<!ENTITY barwedge         "&#x02305;" ><!--PROJECTIVE -->
+<!ENTITY bbrk             "&#x023B5;" ><!--BOTTOM SQUARE BRACKET -->
+<!ENTITY bbrktbrk         "&#x023B6;" ><!--BOTTOM SQUARE BRACKET OVER TOP SQUARE BRACKET -->
+<!ENTITY bcong            "&#x0224C;" ><!--ALL EQUAL TO -->
+<!ENTITY bcy              "&#x00431;" ><!--CYRILLIC SMALL LETTER BE -->
+<!ENTITY bdquo            "&#x0201E;" ><!--DOUBLE LOW-9 QUOTATION MARK -->
+<!ENTITY becaus           "&#x02235;" ><!--BECAUSE -->
+<!ENTITY because          "&#x02235;" ><!--BECAUSE -->
+<!ENTITY bemptyv          "&#x029B0;" ><!--REVERSED EMPTY SET -->
+<!ENTITY bepsi            "&#x003F6;" ><!--GREEK REVERSED LUNATE EPSILON SYMBOL -->
+<!ENTITY bernou           "&#x0212C;" ><!--SCRIPT CAPITAL B -->
+<!ENTITY beta             "&#x003B2;" ><!--GREEK SMALL LETTER BETA -->
+<!ENTITY beth             "&#x02136;" ><!--BET SYMBOL -->
+<!ENTITY between          "&#x0226C;" ><!--BETWEEN -->
+<!ENTITY bfr              "&#x1D51F;" ><!--MATHEMATICAL FRAKTUR SMALL B -->
+<!ENTITY bigcap           "&#x022C2;" ><!--N-ARY INTERSECTION -->
+<!ENTITY bigcirc          "&#x025EF;" ><!--LARGE CIRCLE -->
+<!ENTITY bigcup           "&#x022C3;" ><!--N-ARY UNION -->
+<!ENTITY bigodot          "&#x02A00;" ><!--N-ARY CIRCLED DOT OPERATOR -->
+<!ENTITY bigoplus         "&#x02A01;" ><!--N-ARY CIRCLED PLUS OPERATOR -->
+<!ENTITY bigotimes        "&#x02A02;" ><!--N-ARY CIRCLED TIMES OPERATOR -->
+<!ENTITY bigsqcup         "&#x02A06;" ><!--N-ARY SQUARE UNION OPERATOR -->
+<!ENTITY bigstar          "&#x02605;" ><!--BLACK STAR -->
+<!ENTITY bigtriangledown  "&#x025BD;" ><!--WHITE DOWN-POINTING TRIANGLE -->
+<!ENTITY bigtriangleup    "&#x025B3;" ><!--WHITE UP-POINTING TRIANGLE -->
+<!ENTITY biguplus         "&#x02A04;" ><!--N-ARY UNION OPERATOR WITH PLUS -->
+<!ENTITY bigvee           "&#x022C1;" ><!--N-ARY LOGICAL OR -->
+<!ENTITY bigwedge         "&#x022C0;" ><!--N-ARY LOGICAL AND -->
+<!ENTITY bkarow           "&#x0290D;" ><!--RIGHTWARDS DOUBLE DASH ARROW -->
+<!ENTITY blacklozenge     "&#x029EB;" ><!--BLACK LOZENGE -->
+<!ENTITY blacksquare      "&#x025AA;" ><!--BLACK SMALL SQUARE -->
+<!ENTITY blacktriangle    "&#x025B4;" ><!--BLACK UP-POINTING SMALL TRIANGLE -->
+<!ENTITY blacktriangledown "&#x025BE;" ><!--BLACK DOWN-POINTING SMALL TRIANGLE -->
+<!ENTITY blacktriangleleft "&#x025C2;" ><!--BLACK LEFT-POINTING SMALL TRIANGLE -->
+<!ENTITY blacktriangleright "&#x025B8;" ><!--BLACK RIGHT-POINTING SMALL TRIANGLE -->
+<!ENTITY blank            "&#x02423;" ><!--OPEN BOX -->
+<!ENTITY blk12            "&#x02592;" ><!--MEDIUM SHADE -->
+<!ENTITY blk14            "&#x02591;" ><!--LIGHT SHADE -->
+<!ENTITY blk34            "&#x02593;" ><!--DARK SHADE -->
+<!ENTITY block            "&#x02588;" ><!--FULL BLOCK -->
+<!ENTITY bne              "&#x0003D;&#x020E5;" ><!--EQUALS SIGN with reverse slash -->
+<!ENTITY bnequiv          "&#x02261;&#x020E5;" ><!--IDENTICAL TO with reverse slash -->
+<!ENTITY bnot             "&#x02310;" ><!--REVERSED NOT SIGN -->
+<!ENTITY bopf             "&#x1D553;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL B -->
+<!ENTITY bot              "&#x022A5;" ><!--UP TACK -->
+<!ENTITY bottom           "&#x022A5;" ><!--UP TACK -->
+<!ENTITY bowtie           "&#x022C8;" ><!--BOWTIE -->
+<!ENTITY boxDL            "&#x02557;" ><!--BOX DRAWINGS DOUBLE DOWN AND LEFT -->
+<!ENTITY boxDR            "&#x02554;" ><!--BOX DRAWINGS DOUBLE DOWN AND RIGHT -->
+<!ENTITY boxDl            "&#x02556;" ><!--BOX DRAWINGS DOWN DOUBLE AND LEFT SINGLE -->
+<!ENTITY boxDr            "&#x02553;" ><!--BOX DRAWINGS DOWN DOUBLE AND RIGHT SINGLE -->
+<!ENTITY boxH             "&#x02550;" ><!--BOX DRAWINGS DOUBLE HORIZONTAL -->
+<!ENTITY boxHD            "&#x02566;" ><!--BOX DRAWINGS DOUBLE DOWN AND HORIZONTAL -->
+<!ENTITY boxHU            "&#x02569;" ><!--BOX DRAWINGS DOUBLE UP AND HORIZONTAL -->
+<!ENTITY boxHd            "&#x02564;" ><!--BOX DRAWINGS DOWN SINGLE AND HORIZONTAL DOUBLE -->
+<!ENTITY boxHu            "&#x02567;" ><!--BOX DRAWINGS UP SINGLE AND HORIZONTAL DOUBLE -->
+<!ENTITY boxUL            "&#x0255D;" ><!--BOX DRAWINGS DOUBLE UP AND LEFT -->
+<!ENTITY boxUR            "&#x0255A;" ><!--BOX DRAWINGS DOUBLE UP AND RIGHT -->
+<!ENTITY boxUl            "&#x0255C;" ><!--BOX DRAWINGS UP DOUBLE AND LEFT SINGLE -->
+<!ENTITY boxUr            "&#x02559;" ><!--BOX DRAWINGS UP DOUBLE AND RIGHT SINGLE -->
+<!ENTITY boxV             "&#x02551;" ><!--BOX DRAWINGS DOUBLE VERTICAL -->
+<!ENTITY boxVH            "&#x0256C;" ><!--BOX DRAWINGS DOUBLE VERTICAL AND HORIZONTAL -->
+<!ENTITY boxVL            "&#x02563;" ><!--BOX DRAWINGS DOUBLE VERTICAL AND LEFT -->
+<!ENTITY boxVR            "&#x02560;" ><!--BOX DRAWINGS DOUBLE VERTICAL AND RIGHT -->
+<!ENTITY boxVh            "&#x0256B;" ><!--BOX DRAWINGS VERTICAL DOUBLE AND HORIZONTAL SINGLE -->
+<!ENTITY boxVl            "&#x02562;" ><!--BOX DRAWINGS VERTICAL DOUBLE AND LEFT SINGLE -->
+<!ENTITY boxVr            "&#x0255F;" ><!--BOX DRAWINGS VERTICAL DOUBLE AND RIGHT SINGLE -->
+<!ENTITY boxbox           "&#x029C9;" ><!--TWO JOINED SQUARES -->
+<!ENTITY boxdL            "&#x02555;" ><!--BOX DRAWINGS DOWN SINGLE AND LEFT DOUBLE -->
+<!ENTITY boxdR            "&#x02552;" ><!--BOX DRAWINGS DOWN SINGLE AND RIGHT DOUBLE -->
+<!ENTITY boxdl            "&#x02510;" ><!--BOX DRAWINGS LIGHT DOWN AND LEFT -->
+<!ENTITY boxdr            "&#x0250C;" ><!--BOX DRAWINGS LIGHT DOWN AND RIGHT -->
+<!ENTITY boxh             "&#x02500;" ><!--BOX DRAWINGS LIGHT HORIZONTAL -->
+<!ENTITY boxhD            "&#x02565;" ><!--BOX DRAWINGS DOWN DOUBLE AND HORIZONTAL SINGLE -->
+<!ENTITY boxhU            "&#x02568;" ><!--BOX DRAWINGS UP DOUBLE AND HORIZONTAL SINGLE -->
+<!ENTITY boxhd            "&#x0252C;" ><!--BOX DRAWINGS LIGHT DOWN AND HORIZONTAL -->
+<!ENTITY boxhu            "&#x02534;" ><!--BOX DRAWINGS LIGHT UP AND HORIZONTAL -->
+<!ENTITY boxminus         "&#x0229F;" ><!--SQUARED MINUS -->
+<!ENTITY boxplus          "&#x0229E;" ><!--SQUARED PLUS -->
+<!ENTITY boxtimes         "&#x022A0;" ><!--SQUARED TIMES -->
+<!ENTITY boxuL            "&#x0255B;" ><!--BOX DRAWINGS UP SINGLE AND LEFT DOUBLE -->
+<!ENTITY boxuR            "&#x02558;" ><!--BOX DRAWINGS UP SINGLE AND RIGHT DOUBLE -->
+<!ENTITY boxul            "&#x02518;" ><!--BOX DRAWINGS LIGHT UP AND LEFT -->
+<!ENTITY boxur            "&#x02514;" ><!--BOX DRAWINGS LIGHT UP AND RIGHT -->
+<!ENTITY boxv             "&#x02502;" ><!--BOX DRAWINGS LIGHT VERTICAL -->
+<!ENTITY boxvH            "&#x0256A;" ><!--BOX DRAWINGS VERTICAL SINGLE AND HORIZONTAL DOUBLE -->
+<!ENTITY boxvL            "&#x02561;" ><!--BOX DRAWINGS VERTICAL SINGLE AND LEFT DOUBLE -->
+<!ENTITY boxvR            "&#x0255E;" ><!--BOX DRAWINGS VERTICAL SINGLE AND RIGHT DOUBLE -->
+<!ENTITY boxvh            "&#x0253C;" ><!--BOX DRAWINGS LIGHT VERTICAL AND HORIZONTAL -->
+<!ENTITY boxvl            "&#x02524;" ><!--BOX DRAWINGS LIGHT VERTICAL AND LEFT -->
+<!ENTITY boxvr            "&#x0251C;" ><!--BOX DRAWINGS LIGHT VERTICAL AND RIGHT -->
+<!ENTITY bprime           "&#x02035;" ><!--REVERSED PRIME -->
+<!ENTITY breve            "&#x002D8;" ><!--BREVE -->
+<!ENTITY brvbar           "&#x000A6;" ><!--BROKEN BAR -->
+<!ENTITY bscr             "&#x1D4B7;" ><!--MATHEMATICAL SCRIPT SMALL B -->
+<!ENTITY bsemi            "&#x0204F;" ><!--REVERSED SEMICOLON -->
+<!ENTITY bsim             "&#x0223D;" ><!--REVERSED TILDE -->
+<!ENTITY bsime            "&#x022CD;" ><!--REVERSED TILDE EQUALS -->
+<!ENTITY bsol             "&#x0005C;" ><!--REVERSE SOLIDUS -->
+<!ENTITY bsolb            "&#x029C5;" ><!--SQUARED FALLING DIAGONAL SLASH -->
+<!ENTITY bsolhsub         "&#x027C8;" ><!--REVERSE SOLIDUS PRECEDING SUBSET -->
+<!ENTITY bull             "&#x02022;" ><!--BULLET -->
+<!ENTITY bullet           "&#x02022;" ><!--BULLET -->
+<!ENTITY bump             "&#x0224E;" ><!--GEOMETRICALLY EQUIVALENT TO -->
+<!ENTITY bumpE            "&#x02AAE;" ><!--EQUALS SIGN WITH BUMPY ABOVE -->
+<!ENTITY bumpe            "&#x0224F;" ><!--DIFFERENCE BETWEEN -->
+<!ENTITY bumpeq           "&#x0224F;" ><!--DIFFERENCE BETWEEN -->
+<!ENTITY cacute           "&#x00107;" ><!--LATIN SMALL LETTER C WITH ACUTE -->
+<!ENTITY cap              "&#x02229;" ><!--INTERSECTION -->
+<!ENTITY capand           "&#x02A44;" ><!--INTERSECTION WITH LOGICAL AND -->
+<!ENTITY capbrcup         "&#x02A49;" ><!--INTERSECTION ABOVE BAR ABOVE UNION -->
+<!ENTITY capcap           "&#x02A4B;" ><!--INTERSECTION BESIDE AND JOINED WITH INTERSECTION -->
+<!ENTITY capcup           "&#x02A47;" ><!--INTERSECTION ABOVE UNION -->
+<!ENTITY capdot           "&#x02A40;" ><!--INTERSECTION WITH DOT -->
+<!ENTITY caps             "&#x02229;&#x0FE00;" ><!--INTERSECTION with serifs -->
+<!ENTITY caret            "&#x02041;" ><!--CARET INSERTION POINT -->
+<!ENTITY caron            "&#x002C7;" ><!--CARON -->
+<!ENTITY ccaps            "&#x02A4D;" ><!--CLOSED INTERSECTION WITH SERIFS -->
+<!ENTITY ccaron           "&#x0010D;" ><!--LATIN SMALL LETTER C WITH CARON -->
+<!ENTITY ccedil           "&#x000E7;" ><!--LATIN SMALL LETTER C WITH CEDILLA -->
+<!ENTITY ccirc            "&#x00109;" ><!--LATIN SMALL LETTER C WITH CIRCUMFLEX -->
+<!ENTITY ccups            "&#x02A4C;" ><!--CLOSED UNION WITH SERIFS -->
+<!ENTITY ccupssm          "&#x02A50;" ><!--CLOSED UNION WITH SERIFS AND SMASH PRODUCT -->
+<!ENTITY cdot             "&#x0010B;" ><!--LATIN SMALL LETTER C WITH DOT ABOVE -->
+<!ENTITY cedil            "&#x000B8;" ><!--CEDILLA -->
+<!ENTITY cemptyv          "&#x029B2;" ><!--EMPTY SET WITH SMALL CIRCLE ABOVE -->
+<!ENTITY cent             "&#x000A2;" ><!--CENT SIGN -->
+<!ENTITY centerdot        "&#x000B7;" ><!--MIDDLE DOT -->
+<!ENTITY cfr              "&#x1D520;" ><!--MATHEMATICAL FRAKTUR SMALL C -->
+<!ENTITY chcy             "&#x00447;" ><!--CYRILLIC SMALL LETTER CHE -->
+<!ENTITY check            "&#x02713;" ><!--CHECK MARK -->
+<!ENTITY checkmark        "&#x02713;" ><!--CHECK MARK -->
+<!ENTITY chi              "&#x003C7;" ><!--GREEK SMALL LETTER CHI -->
+<!ENTITY cir              "&#x025CB;" ><!--WHITE CIRCLE -->
+<!ENTITY cirE             "&#x029C3;" ><!--CIRCLE WITH TWO HORIZONTAL STROKES TO THE RIGHT -->
+<!ENTITY circ             "&#x002C6;" ><!--MODIFIER LETTER CIRCUMFLEX ACCENT -->
+<!ENTITY circeq           "&#x02257;" ><!--RING EQUAL TO -->
+<!ENTITY circlearrowleft  "&#x021BA;" ><!--ANTICLOCKWISE OPEN CIRCLE ARROW -->
+<!ENTITY circlearrowright "&#x021BB;" ><!--CLOCKWISE OPEN CIRCLE ARROW -->
+<!ENTITY circledR         "&#x000AE;" ><!--REGISTERED SIGN -->
+<!ENTITY circledS         "&#x024C8;" ><!--CIRCLED LATIN CAPITAL LETTER S -->
+<!ENTITY circledast       "&#x0229B;" ><!--CIRCLED ASTERISK OPERATOR -->
+<!ENTITY circledcirc      "&#x0229A;" ><!--CIRCLED RING OPERATOR -->
+<!ENTITY circleddash      "&#x0229D;" ><!--CIRCLED DASH -->
+<!ENTITY cire             "&#x02257;" ><!--RING EQUAL TO -->
+<!ENTITY cirfnint         "&#x02A10;" ><!--CIRCULATION FUNCTION -->
+<!ENTITY cirmid           "&#x02AEF;" ><!--VERTICAL LINE WITH CIRCLE ABOVE -->
+<!ENTITY cirscir          "&#x029C2;" ><!--CIRCLE WITH SMALL CIRCLE TO THE RIGHT -->
+<!ENTITY clubs            "&#x02663;" ><!--BLACK CLUB SUIT -->
+<!ENTITY clubsuit         "&#x02663;" ><!--BLACK CLUB SUIT -->
+<!ENTITY colon            "&#x0003A;" ><!--COLON -->
+<!ENTITY colone           "&#x02254;" ><!--COLON EQUALS -->
+<!ENTITY coloneq          "&#x02254;" ><!--COLON EQUALS -->
+<!ENTITY comma            "&#x0002C;" ><!--COMMA -->
+<!ENTITY commat           "&#x00040;" ><!--COMMERCIAL AT -->
+<!ENTITY comp             "&#x02201;" ><!--COMPLEMENT -->
+<!ENTITY compfn           "&#x02218;" ><!--RING OPERATOR -->
+<!ENTITY complement       "&#x02201;" ><!--COMPLEMENT -->
+<!ENTITY complexes        "&#x02102;" ><!--DOUBLE-STRUCK CAPITAL C -->
+<!ENTITY cong             "&#x02245;" ><!--APPROXIMATELY EQUAL TO -->
+<!ENTITY congdot          "&#x02A6D;" ><!--CONGRUENT WITH DOT ABOVE -->
+<!ENTITY conint           "&#x0222E;" ><!--CONTOUR INTEGRAL -->
+<!ENTITY copf             "&#x1D554;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL C -->
+<!ENTITY coprod           "&#x02210;" ><!--N-ARY COPRODUCT -->
+<!ENTITY copy             "&#x000A9;" ><!--COPYRIGHT SIGN -->
+<!ENTITY copysr           "&#x02117;" ><!--SOUND RECORDING COPYRIGHT -->
+<!ENTITY crarr            "&#x021B5;" ><!--DOWNWARDS ARROW WITH CORNER LEFTWARDS -->
+<!ENTITY cross            "&#x02717;" ><!--BALLOT X -->
+<!ENTITY cscr             "&#x1D4B8;" ><!--MATHEMATICAL SCRIPT SMALL C -->
+<!ENTITY csub             "&#x02ACF;" ><!--CLOSED SUBSET -->
+<!ENTITY csube            "&#x02AD1;" ><!--CLOSED SUBSET OR EQUAL TO -->
+<!ENTITY csup             "&#x02AD0;" ><!--CLOSED SUPERSET -->
+<!ENTITY csupe            "&#x02AD2;" ><!--CLOSED SUPERSET OR EQUAL TO -->
+<!ENTITY ctdot            "&#x022EF;" ><!--MIDLINE HORIZONTAL ELLIPSIS -->
+<!ENTITY cudarrl          "&#x02938;" ><!--RIGHT-SIDE ARC CLOCKWISE ARROW -->
+<!ENTITY cudarrr          "&#x02935;" ><!--ARROW POINTING RIGHTWARDS THEN CURVING DOWNWARDS -->
+<!ENTITY cuepr            "&#x022DE;" ><!--EQUAL TO OR PRECEDES -->
+<!ENTITY cuesc            "&#x022DF;" ><!--EQUAL TO OR SUCCEEDS -->
+<!ENTITY cularr           "&#x021B6;" ><!--ANTICLOCKWISE TOP SEMICIRCLE ARROW -->
+<!ENTITY cularrp          "&#x0293D;" ><!--TOP ARC ANTICLOCKWISE ARROW WITH PLUS -->
+<!ENTITY cup              "&#x0222A;" ><!--UNION -->
+<!ENTITY cupbrcap         "&#x02A48;" ><!--UNION ABOVE BAR ABOVE INTERSECTION -->
+<!ENTITY cupcap           "&#x02A46;" ><!--UNION ABOVE INTERSECTION -->
+<!ENTITY cupcup           "&#x02A4A;" ><!--UNION BESIDE AND JOINED WITH UNION -->
+<!ENTITY cupdot           "&#x0228D;" ><!--MULTISET MULTIPLICATION -->
+<!ENTITY cupor            "&#x02A45;" ><!--UNION WITH LOGICAL OR -->
+<!ENTITY cups             "&#x0222A;&#x0FE00;" ><!--UNION with serifs -->
+<!ENTITY curarr           "&#x021B7;" ><!--CLOCKWISE TOP SEMICIRCLE ARROW -->
+<!ENTITY curarrm          "&#x0293C;" ><!--TOP ARC CLOCKWISE ARROW WITH MINUS -->
+<!ENTITY curlyeqprec      "&#x022DE;" ><!--EQUAL TO OR PRECEDES -->
+<!ENTITY curlyeqsucc      "&#x022DF;" ><!--EQUAL TO OR SUCCEEDS -->
+<!ENTITY curlyvee         "&#x022CE;" ><!--CURLY LOGICAL OR -->
+<!ENTITY curlywedge       "&#x022CF;" ><!--CURLY LOGICAL AND -->
+<!ENTITY curren           "&#x000A4;" ><!--CURRENCY SIGN -->
+<!ENTITY curvearrowleft   "&#x021B6;" ><!--ANTICLOCKWISE TOP SEMICIRCLE ARROW -->
+<!ENTITY curvearrowright  "&#x021B7;" ><!--CLOCKWISE TOP SEMICIRCLE ARROW -->
+<!ENTITY cuvee            "&#x022CE;" ><!--CURLY LOGICAL OR -->
+<!ENTITY cuwed            "&#x022CF;" ><!--CURLY LOGICAL AND -->
+<!ENTITY cwconint         "&#x02232;" ><!--CLOCKWISE CONTOUR INTEGRAL -->
+<!ENTITY cwint            "&#x02231;" ><!--CLOCKWISE INTEGRAL -->
+<!ENTITY cylcty           "&#x0232D;" ><!--CYLINDRICITY -->
+<!ENTITY dArr             "&#x021D3;" ><!--DOWNWARDS DOUBLE ARROW -->
+<!ENTITY dHar             "&#x02965;" ><!--DOWNWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON WITH BARB RIGHT -->
+<!ENTITY dagger           "&#x02020;" ><!--DAGGER -->
+<!ENTITY daleth           "&#x02138;" ><!--DALET SYMBOL -->
+<!ENTITY darr             "&#x02193;" ><!--DOWNWARDS ARROW -->
+<!ENTITY dash             "&#x02010;" ><!--HYPHEN -->
+<!ENTITY dashv            "&#x022A3;" ><!--LEFT TACK -->
+<!ENTITY dbkarow          "&#x0290F;" ><!--RIGHTWARDS TRIPLE DASH ARROW -->
+<!ENTITY dblac            "&#x002DD;" ><!--DOUBLE ACUTE ACCENT -->
+<!ENTITY dcaron           "&#x0010F;" ><!--LATIN SMALL LETTER D WITH CARON -->
+<!ENTITY dcy              "&#x00434;" ><!--CYRILLIC SMALL LETTER DE -->
+<!ENTITY dd               "&#x02146;" ><!--DOUBLE-STRUCK ITALIC SMALL D -->
+<!ENTITY ddagger          "&#x02021;" ><!--DOUBLE DAGGER -->
+<!ENTITY ddarr            "&#x021CA;" ><!--DOWNWARDS PAIRED ARROWS -->
+<!ENTITY ddotseq          "&#x02A77;" ><!--EQUALS SIGN WITH TWO DOTS ABOVE AND TWO DOTS BELOW -->
+<!ENTITY deg              "&#x000B0;" ><!--DEGREE SIGN -->
+<!ENTITY delta            "&#x003B4;" ><!--GREEK SMALL LETTER DELTA -->
+<!ENTITY demptyv          "&#x029B1;" ><!--EMPTY SET WITH OVERBAR -->
+<!ENTITY dfisht           "&#x0297F;" ><!--DOWN FISH TAIL -->
+<!ENTITY dfr              "&#x1D521;" ><!--MATHEMATICAL FRAKTUR SMALL D -->
+<!ENTITY dharl            "&#x021C3;" ><!--DOWNWARDS HARPOON WITH BARB LEFTWARDS -->
+<!ENTITY dharr            "&#x021C2;" ><!--DOWNWARDS HARPOON WITH BARB RIGHTWARDS -->
+<!ENTITY diam             "&#x022C4;" ><!--DIAMOND OPERATOR -->
+<!ENTITY diamond          "&#x022C4;" ><!--DIAMOND OPERATOR -->
+<!ENTITY diamondsuit      "&#x02666;" ><!--BLACK DIAMOND SUIT -->
+<!ENTITY diams            "&#x02666;" ><!--BLACK DIAMOND SUIT -->
+<!ENTITY die              "&#x000A8;" ><!--DIAERESIS -->
+<!ENTITY digamma          "&#x003DD;" ><!--GREEK SMALL LETTER DIGAMMA -->
+<!ENTITY disin            "&#x022F2;" ><!--ELEMENT OF WITH LONG HORIZONTAL STROKE -->
+<!ENTITY div              "&#x000F7;" ><!--DIVISION SIGN -->
+<!ENTITY divide           "&#x000F7;" ><!--DIVISION SIGN -->
+<!ENTITY divideontimes    "&#x022C7;" ><!--DIVISION TIMES -->
+<!ENTITY divonx           "&#x022C7;" ><!--DIVISION TIMES -->
+<!ENTITY djcy             "&#x00452;" ><!--CYRILLIC SMALL LETTER DJE -->
+<!ENTITY dlcorn           "&#x0231E;" ><!--BOTTOM LEFT CORNER -->
+<!ENTITY dlcrop           "&#x0230D;" ><!--BOTTOM LEFT CROP -->
+<!ENTITY dollar           "&#x00024;" ><!--DOLLAR SIGN -->
+<!ENTITY dopf             "&#x1D555;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL D -->
+<!ENTITY dot              "&#x002D9;" ><!--DOT ABOVE -->
+<!ENTITY doteq            "&#x02250;" ><!--APPROACHES THE LIMIT -->
+<!ENTITY doteqdot         "&#x02251;" ><!--GEOMETRICALLY EQUAL TO -->
+<!ENTITY dotminus         "&#x02238;" ><!--DOT MINUS -->
+<!ENTITY dotplus          "&#x02214;" ><!--DOT PLUS -->
+<!ENTITY dotsquare        "&#x022A1;" ><!--SQUARED DOT OPERATOR -->
+<!ENTITY doublebarwedge   "&#x02306;" ><!--PERSPECTIVE -->
+<!ENTITY downarrow        "&#x02193;" ><!--DOWNWARDS ARROW -->
+<!ENTITY downdownarrows   "&#x021CA;" ><!--DOWNWARDS PAIRED ARROWS -->
+<!ENTITY downharpoonleft  "&#x021C3;" ><!--DOWNWARDS HARPOON WITH BARB LEFTWARDS -->
+<!ENTITY downharpoonright "&#x021C2;" ><!--DOWNWARDS HARPOON WITH BARB RIGHTWARDS -->
+<!ENTITY drbkarow         "&#x02910;" ><!--RIGHTWARDS TWO-HEADED TRIPLE DASH ARROW -->
+<!ENTITY drcorn           "&#x0231F;" ><!--BOTTOM RIGHT CORNER -->
+<!ENTITY drcrop           "&#x0230C;" ><!--BOTTOM RIGHT CROP -->
+<!ENTITY dscr             "&#x1D4B9;" ><!--MATHEMATICAL SCRIPT SMALL D -->
+<!ENTITY dscy             "&#x00455;" ><!--CYRILLIC SMALL LETTER DZE -->
+<!ENTITY dsol             "&#x029F6;" ><!--SOLIDUS WITH OVERBAR -->
+<!ENTITY dstrok           "&#x00111;" ><!--LATIN SMALL LETTER D WITH STROKE -->
+<!ENTITY dtdot            "&#x022F1;" ><!--DOWN RIGHT DIAGONAL ELLIPSIS -->
+<!ENTITY dtri             "&#x025BF;" ><!--WHITE DOWN-POINTING SMALL TRIANGLE -->
+<!ENTITY dtrif            "&#x025BE;" ><!--BLACK DOWN-POINTING SMALL TRIANGLE -->
+<!ENTITY duarr            "&#x021F5;" ><!--DOWNWARDS ARROW LEFTWARDS OF UPWARDS ARROW -->
+<!ENTITY duhar            "&#x0296F;" ><!--DOWNWARDS HARPOON WITH BARB LEFT BESIDE UPWARDS HARPOON WITH BARB RIGHT -->
+<!ENTITY dwangle          "&#x029A6;" ><!--OBLIQUE ANGLE OPENING UP -->
+<!ENTITY dzcy             "&#x0045F;" ><!--CYRILLIC SMALL LETTER DZHE -->
+<!ENTITY dzigrarr         "&#x027FF;" ><!--LONG RIGHTWARDS SQUIGGLE ARROW -->
+<!ENTITY eDDot            "&#x02A77;" ><!--EQUALS SIGN WITH TWO DOTS ABOVE AND TWO DOTS BELOW -->
+<!ENTITY eDot             "&#x02251;" ><!--GEOMETRICALLY EQUAL TO -->
+<!ENTITY eacute           "&#x000E9;" ><!--LATIN SMALL LETTER E WITH ACUTE -->
+<!ENTITY easter           "&#x02A6E;" ><!--EQUALS WITH ASTERISK -->
+<!ENTITY ecaron           "&#x0011B;" ><!--LATIN SMALL LETTER E WITH CARON -->
+<!ENTITY ecir             "&#x02256;" ><!--RING IN EQUAL TO -->
+<!ENTITY ecirc            "&#x000EA;" ><!--LATIN SMALL LETTER E WITH CIRCUMFLEX -->
+<!ENTITY ecolon           "&#x02255;" ><!--EQUALS COLON -->
+<!ENTITY ecy              "&#x0044D;" ><!--CYRILLIC SMALL LETTER E -->
+<!ENTITY edot             "&#x00117;" ><!--LATIN SMALL LETTER E WITH DOT ABOVE -->
+<!ENTITY ee               "&#x02147;" ><!--DOUBLE-STRUCK ITALIC SMALL E -->
+<!ENTITY efDot            "&#x02252;" ><!--APPROXIMATELY EQUAL TO OR THE IMAGE OF -->
+<!ENTITY efr              "&#x1D522;" ><!--MATHEMATICAL FRAKTUR SMALL E -->
+<!ENTITY eg               "&#x02A9A;" ><!--DOUBLE-LINE EQUAL TO OR GREATER-THAN -->
+<!ENTITY egrave           "&#x000E8;" ><!--LATIN SMALL LETTER E WITH GRAVE -->
+<!ENTITY egs              "&#x02A96;" ><!--SLANTED EQUAL TO OR GREATER-THAN -->
+<!ENTITY egsdot           "&#x02A98;" ><!--SLANTED EQUAL TO OR GREATER-THAN WITH DOT INSIDE -->
+<!ENTITY el               "&#x02A99;" ><!--DOUBLE-LINE EQUAL TO OR LESS-THAN -->
+<!ENTITY elinters         "&#x023E7;" ><!--ELECTRICAL INTERSECTION -->
+<!ENTITY ell              "&#x02113;" ><!--SCRIPT SMALL L -->
+<!ENTITY els              "&#x02A95;" ><!--SLANTED EQUAL TO OR LESS-THAN -->
+<!ENTITY elsdot           "&#x02A97;" ><!--SLANTED EQUAL TO OR LESS-THAN WITH DOT INSIDE -->
+<!ENTITY emacr            "&#x00113;" ><!--LATIN SMALL LETTER E WITH MACRON -->
+<!ENTITY empty            "&#x02205;" ><!--EMPTY SET -->
+<!ENTITY emptyset         "&#x02205;" ><!--EMPTY SET -->
+<!ENTITY emptyv           "&#x02205;" ><!--EMPTY SET -->
+<!ENTITY emsp             "&#x02003;" ><!--EM SPACE -->
+<!ENTITY emsp13           "&#x02004;" ><!--THREE-PER-EM SPACE -->
+<!ENTITY emsp14           "&#x02005;" ><!--FOUR-PER-EM SPACE -->
+<!ENTITY eng              "&#x0014B;" ><!--LATIN SMALL LETTER ENG -->
+<!ENTITY ensp             "&#x02002;" ><!--EN SPACE -->
+<!ENTITY eogon            "&#x00119;" ><!--LATIN SMALL LETTER E WITH OGONEK -->
+<!ENTITY eopf             "&#x1D556;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL E -->
+<!ENTITY epar             "&#x022D5;" ><!--EQUAL AND PARALLEL TO -->
+<!ENTITY eparsl           "&#x029E3;" ><!--EQUALS SIGN AND SLANTED PARALLEL -->
+<!ENTITY eplus            "&#x02A71;" ><!--EQUALS SIGN ABOVE PLUS SIGN -->
+<!ENTITY epsi             "&#x003B5;" ><!--GREEK SMALL LETTER EPSILON -->
+<!ENTITY epsilon          "&#x003B5;" ><!--GREEK SMALL LETTER EPSILON -->
+<!ENTITY epsiv            "&#x003F5;" ><!--GREEK LUNATE EPSILON SYMBOL -->
+<!ENTITY eqcirc           "&#x02256;" ><!--RING IN EQUAL TO -->
+<!ENTITY eqcolon          "&#x02255;" ><!--EQUALS COLON -->
+<!ENTITY eqsim            "&#x02242;" ><!--MINUS TILDE -->
+<!ENTITY eqslantgtr       "&#x02A96;" ><!--SLANTED EQUAL TO OR GREATER-THAN -->
+<!ENTITY eqslantless      "&#x02A95;" ><!--SLANTED EQUAL TO OR LESS-THAN -->
+<!ENTITY equals           "&#x0003D;" ><!--EQUALS SIGN -->
+<!ENTITY equest           "&#x0225F;" ><!--QUESTIONED EQUAL TO -->
+<!ENTITY equiv            "&#x02261;" ><!--IDENTICAL TO -->
+<!ENTITY equivDD          "&#x02A78;" ><!--EQUIVALENT WITH FOUR DOTS ABOVE -->
+<!ENTITY eqvparsl         "&#x029E5;" ><!--IDENTICAL TO AND SLANTED PARALLEL -->
+<!ENTITY erDot            "&#x02253;" ><!--IMAGE OF OR APPROXIMATELY EQUAL TO -->
+<!ENTITY erarr            "&#x02971;" ><!--EQUALS SIGN ABOVE RIGHTWARDS ARROW -->
+<!ENTITY escr             "&#x0212F;" ><!--SCRIPT SMALL E -->
+<!ENTITY esdot            "&#x02250;" ><!--APPROACHES THE LIMIT -->
+<!ENTITY esim             "&#x02242;" ><!--MINUS TILDE -->
+<!ENTITY eta              "&#x003B7;" ><!--GREEK SMALL LETTER ETA -->
+<!ENTITY eth              "&#x000F0;" ><!--LATIN SMALL LETTER ETH -->
+<!ENTITY euml             "&#x000EB;" ><!--LATIN SMALL LETTER E WITH DIAERESIS -->
+<!ENTITY euro             "&#x020AC;" ><!--EURO SIGN -->
+<!ENTITY excl             "&#x00021;" ><!--EXCLAMATION MARK -->
+<!ENTITY exist            "&#x02203;" ><!--THERE EXISTS -->
+<!ENTITY expectation      "&#x02130;" ><!--SCRIPT CAPITAL E -->
+<!ENTITY exponentiale     "&#x02147;" ><!--DOUBLE-STRUCK ITALIC SMALL E -->
+<!ENTITY fallingdotseq    "&#x02252;" ><!--APPROXIMATELY EQUAL TO OR THE IMAGE OF -->
+<!ENTITY fcy              "&#x00444;" ><!--CYRILLIC SMALL LETTER EF -->
+<!ENTITY female           "&#x02640;" ><!--FEMALE SIGN -->
+<!ENTITY ffilig           "&#x0FB03;" ><!--LATIN SMALL LIGATURE FFI -->
+<!ENTITY fflig            "&#x0FB00;" ><!--LATIN SMALL LIGATURE FF -->
+<!ENTITY ffllig           "&#x0FB04;" ><!--LATIN SMALL LIGATURE FFL -->
+<!ENTITY ffr              "&#x1D523;" ><!--MATHEMATICAL FRAKTUR SMALL F -->
+<!ENTITY filig            "&#x0FB01;" ><!--LATIN SMALL LIGATURE FI -->
+<!ENTITY fjlig            "&#x00066;&#x0006A;" ><!--fj ligature -->
+<!ENTITY flat             "&#x0266D;" ><!--MUSIC FLAT SIGN -->
+<!ENTITY fllig            "&#x0FB02;" ><!--LATIN SMALL LIGATURE FL -->
+<!ENTITY fltns            "&#x025B1;" ><!--WHITE PARALLELOGRAM -->
+<!ENTITY fnof             "&#x00192;" ><!--LATIN SMALL LETTER F WITH HOOK -->
+<!ENTITY fopf             "&#x1D557;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL F -->
+<!ENTITY forall           "&#x02200;" ><!--FOR ALL -->
+<!ENTITY fork             "&#x022D4;" ><!--PITCHFORK -->
+<!ENTITY forkv            "&#x02AD9;" ><!--ELEMENT OF OPENING DOWNWARDS -->
+<!ENTITY fpartint         "&#x02A0D;" ><!--FINITE PART INTEGRAL -->
+<!ENTITY frac12           "&#x000BD;" ><!--VULGAR FRACTION ONE HALF -->
+<!ENTITY frac13           "&#x02153;" ><!--VULGAR FRACTION ONE THIRD -->
+<!ENTITY frac14           "&#x000BC;" ><!--VULGAR FRACTION ONE QUARTER -->
+<!ENTITY frac15           "&#x02155;" ><!--VULGAR FRACTION ONE FIFTH -->
+<!ENTITY frac16           "&#x02159;" ><!--VULGAR FRACTION ONE SIXTH -->
+<!ENTITY frac18           "&#x0215B;" ><!--VULGAR FRACTION ONE EIGHTH -->
+<!ENTITY frac23           "&#x02154;" ><!--VULGAR FRACTION TWO THIRDS -->
+<!ENTITY frac25           "&#x02156;" ><!--VULGAR FRACTION TWO FIFTHS -->
+<!ENTITY frac34           "&#x000BE;" ><!--VULGAR FRACTION THREE QUARTERS -->
+<!ENTITY frac35           "&#x02157;" ><!--VULGAR FRACTION THREE FIFTHS -->
+<!ENTITY frac38           "&#x0215C;" ><!--VULGAR FRACTION THREE EIGHTHS -->
+<!ENTITY frac45           "&#x02158;" ><!--VULGAR FRACTION FOUR FIFTHS -->
+<!ENTITY frac56           "&#x0215A;" ><!--VULGAR FRACTION FIVE SIXTHS -->
+<!ENTITY frac58           "&#x0215D;" ><!--VULGAR FRACTION FIVE EIGHTHS -->
+<!ENTITY frac78           "&#x0215E;" ><!--VULGAR FRACTION SEVEN EIGHTHS -->
+<!ENTITY frasl            "&#x02044;" ><!--FRACTION SLASH -->
+<!ENTITY frown            "&#x02322;" ><!--FROWN -->
+<!ENTITY fscr             "&#x1D4BB;" ><!--MATHEMATICAL SCRIPT SMALL F -->
+<!ENTITY gE               "&#x02267;" ><!--GREATER-THAN OVER EQUAL TO -->
+<!ENTITY gEl              "&#x02A8C;" ><!--GREATER-THAN ABOVE DOUBLE-LINE EQUAL ABOVE LESS-THAN -->
+<!ENTITY gacute           "&#x001F5;" ><!--LATIN SMALL LETTER G WITH ACUTE -->
+<!ENTITY gamma            "&#x003B3;" ><!--GREEK SMALL LETTER GAMMA -->
+<!ENTITY gammad           "&#x003DD;" ><!--GREEK SMALL LETTER DIGAMMA -->
+<!ENTITY gap              "&#x02A86;" ><!--GREATER-THAN OR APPROXIMATE -->
+<!ENTITY gbreve           "&#x0011F;" ><!--LATIN SMALL LETTER G WITH BREVE -->
+<!ENTITY gcirc            "&#x0011D;" ><!--LATIN SMALL LETTER G WITH CIRCUMFLEX -->
+<!ENTITY gcy              "&#x00433;" ><!--CYRILLIC SMALL LETTER GHE -->
+<!ENTITY gdot             "&#x00121;" ><!--LATIN SMALL LETTER G WITH DOT ABOVE -->
+<!ENTITY ge               "&#x02265;" ><!--GREATER-THAN OR EQUAL TO -->
+<!ENTITY gel              "&#x022DB;" ><!--GREATER-THAN EQUAL TO OR LESS-THAN -->
+<!ENTITY geq              "&#x02265;" ><!--GREATER-THAN OR EQUAL TO -->
+<!ENTITY geqq             "&#x02267;" ><!--GREATER-THAN OVER EQUAL TO -->
+<!ENTITY geqslant         "&#x02A7E;" ><!--GREATER-THAN OR SLANTED EQUAL TO -->
+<!ENTITY ges              "&#x02A7E;" ><!--GREATER-THAN OR SLANTED EQUAL TO -->
+<!ENTITY gescc            "&#x02AA9;" ><!--GREATER-THAN CLOSED BY CURVE ABOVE SLANTED EQUAL -->
+<!ENTITY gesdot           "&#x02A80;" ><!--GREATER-THAN OR SLANTED EQUAL TO WITH DOT INSIDE -->
+<!ENTITY gesdoto          "&#x02A82;" ><!--GREATER-THAN OR SLANTED EQUAL TO WITH DOT ABOVE -->
+<!ENTITY gesdotol         "&#x02A84;" ><!--GREATER-THAN OR SLANTED EQUAL TO WITH DOT ABOVE LEFT -->
+<!ENTITY gesl             "&#x022DB;&#x0FE00;" ><!--GREATER-THAN slanted EQUAL TO OR LESS-THAN -->
+<!ENTITY gesles           "&#x02A94;" ><!--GREATER-THAN ABOVE SLANTED EQUAL ABOVE LESS-THAN ABOVE SLANTED EQUAL -->
+<!ENTITY gfr              "&#x1D524;" ><!--MATHEMATICAL FRAKTUR SMALL G -->
+<!ENTITY gg               "&#x0226B;" ><!--MUCH GREATER-THAN -->
+<!ENTITY ggg              "&#x022D9;" ><!--VERY MUCH GREATER-THAN -->
+<!ENTITY gimel            "&#x02137;" ><!--GIMEL SYMBOL -->
+<!ENTITY gjcy             "&#x00453;" ><!--CYRILLIC SMALL LETTER GJE -->
+<!ENTITY gl               "&#x02277;" ><!--GREATER-THAN OR LESS-THAN -->
+<!ENTITY glE              "&#x02A92;" ><!--GREATER-THAN ABOVE LESS-THAN ABOVE DOUBLE-LINE EQUAL -->
+<!ENTITY gla              "&#x02AA5;" ><!--GREATER-THAN BESIDE LESS-THAN -->
+<!ENTITY glj              "&#x02AA4;" ><!--GREATER-THAN OVERLAPPING LESS-THAN -->
+<!ENTITY gnE              "&#x02269;" ><!--GREATER-THAN BUT NOT EQUAL TO -->
+<!ENTITY gnap             "&#x02A8A;" ><!--GREATER-THAN AND NOT APPROXIMATE -->
+<!ENTITY gnapprox         "&#x02A8A;" ><!--GREATER-THAN AND NOT APPROXIMATE -->
+<!ENTITY gne              "&#x02A88;" ><!--GREATER-THAN AND SINGLE-LINE NOT EQUAL TO -->
+<!ENTITY gneq             "&#x02A88;" ><!--GREATER-THAN AND SINGLE-LINE NOT EQUAL TO -->
+<!ENTITY gneqq            "&#x02269;" ><!--GREATER-THAN BUT NOT EQUAL TO -->
+<!ENTITY gnsim            "&#x022E7;" ><!--GREATER-THAN BUT NOT EQUIVALENT TO -->
+<!ENTITY gopf             "&#x1D558;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL G -->
+<!ENTITY grave            "&#x00060;" ><!--GRAVE ACCENT -->
+<!ENTITY gscr             "&#x0210A;" ><!--SCRIPT SMALL G -->
+<!ENTITY gsim             "&#x02273;" ><!--GREATER-THAN OR EQUIVALENT TO -->
+<!ENTITY gsime            "&#x02A8E;" ><!--GREATER-THAN ABOVE SIMILAR OR EQUAL -->
+<!ENTITY gsiml            "&#x02A90;" ><!--GREATER-THAN ABOVE SIMILAR ABOVE LESS-THAN -->
+<!ENTITY gt               "&#x0003E;" ><!--GREATER-THAN SIGN -->
+<!ENTITY gtcc             "&#x02AA7;" ><!--GREATER-THAN CLOSED BY CURVE -->
+<!ENTITY gtcir            "&#x02A7A;" ><!--GREATER-THAN WITH CIRCLE INSIDE -->
+<!ENTITY gtdot            "&#x022D7;" ><!--GREATER-THAN WITH DOT -->
+<!ENTITY gtlPar           "&#x02995;" ><!--DOUBLE LEFT ARC GREATER-THAN BRACKET -->
+<!ENTITY gtquest          "&#x02A7C;" ><!--GREATER-THAN WITH QUESTION MARK ABOVE -->
+<!ENTITY gtrapprox        "&#x02A86;" ><!--GREATER-THAN OR APPROXIMATE -->
+<!ENTITY gtrarr           "&#x02978;" ><!--GREATER-THAN ABOVE RIGHTWARDS ARROW -->
+<!ENTITY gtrdot           "&#x022D7;" ><!--GREATER-THAN WITH DOT -->
+<!ENTITY gtreqless        "&#x022DB;" ><!--GREATER-THAN EQUAL TO OR LESS-THAN -->
+<!ENTITY gtreqqless       "&#x02A8C;" ><!--GREATER-THAN ABOVE DOUBLE-LINE EQUAL ABOVE LESS-THAN -->
+<!ENTITY gtrless          "&#x02277;" ><!--GREATER-THAN OR LESS-THAN -->
+<!ENTITY gtrsim           "&#x02273;" ><!--GREATER-THAN OR EQUIVALENT TO -->
+<!ENTITY gvertneqq        "&#x02269;&#x0FE00;" ><!--GREATER-THAN BUT NOT EQUAL TO - with vertical stroke -->
+<!ENTITY gvnE             "&#x02269;&#x0FE00;" ><!--GREATER-THAN BUT NOT EQUAL TO - with vertical stroke -->
+<!ENTITY hArr             "&#x021D4;" ><!--LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY hairsp           "&#x0200A;" ><!--HAIR SPACE -->
+<!ENTITY half             "&#x000BD;" ><!--VULGAR FRACTION ONE HALF -->
+<!ENTITY hamilt           "&#x0210B;" ><!--SCRIPT CAPITAL H -->
+<!ENTITY hardcy           "&#x0044A;" ><!--CYRILLIC SMALL LETTER HARD SIGN -->
+<!ENTITY harr             "&#x02194;" ><!--LEFT RIGHT ARROW -->
+<!ENTITY harrcir          "&#x02948;" ><!--LEFT RIGHT ARROW THROUGH SMALL CIRCLE -->
+<!ENTITY harrw            "&#x021AD;" ><!--LEFT RIGHT WAVE ARROW -->
+<!ENTITY hbar             "&#x0210F;" ><!--PLANCK CONSTANT OVER TWO PI -->
+<!ENTITY hcirc            "&#x00125;" ><!--LATIN SMALL LETTER H WITH CIRCUMFLEX -->
+<!ENTITY hearts           "&#x02665;" ><!--BLACK HEART SUIT -->
+<!ENTITY heartsuit        "&#x02665;" ><!--BLACK HEART SUIT -->
+<!ENTITY hellip           "&#x02026;" ><!--HORIZONTAL ELLIPSIS -->
+<!ENTITY hercon           "&#x022B9;" ><!--HERMITIAN CONJUGATE MATRIX -->
+<!ENTITY hfr              "&#x1D525;" ><!--MATHEMATICAL FRAKTUR SMALL H -->
+<!ENTITY hksearow         "&#x02925;" ><!--SOUTH EAST ARROW WITH HOOK -->
+<!ENTITY hkswarow         "&#x02926;" ><!--SOUTH WEST ARROW WITH HOOK -->
+<!ENTITY hoarr            "&#x021FF;" ><!--LEFT RIGHT OPEN-HEADED ARROW -->
+<!ENTITY homtht           "&#x0223B;" ><!--HOMOTHETIC -->
+<!ENTITY hookleftarrow    "&#x021A9;" ><!--LEFTWARDS ARROW WITH HOOK -->
+<!ENTITY hookrightarrow   "&#x021AA;" ><!--RIGHTWARDS ARROW WITH HOOK -->
+<!ENTITY hopf             "&#x1D559;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL H -->
+<!ENTITY horbar           "&#x02015;" ><!--HORIZONTAL BAR -->
+<!ENTITY hscr             "&#x1D4BD;" ><!--MATHEMATICAL SCRIPT SMALL H -->
+<!ENTITY hslash           "&#x0210F;" ><!--PLANCK CONSTANT OVER TWO PI -->
+<!ENTITY hstrok           "&#x00127;" ><!--LATIN SMALL LETTER H WITH STROKE -->
+<!ENTITY hybull           "&#x02043;" ><!--HYPHEN BULLET -->
+<!ENTITY hyphen           "&#x02010;" ><!--HYPHEN -->
+<!ENTITY iacute           "&#x000ED;" ><!--LATIN SMALL LETTER I WITH ACUTE -->
+<!ENTITY ic               "&#x02063;" ><!--INVISIBLE SEPARATOR -->
+<!ENTITY icirc            "&#x000EE;" ><!--LATIN SMALL LETTER I WITH CIRCUMFLEX -->
+<!ENTITY icy              "&#x00438;" ><!--CYRILLIC SMALL LETTER I -->
+<!ENTITY iecy             "&#x00435;" ><!--CYRILLIC SMALL LETTER IE -->
+<!ENTITY iexcl            "&#x000A1;" ><!--INVERTED EXCLAMATION MARK -->
+<!ENTITY iff              "&#x021D4;" ><!--LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY ifr              "&#x1D526;" ><!--MATHEMATICAL FRAKTUR SMALL I -->
+<!ENTITY igrave           "&#x000EC;" ><!--LATIN SMALL LETTER I WITH GRAVE -->
+<!ENTITY ii               "&#x02148;" ><!--DOUBLE-STRUCK ITALIC SMALL I -->
+<!ENTITY iiiint           "&#x02A0C;" ><!--QUADRUPLE INTEGRAL OPERATOR -->
+<!ENTITY iiint            "&#x0222D;" ><!--TRIPLE INTEGRAL -->
+<!ENTITY iinfin           "&#x029DC;" ><!--INCOMPLETE INFINITY -->
+<!ENTITY iiota            "&#x02129;" ><!--TURNED GREEK SMALL LETTER IOTA -->
+<!ENTITY ijlig            "&#x00133;" ><!--LATIN SMALL LIGATURE IJ -->
+<!ENTITY imacr            "&#x0012B;" ><!--LATIN SMALL LETTER I WITH MACRON -->
+<!ENTITY image            "&#x02111;" ><!--BLACK-LETTER CAPITAL I -->
+<!ENTITY imagline         "&#x02110;" ><!--SCRIPT CAPITAL I -->
+<!ENTITY imagpart         "&#x02111;" ><!--BLACK-LETTER CAPITAL I -->
+<!ENTITY imath            "&#x00131;" ><!--LATIN SMALL LETTER DOTLESS I -->
+<!ENTITY imof             "&#x022B7;" ><!--IMAGE OF -->
+<!ENTITY imped            "&#x001B5;" ><!--LATIN CAPITAL LETTER Z WITH STROKE -->
+<!ENTITY in               "&#x02208;" ><!--ELEMENT OF -->
+<!ENTITY incare           "&#x02105;" ><!--CARE OF -->
+<!ENTITY infin            "&#x0221E;" ><!--INFINITY -->
+<!ENTITY infintie         "&#x029DD;" ><!--TIE OVER INFINITY -->
+<!ENTITY inodot           "&#x00131;" ><!--LATIN SMALL LETTER DOTLESS I -->
+<!ENTITY int              "&#x0222B;" ><!--INTEGRAL -->
+<!ENTITY intcal           "&#x022BA;" ><!--INTERCALATE -->
+<!ENTITY integers         "&#x02124;" ><!--DOUBLE-STRUCK CAPITAL Z -->
+<!ENTITY intercal         "&#x022BA;" ><!--INTERCALATE -->
+<!ENTITY intlarhk         "&#x02A17;" ><!--INTEGRAL WITH LEFTWARDS ARROW WITH HOOK -->
+<!ENTITY intprod          "&#x02A3C;" ><!--INTERIOR PRODUCT -->
+<!ENTITY iocy             "&#x00451;" ><!--CYRILLIC SMALL LETTER IO -->
+<!ENTITY iogon            "&#x0012F;" ><!--LATIN SMALL LETTER I WITH OGONEK -->
+<!ENTITY iopf             "&#x1D55A;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL I -->
+<!ENTITY iota             "&#x003B9;" ><!--GREEK SMALL LETTER IOTA -->
+<!ENTITY iprod            "&#x02A3C;" ><!--INTERIOR PRODUCT -->
+<!ENTITY iquest           "&#x000BF;" ><!--INVERTED QUESTION MARK -->
+<!ENTITY iscr             "&#x1D4BE;" ><!--MATHEMATICAL SCRIPT SMALL I -->
+<!ENTITY isin             "&#x02208;" ><!--ELEMENT OF -->
+<!ENTITY isinE            "&#x022F9;" ><!--ELEMENT OF WITH TWO HORIZONTAL STROKES -->
+<!ENTITY isindot          "&#x022F5;" ><!--ELEMENT OF WITH DOT ABOVE -->
+<!ENTITY isins            "&#x022F4;" ><!--SMALL ELEMENT OF WITH VERTICAL BAR AT END OF HORIZONTAL STROKE -->
+<!ENTITY isinsv           "&#x022F3;" ><!--ELEMENT OF WITH VERTICAL BAR AT END OF HORIZONTAL STROKE -->
+<!ENTITY isinv            "&#x02208;" ><!--ELEMENT OF -->
+<!ENTITY it               "&#x02062;" ><!--INVISIBLE TIMES -->
+<!ENTITY itilde           "&#x00129;" ><!--LATIN SMALL LETTER I WITH TILDE -->
+<!ENTITY iukcy            "&#x00456;" ><!--CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I -->
+<!ENTITY iuml             "&#x000EF;" ><!--LATIN SMALL LETTER I WITH DIAERESIS -->
+<!ENTITY jcirc            "&#x00135;" ><!--LATIN SMALL LETTER J WITH CIRCUMFLEX -->
+<!ENTITY jcy              "&#x00439;" ><!--CYRILLIC SMALL LETTER SHORT I -->
+<!ENTITY jfr              "&#x1D527;" ><!--MATHEMATICAL FRAKTUR SMALL J -->
+<!ENTITY jmath            "&#x00237;" ><!--LATIN SMALL LETTER DOTLESS J -->
+<!ENTITY jopf             "&#x1D55B;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL J -->
+<!ENTITY jscr             "&#x1D4BF;" ><!--MATHEMATICAL SCRIPT SMALL J -->
+<!ENTITY jsercy           "&#x00458;" ><!--CYRILLIC SMALL LETTER JE -->
+<!ENTITY jukcy            "&#x00454;" ><!--CYRILLIC SMALL LETTER UKRAINIAN IE -->
+<!ENTITY kappa            "&#x003BA;" ><!--GREEK SMALL LETTER KAPPA -->
+<!ENTITY kappav           "&#x003F0;" ><!--GREEK KAPPA SYMBOL -->
+<!ENTITY kcedil           "&#x00137;" ><!--LATIN SMALL LETTER K WITH CEDILLA -->
+<!ENTITY kcy              "&#x0043A;" ><!--CYRILLIC SMALL LETTER KA -->
+<!ENTITY kfr              "&#x1D528;" ><!--MATHEMATICAL FRAKTUR SMALL K -->
+<!ENTITY kgreen           "&#x00138;" ><!--LATIN SMALL LETTER KRA -->
+<!ENTITY khcy             "&#x00445;" ><!--CYRILLIC SMALL LETTER HA -->
+<!ENTITY kjcy             "&#x0045C;" ><!--CYRILLIC SMALL LETTER KJE -->
+<!ENTITY kopf             "&#x1D55C;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL K -->
+<!ENTITY kscr             "&#x1D4C0;" ><!--MATHEMATICAL SCRIPT SMALL K -->
+<!ENTITY lAarr            "&#x021DA;" ><!--LEFTWARDS TRIPLE ARROW -->
+<!ENTITY lArr             "&#x021D0;" ><!--LEFTWARDS DOUBLE ARROW -->
+<!ENTITY lAtail           "&#x0291B;" ><!--LEFTWARDS DOUBLE ARROW-TAIL -->
+<!ENTITY lBarr            "&#x0290E;" ><!--LEFTWARDS TRIPLE DASH ARROW -->
+<!ENTITY lE               "&#x02266;" ><!--LESS-THAN OVER EQUAL TO -->
+<!ENTITY lEg              "&#x02A8B;" ><!--LESS-THAN ABOVE DOUBLE-LINE EQUAL ABOVE GREATER-THAN -->
+<!ENTITY lHar             "&#x02962;" ><!--LEFTWARDS HARPOON WITH BARB UP ABOVE LEFTWARDS HARPOON WITH BARB DOWN -->
+<!ENTITY lacute           "&#x0013A;" ><!--LATIN SMALL LETTER L WITH ACUTE -->
+<!ENTITY laemptyv         "&#x029B4;" ><!--EMPTY SET WITH LEFT ARROW ABOVE -->
+<!ENTITY lagran           "&#x02112;" ><!--SCRIPT CAPITAL L -->
+<!ENTITY lambda           "&#x003BB;" ><!--GREEK SMALL LETTER LAMDA -->
+<!ENTITY lang             "&#x027E8;" ><!--MATHEMATICAL LEFT ANGLE BRACKET -->
+<!ENTITY langd            "&#x02991;" ><!--LEFT ANGLE BRACKET WITH DOT -->
+<!ENTITY langle           "&#x027E8;" ><!--MATHEMATICAL LEFT ANGLE BRACKET -->
+<!ENTITY lap              "&#x02A85;" ><!--LESS-THAN OR APPROXIMATE -->
+<!ENTITY laquo            "&#x000AB;" ><!--LEFT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+<!ENTITY larr             "&#x02190;" ><!--LEFTWARDS ARROW -->
+<!ENTITY larrb            "&#x021E4;" ><!--LEFTWARDS ARROW TO BAR -->
+<!ENTITY larrbfs          "&#x0291F;" ><!--LEFTWARDS ARROW FROM BAR TO BLACK DIAMOND -->
+<!ENTITY larrfs           "&#x0291D;" ><!--LEFTWARDS ARROW TO BLACK DIAMOND -->
+<!ENTITY larrhk           "&#x021A9;" ><!--LEFTWARDS ARROW WITH HOOK -->
+<!ENTITY larrlp           "&#x021AB;" ><!--LEFTWARDS ARROW WITH LOOP -->
+<!ENTITY larrpl           "&#x02939;" ><!--LEFT-SIDE ARC ANTICLOCKWISE ARROW -->
+<!ENTITY larrsim          "&#x02973;" ><!--LEFTWARDS ARROW ABOVE TILDE OPERATOR -->
+<!ENTITY larrtl           "&#x021A2;" ><!--LEFTWARDS ARROW WITH TAIL -->
+<!ENTITY lat              "&#x02AAB;" ><!--LARGER THAN -->
+<!ENTITY latail           "&#x02919;" ><!--LEFTWARDS ARROW-TAIL -->
+<!ENTITY late             "&#x02AAD;" ><!--LARGER THAN OR EQUAL TO -->
+<!ENTITY lates            "&#x02AAD;&#x0FE00;" ><!--LARGER THAN OR slanted EQUAL -->
+<!ENTITY lbarr            "&#x0290C;" ><!--LEFTWARDS DOUBLE DASH ARROW -->
+<!ENTITY lbbrk            "&#x02772;" ><!--LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT -->
+<!ENTITY lbrace           "&#x0007B;" ><!--LEFT CURLY BRACKET -->
+<!ENTITY lbrack           "&#x0005B;" ><!--LEFT SQUARE BRACKET -->
+<!ENTITY lbrke            "&#x0298B;" ><!--LEFT SQUARE BRACKET WITH UNDERBAR -->
+<!ENTITY lbrksld          "&#x0298F;" ><!--LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER -->
+<!ENTITY lbrkslu          "&#x0298D;" ><!--LEFT SQUARE BRACKET WITH TICK IN TOP CORNER -->
+<!ENTITY lcaron           "&#x0013E;" ><!--LATIN SMALL LETTER L WITH CARON -->
+<!ENTITY lcedil           "&#x0013C;" ><!--LATIN SMALL LETTER L WITH CEDILLA -->
+<!ENTITY lceil            "&#x02308;" ><!--LEFT CEILING -->
+<!ENTITY lcub             "&#x0007B;" ><!--LEFT CURLY BRACKET -->
+<!ENTITY lcy              "&#x0043B;" ><!--CYRILLIC SMALL LETTER EL -->
+<!ENTITY ldca             "&#x02936;" ><!--ARROW POINTING DOWNWARDS THEN CURVING LEFTWARDS -->
+<!ENTITY ldquo            "&#x0201C;" ><!--LEFT DOUBLE QUOTATION MARK -->
+<!ENTITY ldquor           "&#x0201E;" ><!--DOUBLE LOW-9 QUOTATION MARK -->
+<!ENTITY ldrdhar          "&#x02967;" ><!--LEFTWARDS HARPOON WITH BARB DOWN ABOVE RIGHTWARDS HARPOON WITH BARB DOWN -->
+<!ENTITY ldrushar         "&#x0294B;" ><!--LEFT BARB DOWN RIGHT BARB UP HARPOON -->
+<!ENTITY ldsh             "&#x021B2;" ><!--DOWNWARDS ARROW WITH TIP LEFTWARDS -->
+<!ENTITY le               "&#x02264;" ><!--LESS-THAN OR EQUAL TO -->
+<!ENTITY leftarrow        "&#x02190;" ><!--LEFTWARDS ARROW -->
+<!ENTITY leftarrowtail    "&#x021A2;" ><!--LEFTWARDS ARROW WITH TAIL -->
+<!ENTITY leftharpoondown  "&#x021BD;" ><!--LEFTWARDS HARPOON WITH BARB DOWNWARDS -->
+<!ENTITY leftharpoonup    "&#x021BC;" ><!--LEFTWARDS HARPOON WITH BARB UPWARDS -->
+<!ENTITY leftleftarrows   "&#x021C7;" ><!--LEFTWARDS PAIRED ARROWS -->
+<!ENTITY leftrightarrow   "&#x02194;" ><!--LEFT RIGHT ARROW -->
+<!ENTITY leftrightarrows  "&#x021C6;" ><!--LEFTWARDS ARROW OVER RIGHTWARDS ARROW -->
+<!ENTITY leftrightharpoons "&#x021CB;" ><!--LEFTWARDS HARPOON OVER RIGHTWARDS HARPOON -->
+<!ENTITY leftrightsquigarrow "&#x021AD;" ><!--LEFT RIGHT WAVE ARROW -->
+<!ENTITY leftthreetimes   "&#x022CB;" ><!--LEFT SEMIDIRECT PRODUCT -->
+<!ENTITY leg              "&#x022DA;" ><!--LESS-THAN EQUAL TO OR GREATER-THAN -->
+<!ENTITY leq              "&#x02264;" ><!--LESS-THAN OR EQUAL TO -->
+<!ENTITY leqq             "&#x02266;" ><!--LESS-THAN OVER EQUAL TO -->
+<!ENTITY leqslant         "&#x02A7D;" ><!--LESS-THAN OR SLANTED EQUAL TO -->
+<!ENTITY les              "&#x02A7D;" ><!--LESS-THAN OR SLANTED EQUAL TO -->
+<!ENTITY lescc            "&#x02AA8;" ><!--LESS-THAN CLOSED BY CURVE ABOVE SLANTED EQUAL -->
+<!ENTITY lesdot           "&#x02A7F;" ><!--LESS-THAN OR SLANTED EQUAL TO WITH DOT INSIDE -->
+<!ENTITY lesdoto          "&#x02A81;" ><!--LESS-THAN OR SLANTED EQUAL TO WITH DOT ABOVE -->
+<!ENTITY lesdotor         "&#x02A83;" ><!--LESS-THAN OR SLANTED EQUAL TO WITH DOT ABOVE RIGHT -->
+<!ENTITY lesg             "&#x022DA;&#x0FE00;" ><!--LESS-THAN slanted EQUAL TO OR GREATER-THAN -->
+<!ENTITY lesges           "&#x02A93;" ><!--LESS-THAN ABOVE SLANTED EQUAL ABOVE GREATER-THAN ABOVE SLANTED EQUAL -->
+<!ENTITY lessapprox       "&#x02A85;" ><!--LESS-THAN OR APPROXIMATE -->
+<!ENTITY lessdot          "&#x022D6;" ><!--LESS-THAN WITH DOT -->
+<!ENTITY lesseqgtr        "&#x022DA;" ><!--LESS-THAN EQUAL TO OR GREATER-THAN -->
+<!ENTITY lesseqqgtr       "&#x02A8B;" ><!--LESS-THAN ABOVE DOUBLE-LINE EQUAL ABOVE GREATER-THAN -->
+<!ENTITY lessgtr          "&#x02276;" ><!--LESS-THAN OR GREATER-THAN -->
+<!ENTITY lesssim          "&#x02272;" ><!--LESS-THAN OR EQUIVALENT TO -->
+<!ENTITY lfisht           "&#x0297C;" ><!--LEFT FISH TAIL -->
+<!ENTITY lfloor           "&#x0230A;" ><!--LEFT FLOOR -->
+<!ENTITY lfr              "&#x1D529;" ><!--MATHEMATICAL FRAKTUR SMALL L -->
+<!ENTITY lg               "&#x02276;" ><!--LESS-THAN OR GREATER-THAN -->
+<!ENTITY lgE              "&#x02A91;" ><!--LESS-THAN ABOVE GREATER-THAN ABOVE DOUBLE-LINE EQUAL -->
+<!ENTITY lhard            "&#x021BD;" ><!--LEFTWARDS HARPOON WITH BARB DOWNWARDS -->
+<!ENTITY lharu            "&#x021BC;" ><!--LEFTWARDS HARPOON WITH BARB UPWARDS -->
+<!ENTITY lharul           "&#x0296A;" ><!--LEFTWARDS HARPOON WITH BARB UP ABOVE LONG DASH -->
+<!ENTITY lhblk            "&#x02584;" ><!--LOWER HALF BLOCK -->
+<!ENTITY ljcy             "&#x00459;" ><!--CYRILLIC SMALL LETTER LJE -->
+<!ENTITY ll               "&#x0226A;" ><!--MUCH LESS-THAN -->
+<!ENTITY llarr            "&#x021C7;" ><!--LEFTWARDS PAIRED ARROWS -->
+<!ENTITY llcorner         "&#x0231E;" ><!--BOTTOM LEFT CORNER -->
+<!ENTITY llhard           "&#x0296B;" ><!--LEFTWARDS HARPOON WITH BARB DOWN BELOW LONG DASH -->
+<!ENTITY lltri            "&#x025FA;" ><!--LOWER LEFT TRIANGLE -->
+<!ENTITY lmidot           "&#x00140;" ><!--LATIN SMALL LETTER L WITH MIDDLE DOT -->
+<!ENTITY lmoust           "&#x023B0;" ><!--UPPER LEFT OR LOWER RIGHT CURLY BRACKET SECTION -->
+<!ENTITY lmoustache       "&#x023B0;" ><!--UPPER LEFT OR LOWER RIGHT CURLY BRACKET SECTION -->
+<!ENTITY lnE              "&#x02268;" ><!--LESS-THAN BUT NOT EQUAL TO -->
+<!ENTITY lnap             "&#x02A89;" ><!--LESS-THAN AND NOT APPROXIMATE -->
+<!ENTITY lnapprox         "&#x02A89;" ><!--LESS-THAN AND NOT APPROXIMATE -->
+<!ENTITY lne              "&#x02A87;" ><!--LESS-THAN AND SINGLE-LINE NOT EQUAL TO -->
+<!ENTITY lneq             "&#x02A87;" ><!--LESS-THAN AND SINGLE-LINE NOT EQUAL TO -->
+<!ENTITY lneqq            "&#x02268;" ><!--LESS-THAN BUT NOT EQUAL TO -->
+<!ENTITY lnsim            "&#x022E6;" ><!--LESS-THAN BUT NOT EQUIVALENT TO -->
+<!ENTITY loang            "&#x027EC;" ><!--MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET -->
+<!ENTITY loarr            "&#x021FD;" ><!--LEFTWARDS OPEN-HEADED ARROW -->
+<!ENTITY lobrk            "&#x027E6;" ><!--MATHEMATICAL LEFT WHITE SQUARE BRACKET -->
+<!ENTITY longleftarrow    "&#x027F5;" ><!--LONG LEFTWARDS ARROW -->
+<!ENTITY longleftrightarrow "&#x027F7;" ><!--LONG LEFT RIGHT ARROW -->
+<!ENTITY longmapsto       "&#x027FC;" ><!--LONG RIGHTWARDS ARROW FROM BAR -->
+<!ENTITY longrightarrow   "&#x027F6;" ><!--LONG RIGHTWARDS ARROW -->
+<!ENTITY looparrowleft    "&#x021AB;" ><!--LEFTWARDS ARROW WITH LOOP -->
+<!ENTITY looparrowright   "&#x021AC;" ><!--RIGHTWARDS ARROW WITH LOOP -->
+<!ENTITY lopar            "&#x02985;" ><!--LEFT WHITE PARENTHESIS -->
+<!ENTITY lopf             "&#x1D55D;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL L -->
+<!ENTITY loplus           "&#x02A2D;" ><!--PLUS SIGN IN LEFT HALF CIRCLE -->
+<!ENTITY lotimes          "&#x02A34;" ><!--MULTIPLICATION SIGN IN LEFT HALF CIRCLE -->
+<!ENTITY lowast           "&#x02217;" ><!--ASTERISK OPERATOR -->
+<!ENTITY lowbar           "&#x0005F;" ><!--LOW LINE -->
+<!ENTITY loz              "&#x025CA;" ><!--LOZENGE -->
+<!ENTITY lozenge          "&#x025CA;" ><!--LOZENGE -->
+<!ENTITY lozf             "&#x029EB;" ><!--BLACK LOZENGE -->
+<!ENTITY lpar             "&#x00028;" ><!--LEFT PARENTHESIS -->
+<!ENTITY lparlt           "&#x02993;" ><!--LEFT ARC LESS-THAN BRACKET -->
+<!ENTITY lrarr            "&#x021C6;" ><!--LEFTWARDS ARROW OVER RIGHTWARDS ARROW -->
+<!ENTITY lrcorner         "&#x0231F;" ><!--BOTTOM RIGHT CORNER -->
+<!ENTITY lrhar            "&#x021CB;" ><!--LEFTWARDS HARPOON OVER RIGHTWARDS HARPOON -->
+<!ENTITY lrhard           "&#x0296D;" ><!--RIGHTWARDS HARPOON WITH BARB DOWN BELOW LONG DASH -->
+<!ENTITY lrm              "&#x0200E;" ><!--LEFT-TO-RIGHT MARK -->
+<!ENTITY lrtri            "&#x022BF;" ><!--RIGHT TRIANGLE -->
+<!ENTITY lsaquo           "&#x02039;" ><!--SINGLE LEFT-POINTING ANGLE QUOTATION MARK -->
+<!ENTITY lscr             "&#x1D4C1;" ><!--MATHEMATICAL SCRIPT SMALL L -->
+<!ENTITY lsh              "&#x021B0;" ><!--UPWARDS ARROW WITH TIP LEFTWARDS -->
+<!ENTITY lsim             "&#x02272;" ><!--LESS-THAN OR EQUIVALENT TO -->
+<!ENTITY lsime            "&#x02A8D;" ><!--LESS-THAN ABOVE SIMILAR OR EQUAL -->
+<!ENTITY lsimg            "&#x02A8F;" ><!--LESS-THAN ABOVE SIMILAR ABOVE GREATER-THAN -->
+<!ENTITY lsqb             "&#x0005B;" ><!--LEFT SQUARE BRACKET -->
+<!ENTITY lsquo            "&#x02018;" ><!--LEFT SINGLE QUOTATION MARK -->
+<!ENTITY lsquor           "&#x0201A;" ><!--SINGLE LOW-9 QUOTATION MARK -->
+<!ENTITY lstrok           "&#x00142;" ><!--LATIN SMALL LETTER L WITH STROKE -->
+<!ENTITY lt               "&#38;#60;" ><!--LESS-THAN SIGN -->
+<!ENTITY ltcc             "&#x02AA6;" ><!--LESS-THAN CLOSED BY CURVE -->
+<!ENTITY ltcir            "&#x02A79;" ><!--LESS-THAN WITH CIRCLE INSIDE -->
+<!ENTITY ltdot            "&#x022D6;" ><!--LESS-THAN WITH DOT -->
+<!ENTITY lthree           "&#x022CB;" ><!--LEFT SEMIDIRECT PRODUCT -->
+<!ENTITY ltimes           "&#x022C9;" ><!--LEFT NORMAL FACTOR SEMIDIRECT PRODUCT -->
+<!ENTITY ltlarr           "&#x02976;" ><!--LESS-THAN ABOVE LEFTWARDS ARROW -->
+<!ENTITY ltquest          "&#x02A7B;" ><!--LESS-THAN WITH QUESTION MARK ABOVE -->
+<!ENTITY ltrPar           "&#x02996;" ><!--DOUBLE RIGHT ARC LESS-THAN BRACKET -->
+<!ENTITY ltri             "&#x025C3;" ><!--WHITE LEFT-POINTING SMALL TRIANGLE -->
+<!ENTITY ltrie            "&#x022B4;" ><!--NORMAL SUBGROUP OF OR EQUAL TO -->
+<!ENTITY ltrif            "&#x025C2;" ><!--BLACK LEFT-POINTING SMALL TRIANGLE -->
+<!ENTITY lurdshar         "&#x0294A;" ><!--LEFT BARB UP RIGHT BARB DOWN HARPOON -->
+<!ENTITY luruhar          "&#x02966;" ><!--LEFTWARDS HARPOON WITH BARB UP ABOVE RIGHTWARDS HARPOON WITH BARB UP -->
+<!ENTITY lvertneqq        "&#x02268;&#x0FE00;" ><!--LESS-THAN BUT NOT EQUAL TO - with vertical stroke -->
+<!ENTITY lvnE             "&#x02268;&#x0FE00;" ><!--LESS-THAN BUT NOT EQUAL TO - with vertical stroke -->
+<!ENTITY mDDot            "&#x0223A;" ><!--GEOMETRIC PROPORTION -->
+<!ENTITY macr             "&#x000AF;" ><!--MACRON -->
+<!ENTITY male             "&#x02642;" ><!--MALE SIGN -->
+<!ENTITY malt             "&#x02720;" ><!--MALTESE CROSS -->
+<!ENTITY maltese          "&#x02720;" ><!--MALTESE CROSS -->
+<!ENTITY map              "&#x021A6;" ><!--RIGHTWARDS ARROW FROM BAR -->
+<!ENTITY mapsto           "&#x021A6;" ><!--RIGHTWARDS ARROW FROM BAR -->
+<!ENTITY mapstodown       "&#x021A7;" ><!--DOWNWARDS ARROW FROM BAR -->
+<!ENTITY mapstoleft       "&#x021A4;" ><!--LEFTWARDS ARROW FROM BAR -->
+<!ENTITY mapstoup         "&#x021A5;" ><!--UPWARDS ARROW FROM BAR -->
+<!ENTITY marker           "&#x025AE;" ><!--BLACK VERTICAL RECTANGLE -->
+<!ENTITY mcomma           "&#x02A29;" ><!--MINUS SIGN WITH COMMA ABOVE -->
+<!ENTITY mcy              "&#x0043C;" ><!--CYRILLIC SMALL LETTER EM -->
+<!ENTITY mdash            "&#x02014;" ><!--EM DASH -->
+<!ENTITY measuredangle    "&#x02221;" ><!--MEASURED ANGLE -->
+<!ENTITY mfr              "&#x1D52A;" ><!--MATHEMATICAL FRAKTUR SMALL M -->
+<!ENTITY mho              "&#x02127;" ><!--INVERTED OHM SIGN -->
+<!ENTITY micro            "&#x000B5;" ><!--MICRO SIGN -->
+<!ENTITY mid              "&#x02223;" ><!--DIVIDES -->
+<!ENTITY midast           "&#x0002A;" ><!--ASTERISK -->
+<!ENTITY midcir           "&#x02AF0;" ><!--VERTICAL LINE WITH CIRCLE BELOW -->
+<!ENTITY middot           "&#x000B7;" ><!--MIDDLE DOT -->
+<!ENTITY minus            "&#x02212;" ><!--MINUS SIGN -->
+<!ENTITY minusb           "&#x0229F;" ><!--SQUARED MINUS -->
+<!ENTITY minusd           "&#x02238;" ><!--DOT MINUS -->
+<!ENTITY minusdu          "&#x02A2A;" ><!--MINUS SIGN WITH DOT BELOW -->
+<!ENTITY mlcp             "&#x02ADB;" ><!--TRANSVERSAL INTERSECTION -->
+<!ENTITY mldr             "&#x02026;" ><!--HORIZONTAL ELLIPSIS -->
+<!ENTITY mnplus           "&#x02213;" ><!--MINUS-OR-PLUS SIGN -->
+<!ENTITY models           "&#x022A7;" ><!--MODELS -->
+<!ENTITY mopf             "&#x1D55E;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL M -->
+<!ENTITY mp               "&#x02213;" ><!--MINUS-OR-PLUS SIGN -->
+<!ENTITY mscr             "&#x1D4C2;" ><!--MATHEMATICAL SCRIPT SMALL M -->
+<!ENTITY mstpos           "&#x0223E;" ><!--INVERTED LAZY S -->
+<!ENTITY mu               "&#x003BC;" ><!--GREEK SMALL LETTER MU -->
+<!ENTITY multimap         "&#x022B8;" ><!--MULTIMAP -->
+<!ENTITY mumap            "&#x022B8;" ><!--MULTIMAP -->
+<!ENTITY nGg              "&#x022D9;&#x00338;" ><!--VERY MUCH GREATER-THAN with slash -->
+<!ENTITY nGt              "&#x0226B;&#x020D2;" ><!--MUCH GREATER THAN with vertical line -->
+<!ENTITY nGtv             "&#x0226B;&#x00338;" ><!--MUCH GREATER THAN with slash -->
+<!ENTITY nLeftarrow       "&#x021CD;" ><!--LEFTWARDS DOUBLE ARROW WITH STROKE -->
+<!ENTITY nLeftrightarrow  "&#x021CE;" ><!--LEFT RIGHT DOUBLE ARROW WITH STROKE -->
+<!ENTITY nLl              "&#x022D8;&#x00338;" ><!--VERY MUCH LESS-THAN with slash -->
+<!ENTITY nLt              "&#x0226A;&#x020D2;" ><!--MUCH LESS THAN with vertical line -->
+<!ENTITY nLtv             "&#x0226A;&#x00338;" ><!--MUCH LESS THAN with slash -->
+<!ENTITY nRightarrow      "&#x021CF;" ><!--RIGHTWARDS DOUBLE ARROW WITH STROKE -->
+<!ENTITY nVDash           "&#x022AF;" ><!--NEGATED DOUBLE VERTICAL BAR DOUBLE RIGHT TURNSTILE -->
+<!ENTITY nVdash           "&#x022AE;" ><!--DOES NOT FORCE -->
+<!ENTITY nabla            "&#x02207;" ><!--NABLA -->
+<!ENTITY nacute           "&#x00144;" ><!--LATIN SMALL LETTER N WITH ACUTE -->
+<!ENTITY nang             "&#x02220;&#x020D2;" ><!--ANGLE with vertical line -->
+<!ENTITY nap              "&#x02249;" ><!--NOT ALMOST EQUAL TO -->
+<!ENTITY napE             "&#x02A70;&#x00338;" ><!--APPROXIMATELY EQUAL OR EQUAL TO with slash -->
+<!ENTITY napid            "&#x0224B;&#x00338;" ><!--TRIPLE TILDE with slash -->
+<!ENTITY napos            "&#x00149;" ><!--LATIN SMALL LETTER N PRECEDED BY APOSTROPHE -->
+<!ENTITY napprox          "&#x02249;" ><!--NOT ALMOST EQUAL TO -->
+<!ENTITY natur            "&#x0266E;" ><!--MUSIC NATURAL SIGN -->
+<!ENTITY natural          "&#x0266E;" ><!--MUSIC NATURAL SIGN -->
+<!ENTITY naturals         "&#x02115;" ><!--DOUBLE-STRUCK CAPITAL N -->
+<!ENTITY nbsp             "&#x000A0;" ><!--NO-BREAK SPACE -->
+<!ENTITY nbump            "&#x0224E;&#x00338;" ><!--GEOMETRICALLY EQUIVALENT TO with slash -->
+<!ENTITY nbumpe           "&#x0224F;&#x00338;" ><!--DIFFERENCE BETWEEN with slash -->
+<!ENTITY ncap             "&#x02A43;" ><!--INTERSECTION WITH OVERBAR -->
+<!ENTITY ncaron           "&#x00148;" ><!--LATIN SMALL LETTER N WITH CARON -->
+<!ENTITY ncedil           "&#x00146;" ><!--LATIN SMALL LETTER N WITH CEDILLA -->
+<!ENTITY ncong            "&#x02247;" ><!--NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO -->
+<!ENTITY ncongdot         "&#x02A6D;&#x00338;" ><!--CONGRUENT WITH DOT ABOVE with slash -->
+<!ENTITY ncup             "&#x02A42;" ><!--UNION WITH OVERBAR -->
+<!ENTITY ncy              "&#x0043D;" ><!--CYRILLIC SMALL LETTER EN -->
+<!ENTITY ndash            "&#x02013;" ><!--EN DASH -->
+<!ENTITY ne               "&#x02260;" ><!--NOT EQUAL TO -->
+<!ENTITY neArr            "&#x021D7;" ><!--NORTH EAST DOUBLE ARROW -->
+<!ENTITY nearhk           "&#x02924;" ><!--NORTH EAST ARROW WITH HOOK -->
+<!ENTITY nearr            "&#x02197;" ><!--NORTH EAST ARROW -->
+<!ENTITY nearrow          "&#x02197;" ><!--NORTH EAST ARROW -->
+<!ENTITY nedot            "&#x02250;&#x00338;" ><!--APPROACHES THE LIMIT with slash -->
+<!ENTITY nequiv           "&#x02262;" ><!--NOT IDENTICAL TO -->
+<!ENTITY nesear           "&#x02928;" ><!--NORTH EAST ARROW AND SOUTH EAST ARROW -->
+<!ENTITY nesim            "&#x02242;&#x00338;" ><!--MINUS TILDE with slash -->
+<!ENTITY nexist           "&#x02204;" ><!--THERE DOES NOT EXIST -->
+<!ENTITY nexists          "&#x02204;" ><!--THERE DOES NOT EXIST -->
+<!ENTITY nfr              "&#x1D52B;" ><!--MATHEMATICAL FRAKTUR SMALL N -->
+<!ENTITY ngE              "&#x02267;&#x00338;" ><!--GREATER-THAN OVER EQUAL TO with slash -->
+<!ENTITY nge              "&#x02271;" ><!--NEITHER GREATER-THAN NOR EQUAL TO -->
+<!ENTITY ngeq             "&#x02271;" ><!--NEITHER GREATER-THAN NOR EQUAL TO -->
+<!ENTITY ngeqq            "&#x02267;&#x00338;" ><!--GREATER-THAN OVER EQUAL TO with slash -->
+<!ENTITY ngeqslant        "&#x02A7E;&#x00338;" ><!--GREATER-THAN OR SLANTED EQUAL TO with slash -->
+<!ENTITY nges             "&#x02A7E;&#x00338;" ><!--GREATER-THAN OR SLANTED EQUAL TO with slash -->
+<!ENTITY ngsim            "&#x02275;" ><!--NEITHER GREATER-THAN NOR EQUIVALENT TO -->
+<!ENTITY ngt              "&#x0226F;" ><!--NOT GREATER-THAN -->
+<!ENTITY ngtr             "&#x0226F;" ><!--NOT GREATER-THAN -->
+<!ENTITY nhArr            "&#x021CE;" ><!--LEFT RIGHT DOUBLE ARROW WITH STROKE -->
+<!ENTITY nharr            "&#x021AE;" ><!--LEFT RIGHT ARROW WITH STROKE -->
+<!ENTITY nhpar            "&#x02AF2;" ><!--PARALLEL WITH HORIZONTAL STROKE -->
+<!ENTITY ni               "&#x0220B;" ><!--CONTAINS AS MEMBER -->
+<!ENTITY nis              "&#x022FC;" ><!--SMALL CONTAINS WITH VERTICAL BAR AT END OF HORIZONTAL STROKE -->
+<!ENTITY nisd             "&#x022FA;" ><!--CONTAINS WITH LONG HORIZONTAL STROKE -->
+<!ENTITY niv              "&#x0220B;" ><!--CONTAINS AS MEMBER -->
+<!ENTITY njcy             "&#x0045A;" ><!--CYRILLIC SMALL LETTER NJE -->
+<!ENTITY nlArr            "&#x021CD;" ><!--LEFTWARDS DOUBLE ARROW WITH STROKE -->
+<!ENTITY nlE              "&#x02266;&#x00338;" ><!--LESS-THAN OVER EQUAL TO with slash -->
+<!ENTITY nlarr            "&#x0219A;" ><!--LEFTWARDS ARROW WITH STROKE -->
+<!ENTITY nldr             "&#x02025;" ><!--TWO DOT LEADER -->
+<!ENTITY nle              "&#x02270;" ><!--NEITHER LESS-THAN NOR EQUAL TO -->
+<!ENTITY nleftarrow       "&#x0219A;" ><!--LEFTWARDS ARROW WITH STROKE -->
+<!ENTITY nleftrightarrow  "&#x021AE;" ><!--LEFT RIGHT ARROW WITH STROKE -->
+<!ENTITY nleq             "&#x02270;" ><!--NEITHER LESS-THAN NOR EQUAL TO -->
+<!ENTITY nleqq            "&#x02266;&#x00338;" ><!--LESS-THAN OVER EQUAL TO with slash -->
+<!ENTITY nleqslant        "&#x02A7D;&#x00338;" ><!--LESS-THAN OR SLANTED EQUAL TO with slash -->
+<!ENTITY nles             "&#x02A7D;&#x00338;" ><!--LESS-THAN OR SLANTED EQUAL TO with slash -->
+<!ENTITY nless            "&#x0226E;" ><!--NOT LESS-THAN -->
+<!ENTITY nlsim            "&#x02274;" ><!--NEITHER LESS-THAN NOR EQUIVALENT TO -->
+<!ENTITY nlt              "&#x0226E;" ><!--NOT LESS-THAN -->
+<!ENTITY nltri            "&#x022EA;" ><!--NOT NORMAL SUBGROUP OF -->
+<!ENTITY nltrie           "&#x022EC;" ><!--NOT NORMAL SUBGROUP OF OR EQUAL TO -->
+<!ENTITY nmid             "&#x02224;" ><!--DOES NOT DIVIDE -->
+<!ENTITY nopf             "&#x1D55F;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL N -->
+<!ENTITY not              "&#x000AC;" ><!--NOT SIGN -->
+<!ENTITY notin            "&#x02209;" ><!--NOT AN ELEMENT OF -->
+<!ENTITY notinE           "&#x022F9;&#x00338;" ><!--ELEMENT OF WITH TWO HORIZONTAL STROKES with slash -->
+<!ENTITY notindot         "&#x022F5;&#x00338;" ><!--ELEMENT OF WITH DOT ABOVE with slash -->
+<!ENTITY notinva          "&#x02209;" ><!--NOT AN ELEMENT OF -->
+<!ENTITY notinvb          "&#x022F7;" ><!--SMALL ELEMENT OF WITH OVERBAR -->
+<!ENTITY notinvc          "&#x022F6;" ><!--ELEMENT OF WITH OVERBAR -->
+<!ENTITY notni            "&#x0220C;" ><!--DOES NOT CONTAIN AS MEMBER -->
+<!ENTITY notniva          "&#x0220C;" ><!--DOES NOT CONTAIN AS MEMBER -->
+<!ENTITY notnivb          "&#x022FE;" ><!--SMALL CONTAINS WITH OVERBAR -->
+<!ENTITY notnivc          "&#x022FD;" ><!--CONTAINS WITH OVERBAR -->
+<!ENTITY npar             "&#x02226;" ><!--NOT PARALLEL TO -->
+<!ENTITY nparallel        "&#x02226;" ><!--NOT PARALLEL TO -->
+<!ENTITY nparsl           "&#x02AFD;&#x020E5;" ><!--DOUBLE SOLIDUS OPERATOR with reverse slash -->
+<!ENTITY npart            "&#x02202;&#x00338;" ><!--PARTIAL DIFFERENTIAL with slash -->
+<!ENTITY npolint          "&#x02A14;" ><!--LINE INTEGRATION NOT INCLUDING THE POLE -->
+<!ENTITY npr              "&#x02280;" ><!--DOES NOT PRECEDE -->
+<!ENTITY nprcue           "&#x022E0;" ><!--DOES NOT PRECEDE OR EQUAL -->
+<!ENTITY npre             "&#x02AAF;&#x00338;" ><!--PRECEDES ABOVE SINGLE-LINE EQUALS SIGN with slash -->
+<!ENTITY nprec            "&#x02280;" ><!--DOES NOT PRECEDE -->
+<!ENTITY npreceq          "&#x02AAF;&#x00338;" ><!--PRECEDES ABOVE SINGLE-LINE EQUALS SIGN with slash -->
+<!ENTITY nrArr            "&#x021CF;" ><!--RIGHTWARDS DOUBLE ARROW WITH STROKE -->
+<!ENTITY nrarr            "&#x0219B;" ><!--RIGHTWARDS ARROW WITH STROKE -->
+<!ENTITY nrarrc           "&#x02933;&#x00338;" ><!--WAVE ARROW POINTING DIRECTLY RIGHT with slash -->
+<!ENTITY nrarrw           "&#x0219D;&#x00338;" ><!--RIGHTWARDS WAVE ARROW with slash -->
+<!ENTITY nrightarrow      "&#x0219B;" ><!--RIGHTWARDS ARROW WITH STROKE -->
+<!ENTITY nrtri            "&#x022EB;" ><!--DOES NOT CONTAIN AS NORMAL SUBGROUP -->
+<!ENTITY nrtrie           "&#x022ED;" ><!--DOES NOT CONTAIN AS NORMAL SUBGROUP OR EQUAL -->
+<!ENTITY nsc              "&#x02281;" ><!--DOES NOT SUCCEED -->
+<!ENTITY nsccue           "&#x022E1;" ><!--DOES NOT SUCCEED OR EQUAL -->
+<!ENTITY nsce             "&#x02AB0;&#x00338;" ><!--SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN with slash -->
+<!ENTITY nscr             "&#x1D4C3;" ><!--MATHEMATICAL SCRIPT SMALL N -->
+<!ENTITY nshortmid        "&#x02224;" ><!--DOES NOT DIVIDE -->
+<!ENTITY nshortparallel   "&#x02226;" ><!--NOT PARALLEL TO -->
+<!ENTITY nsim             "&#x02241;" ><!--NOT TILDE -->
+<!ENTITY nsime            "&#x02244;" ><!--NOT ASYMPTOTICALLY EQUAL TO -->
+<!ENTITY nsimeq           "&#x02244;" ><!--NOT ASYMPTOTICALLY EQUAL TO -->
+<!ENTITY nsmid            "&#x02224;" ><!--DOES NOT DIVIDE -->
+<!ENTITY nspar            "&#x02226;" ><!--NOT PARALLEL TO -->
+<!ENTITY nsqsube          "&#x022E2;" ><!--NOT SQUARE IMAGE OF OR EQUAL TO -->
+<!ENTITY nsqsupe          "&#x022E3;" ><!--NOT SQUARE ORIGINAL OF OR EQUAL TO -->
+<!ENTITY nsub             "&#x02284;" ><!--NOT A SUBSET OF -->
+<!ENTITY nsubE            "&#x02AC5;&#x00338;" ><!--SUBSET OF ABOVE EQUALS SIGN with slash -->
+<!ENTITY nsube            "&#x02288;" ><!--NEITHER A SUBSET OF NOR EQUAL TO -->
+<!ENTITY nsubset          "&#x02282;&#x020D2;" ><!--SUBSET OF with vertical line -->
+<!ENTITY nsubseteq        "&#x02288;" ><!--NEITHER A SUBSET OF NOR EQUAL TO -->
+<!ENTITY nsubseteqq       "&#x02AC5;&#x00338;" ><!--SUBSET OF ABOVE EQUALS SIGN with slash -->
+<!ENTITY nsucc            "&#x02281;" ><!--DOES NOT SUCCEED -->
+<!ENTITY nsucceq          "&#x02AB0;&#x00338;" ><!--SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN with slash -->
+<!ENTITY nsup             "&#x02285;" ><!--NOT A SUPERSET OF -->
+<!ENTITY nsupE            "&#x02AC6;&#x00338;" ><!--SUPERSET OF ABOVE EQUALS SIGN with slash -->
+<!ENTITY nsupe            "&#x02289;" ><!--NEITHER A SUPERSET OF NOR EQUAL TO -->
+<!ENTITY nsupset          "&#x02283;&#x020D2;" ><!--SUPERSET OF with vertical line -->
+<!ENTITY nsupseteq        "&#x02289;" ><!--NEITHER A SUPERSET OF NOR EQUAL TO -->
+<!ENTITY nsupseteqq       "&#x02AC6;&#x00338;" ><!--SUPERSET OF ABOVE EQUALS SIGN with slash -->
+<!ENTITY ntgl             "&#x02279;" ><!--NEITHER GREATER-THAN NOR LESS-THAN -->
+<!ENTITY ntilde           "&#x000F1;" ><!--LATIN SMALL LETTER N WITH TILDE -->
+<!ENTITY ntlg             "&#x02278;" ><!--NEITHER LESS-THAN NOR GREATER-THAN -->
+<!ENTITY ntriangleleft    "&#x022EA;" ><!--NOT NORMAL SUBGROUP OF -->
+<!ENTITY ntrianglelefteq  "&#x022EC;" ><!--NOT NORMAL SUBGROUP OF OR EQUAL TO -->
+<!ENTITY ntriangleright   "&#x022EB;" ><!--DOES NOT CONTAIN AS NORMAL SUBGROUP -->
+<!ENTITY ntrianglerighteq "&#x022ED;" ><!--DOES NOT CONTAIN AS NORMAL SUBGROUP OR EQUAL -->
+<!ENTITY nu               "&#x003BD;" ><!--GREEK SMALL LETTER NU -->
+<!ENTITY num              "&#x00023;" ><!--NUMBER SIGN -->
+<!ENTITY numero           "&#x02116;" ><!--NUMERO SIGN -->
+<!ENTITY numsp            "&#x02007;" ><!--FIGURE SPACE -->
+<!ENTITY nvDash           "&#x022AD;" ><!--NOT TRUE -->
+<!ENTITY nvHarr           "&#x02904;" ><!--LEFT RIGHT DOUBLE ARROW WITH VERTICAL STROKE -->
+<!ENTITY nvap             "&#x0224D;&#x020D2;" ><!--EQUIVALENT TO with vertical line -->
+<!ENTITY nvdash           "&#x022AC;" ><!--DOES NOT PROVE -->
+<!ENTITY nvge             "&#x02265;&#x020D2;" ><!--GREATER-THAN OR EQUAL TO with vertical line -->
+<!ENTITY nvgt             "&#x0003E;&#x020D2;" ><!--GREATER-THAN SIGN with vertical line -->
+<!ENTITY nvinfin          "&#x029DE;" ><!--INFINITY NEGATED WITH VERTICAL BAR -->
+<!ENTITY nvlArr           "&#x02902;" ><!--LEFTWARDS DOUBLE ARROW WITH VERTICAL STROKE -->
+<!ENTITY nvle             "&#x02264;&#x020D2;" ><!--LESS-THAN OR EQUAL TO with vertical line -->
+<!ENTITY nvlt             "&#38;#x0003C;&#x020D2;" ><!--LESS-THAN SIGN with vertical line -->
+<!ENTITY nvltrie          "&#x022B4;&#x020D2;" ><!--NORMAL SUBGROUP OF OR EQUAL TO with vertical line -->
+<!ENTITY nvrArr           "&#x02903;" ><!--RIGHTWARDS DOUBLE ARROW WITH VERTICAL STROKE -->
+<!ENTITY nvrtrie          "&#x022B5;&#x020D2;" ><!--CONTAINS AS NORMAL SUBGROUP OR EQUAL TO with vertical line -->
+<!ENTITY nvsim            "&#x0223C;&#x020D2;" ><!--TILDE OPERATOR with vertical line -->
+<!ENTITY nwArr            "&#x021D6;" ><!--NORTH WEST DOUBLE ARROW -->
+<!ENTITY nwarhk           "&#x02923;" ><!--NORTH WEST ARROW WITH HOOK -->
+<!ENTITY nwarr            "&#x02196;" ><!--NORTH WEST ARROW -->
+<!ENTITY nwarrow          "&#x02196;" ><!--NORTH WEST ARROW -->
+<!ENTITY nwnear           "&#x02927;" ><!--NORTH WEST ARROW AND NORTH EAST ARROW -->
+<!ENTITY oS               "&#x024C8;" ><!--CIRCLED LATIN CAPITAL LETTER S -->
+<!ENTITY oacute           "&#x000F3;" ><!--LATIN SMALL LETTER O WITH ACUTE -->
+<!ENTITY oast             "&#x0229B;" ><!--CIRCLED ASTERISK OPERATOR -->
+<!ENTITY ocir             "&#x0229A;" ><!--CIRCLED RING OPERATOR -->
+<!ENTITY ocirc            "&#x000F4;" ><!--LATIN SMALL LETTER O WITH CIRCUMFLEX -->
+<!ENTITY ocy              "&#x0043E;" ><!--CYRILLIC SMALL LETTER O -->
+<!ENTITY odash            "&#x0229D;" ><!--CIRCLED DASH -->
+<!ENTITY odblac           "&#x00151;" ><!--LATIN SMALL LETTER O WITH DOUBLE ACUTE -->
+<!ENTITY odiv             "&#x02A38;" ><!--CIRCLED DIVISION SIGN -->
+<!ENTITY odot             "&#x02299;" ><!--CIRCLED DOT OPERATOR -->
+<!ENTITY odsold           "&#x029BC;" ><!--CIRCLED ANTICLOCKWISE-ROTATED DIVISION SIGN -->
+<!ENTITY oelig            "&#x00153;" ><!--LATIN SMALL LIGATURE OE -->
+<!ENTITY ofcir            "&#x029BF;" ><!--CIRCLED BULLET -->
+<!ENTITY ofr              "&#x1D52C;" ><!--MATHEMATICAL FRAKTUR SMALL O -->
+<!ENTITY ogon             "&#x002DB;" ><!--OGONEK -->
+<!ENTITY ograve           "&#x000F2;" ><!--LATIN SMALL LETTER O WITH GRAVE -->
+<!ENTITY ogt              "&#x029C1;" ><!--CIRCLED GREATER-THAN -->
+<!ENTITY ohbar            "&#x029B5;" ><!--CIRCLE WITH HORIZONTAL BAR -->
+<!ENTITY ohm              "&#x003A9;" ><!--GREEK CAPITAL LETTER OMEGA -->
+<!ENTITY oint             "&#x0222E;" ><!--CONTOUR INTEGRAL -->
+<!ENTITY olarr            "&#x021BA;" ><!--ANTICLOCKWISE OPEN CIRCLE ARROW -->
+<!ENTITY olcir            "&#x029BE;" ><!--CIRCLED WHITE BULLET -->
+<!ENTITY olcross          "&#x029BB;" ><!--CIRCLE WITH SUPERIMPOSED X -->
+<!ENTITY oline            "&#x0203E;" ><!--OVERLINE -->
+<!ENTITY olt              "&#x029C0;" ><!--CIRCLED LESS-THAN -->
+<!ENTITY omacr            "&#x0014D;" ><!--LATIN SMALL LETTER O WITH MACRON -->
+<!ENTITY omega            "&#x003C9;" ><!--GREEK SMALL LETTER OMEGA -->
+<!ENTITY omicron          "&#x003BF;" ><!--GREEK SMALL LETTER OMICRON -->
+<!ENTITY omid             "&#x029B6;" ><!--CIRCLED VERTICAL BAR -->
+<!ENTITY ominus           "&#x02296;" ><!--CIRCLED MINUS -->
+<!ENTITY oopf             "&#x1D560;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL O -->
+<!ENTITY opar             "&#x029B7;" ><!--CIRCLED PARALLEL -->
+<!ENTITY operp            "&#x029B9;" ><!--CIRCLED PERPENDICULAR -->
+<!ENTITY oplus            "&#x02295;" ><!--CIRCLED PLUS -->
+<!ENTITY or               "&#x02228;" ><!--LOGICAL OR -->
+<!ENTITY orarr            "&#x021BB;" ><!--CLOCKWISE OPEN CIRCLE ARROW -->
+<!ENTITY ord              "&#x02A5D;" ><!--LOGICAL OR WITH HORIZONTAL DASH -->
+<!ENTITY order            "&#x02134;" ><!--SCRIPT SMALL O -->
+<!ENTITY orderof          "&#x02134;" ><!--SCRIPT SMALL O -->
+<!ENTITY ordf             "&#x000AA;" ><!--FEMININE ORDINAL INDICATOR -->
+<!ENTITY ordm             "&#x000BA;" ><!--MASCULINE ORDINAL INDICATOR -->
+<!ENTITY origof           "&#x022B6;" ><!--ORIGINAL OF -->
+<!ENTITY oror             "&#x02A56;" ><!--TWO INTERSECTING LOGICAL OR -->
+<!ENTITY orslope          "&#x02A57;" ><!--SLOPING LARGE OR -->
+<!ENTITY orv              "&#x02A5B;" ><!--LOGICAL OR WITH MIDDLE STEM -->
+<!ENTITY oscr             "&#x02134;" ><!--SCRIPT SMALL O -->
+<!ENTITY oslash           "&#x000F8;" ><!--LATIN SMALL LETTER O WITH STROKE -->
+<!ENTITY osol             "&#x02298;" ><!--CIRCLED DIVISION SLASH -->
+<!ENTITY otilde           "&#x000F5;" ><!--LATIN SMALL LETTER O WITH TILDE -->
+<!ENTITY otimes           "&#x02297;" ><!--CIRCLED TIMES -->
+<!ENTITY otimesas         "&#x02A36;" ><!--CIRCLED MULTIPLICATION SIGN WITH CIRCUMFLEX ACCENT -->
+<!ENTITY ouml             "&#x000F6;" ><!--LATIN SMALL LETTER O WITH DIAERESIS -->
+<!ENTITY ovbar            "&#x0233D;" ><!--APL FUNCTIONAL SYMBOL CIRCLE STILE -->
+<!ENTITY par              "&#x02225;" ><!--PARALLEL TO -->
+<!ENTITY para             "&#x000B6;" ><!--PILCROW SIGN -->
+<!ENTITY parallel         "&#x02225;" ><!--PARALLEL TO -->
+<!ENTITY parsim           "&#x02AF3;" ><!--PARALLEL WITH TILDE OPERATOR -->
+<!ENTITY parsl            "&#x02AFD;" ><!--DOUBLE SOLIDUS OPERATOR -->
+<!ENTITY part             "&#x02202;" ><!--PARTIAL DIFFERENTIAL -->
+<!ENTITY pcy              "&#x0043F;" ><!--CYRILLIC SMALL LETTER PE -->
+<!ENTITY percnt           "&#x00025;" ><!--PERCENT SIGN -->
+<!ENTITY period           "&#x0002E;" ><!--FULL STOP -->
+<!ENTITY permil           "&#x02030;" ><!--PER MILLE SIGN -->
+<!ENTITY perp             "&#x022A5;" ><!--UP TACK -->
+<!ENTITY pertenk          "&#x02031;" ><!--PER TEN THOUSAND SIGN -->
+<!ENTITY pfr              "&#x1D52D;" ><!--MATHEMATICAL FRAKTUR SMALL P -->
+<!ENTITY phi              "&#x003C6;" ><!--GREEK SMALL LETTER PHI -->
+<!ENTITY phiv             "&#x003D5;" ><!--GREEK PHI SYMBOL -->
+<!ENTITY phmmat           "&#x02133;" ><!--SCRIPT CAPITAL M -->
+<!ENTITY phone            "&#x0260E;" ><!--BLACK TELEPHONE -->
+<!ENTITY pi               "&#x003C0;" ><!--GREEK SMALL LETTER PI -->
+<!ENTITY pitchfork        "&#x022D4;" ><!--PITCHFORK -->
+<!ENTITY piv              "&#x003D6;" ><!--GREEK PI SYMBOL -->
+<!ENTITY planck           "&#x0210F;" ><!--PLANCK CONSTANT OVER TWO PI -->
+<!ENTITY planckh          "&#x0210E;" ><!--PLANCK CONSTANT -->
+<!ENTITY plankv           "&#x0210F;" ><!--PLANCK CONSTANT OVER TWO PI -->
+<!ENTITY plus             "&#x0002B;" ><!--PLUS SIGN -->
+<!ENTITY plusacir         "&#x02A23;" ><!--PLUS SIGN WITH CIRCUMFLEX ACCENT ABOVE -->
+<!ENTITY plusb            "&#x0229E;" ><!--SQUARED PLUS -->
+<!ENTITY pluscir          "&#x02A22;" ><!--PLUS SIGN WITH SMALL CIRCLE ABOVE -->
+<!ENTITY plusdo           "&#x02214;" ><!--DOT PLUS -->
+<!ENTITY plusdu           "&#x02A25;" ><!--PLUS SIGN WITH DOT BELOW -->
+<!ENTITY pluse            "&#x02A72;" ><!--PLUS SIGN ABOVE EQUALS SIGN -->
+<!ENTITY plusmn           "&#x000B1;" ><!--PLUS-MINUS SIGN -->
+<!ENTITY plussim          "&#x02A26;" ><!--PLUS SIGN WITH TILDE BELOW -->
+<!ENTITY plustwo          "&#x02A27;" ><!--PLUS SIGN WITH SUBSCRIPT TWO -->
+<!ENTITY pm               "&#x000B1;" ><!--PLUS-MINUS SIGN -->
+<!ENTITY pointint         "&#x02A15;" ><!--INTEGRAL AROUND A POINT OPERATOR -->
+<!ENTITY popf             "&#x1D561;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL P -->
+<!ENTITY pound            "&#x000A3;" ><!--POUND SIGN -->
+<!ENTITY pr               "&#x0227A;" ><!--PRECEDES -->
+<!ENTITY prE              "&#x02AB3;" ><!--PRECEDES ABOVE EQUALS SIGN -->
+<!ENTITY prap             "&#x02AB7;" ><!--PRECEDES ABOVE ALMOST EQUAL TO -->
+<!ENTITY prcue            "&#x0227C;" ><!--PRECEDES OR EQUAL TO -->
+<!ENTITY pre              "&#x02AAF;" ><!--PRECEDES ABOVE SINGLE-LINE EQUALS SIGN -->
+<!ENTITY prec             "&#x0227A;" ><!--PRECEDES -->
+<!ENTITY precapprox       "&#x02AB7;" ><!--PRECEDES ABOVE ALMOST EQUAL TO -->
+<!ENTITY preccurlyeq      "&#x0227C;" ><!--PRECEDES OR EQUAL TO -->
+<!ENTITY preceq           "&#x02AAF;" ><!--PRECEDES ABOVE SINGLE-LINE EQUALS SIGN -->
+<!ENTITY precnapprox      "&#x02AB9;" ><!--PRECEDES ABOVE NOT ALMOST EQUAL TO -->
+<!ENTITY precneqq         "&#x02AB5;" ><!--PRECEDES ABOVE NOT EQUAL TO -->
+<!ENTITY precnsim         "&#x022E8;" ><!--PRECEDES BUT NOT EQUIVALENT TO -->
+<!ENTITY precsim          "&#x0227E;" ><!--PRECEDES OR EQUIVALENT TO -->
+<!ENTITY prime            "&#x02032;" ><!--PRIME -->
+<!ENTITY primes           "&#x02119;" ><!--DOUBLE-STRUCK CAPITAL P -->
+<!ENTITY prnE             "&#x02AB5;" ><!--PRECEDES ABOVE NOT EQUAL TO -->
+<!ENTITY prnap            "&#x02AB9;" ><!--PRECEDES ABOVE NOT ALMOST EQUAL TO -->
+<!ENTITY prnsim           "&#x022E8;" ><!--PRECEDES BUT NOT EQUIVALENT TO -->
+<!ENTITY prod             "&#x0220F;" ><!--N-ARY PRODUCT -->
+<!ENTITY profalar         "&#x0232E;" ><!--ALL AROUND-PROFILE -->
+<!ENTITY profline         "&#x02312;" ><!--ARC -->
+<!ENTITY profsurf         "&#x02313;" ><!--SEGMENT -->
+<!ENTITY prop             "&#x0221D;" ><!--PROPORTIONAL TO -->
+<!ENTITY propto           "&#x0221D;" ><!--PROPORTIONAL TO -->
+<!ENTITY prsim            "&#x0227E;" ><!--PRECEDES OR EQUIVALENT TO -->
+<!ENTITY prurel           "&#x022B0;" ><!--PRECEDES UNDER RELATION -->
+<!ENTITY pscr             "&#x1D4C5;" ><!--MATHEMATICAL SCRIPT SMALL P -->
+<!ENTITY psi              "&#x003C8;" ><!--GREEK SMALL LETTER PSI -->
+<!ENTITY puncsp           "&#x02008;" ><!--PUNCTUATION SPACE -->
+<!ENTITY qfr              "&#x1D52E;" ><!--MATHEMATICAL FRAKTUR SMALL Q -->
+<!ENTITY qint             "&#x02A0C;" ><!--QUADRUPLE INTEGRAL OPERATOR -->
+<!ENTITY qopf             "&#x1D562;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL Q -->
+<!ENTITY qprime           "&#x02057;" ><!--QUADRUPLE PRIME -->
+<!ENTITY qscr             "&#x1D4C6;" ><!--MATHEMATICAL SCRIPT SMALL Q -->
+<!ENTITY quaternions      "&#x0210D;" ><!--DOUBLE-STRUCK CAPITAL H -->
+<!ENTITY quatint          "&#x02A16;" ><!--QUATERNION INTEGRAL OPERATOR -->
+<!ENTITY quest            "&#x0003F;" ><!--QUESTION MARK -->
+<!ENTITY questeq          "&#x0225F;" ><!--QUESTIONED EQUAL TO -->
+<!ENTITY quot             "&#x00022;" ><!--QUOTATION MARK -->
+<!ENTITY rAarr            "&#x021DB;" ><!--RIGHTWARDS TRIPLE ARROW -->
+<!ENTITY rArr             "&#x021D2;" ><!--RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY rAtail           "&#x0291C;" ><!--RIGHTWARDS DOUBLE ARROW-TAIL -->
+<!ENTITY rBarr            "&#x0290F;" ><!--RIGHTWARDS TRIPLE DASH ARROW -->
+<!ENTITY rHar             "&#x02964;" ><!--RIGHTWARDS HARPOON WITH BARB UP ABOVE RIGHTWARDS HARPOON WITH BARB DOWN -->
+<!ENTITY race             "&#x0223D;&#x00331;" ><!--REVERSED TILDE with underline -->
+<!ENTITY racute           "&#x00155;" ><!--LATIN SMALL LETTER R WITH ACUTE -->
+<!ENTITY radic            "&#x0221A;" ><!--SQUARE ROOT -->
+<!ENTITY raemptyv         "&#x029B3;" ><!--EMPTY SET WITH RIGHT ARROW ABOVE -->
+<!ENTITY rang             "&#x027E9;" ><!--MATHEMATICAL RIGHT ANGLE BRACKET -->
+<!ENTITY rangd            "&#x02992;" ><!--RIGHT ANGLE BRACKET WITH DOT -->
+<!ENTITY range            "&#x029A5;" ><!--REVERSED ANGLE WITH UNDERBAR -->
+<!ENTITY rangle           "&#x027E9;" ><!--MATHEMATICAL RIGHT ANGLE BRACKET -->
+<!ENTITY raquo            "&#x000BB;" ><!--RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK -->
+<!ENTITY rarr             "&#x02192;" ><!--RIGHTWARDS ARROW -->
+<!ENTITY rarrap           "&#x02975;" ><!--RIGHTWARDS ARROW ABOVE ALMOST EQUAL TO -->
+<!ENTITY rarrb            "&#x021E5;" ><!--RIGHTWARDS ARROW TO BAR -->
+<!ENTITY rarrbfs          "&#x02920;" ><!--RIGHTWARDS ARROW FROM BAR TO BLACK DIAMOND -->
+<!ENTITY rarrc            "&#x02933;" ><!--WAVE ARROW POINTING DIRECTLY RIGHT -->
+<!ENTITY rarrfs           "&#x0291E;" ><!--RIGHTWARDS ARROW TO BLACK DIAMOND -->
+<!ENTITY rarrhk           "&#x021AA;" ><!--RIGHTWARDS ARROW WITH HOOK -->
+<!ENTITY rarrlp           "&#x021AC;" ><!--RIGHTWARDS ARROW WITH LOOP -->
+<!ENTITY rarrpl           "&#x02945;" ><!--RIGHTWARDS ARROW WITH PLUS BELOW -->
+<!ENTITY rarrsim          "&#x02974;" ><!--RIGHTWARDS ARROW ABOVE TILDE OPERATOR -->
+<!ENTITY rarrtl           "&#x021A3;" ><!--RIGHTWARDS ARROW WITH TAIL -->
+<!ENTITY rarrw            "&#x0219D;" ><!--RIGHTWARDS WAVE ARROW -->
+<!ENTITY ratail           "&#x0291A;" ><!--RIGHTWARDS ARROW-TAIL -->
+<!ENTITY ratio            "&#x02236;" ><!--RATIO -->
+<!ENTITY rationals        "&#x0211A;" ><!--DOUBLE-STRUCK CAPITAL Q -->
+<!ENTITY rbarr            "&#x0290D;" ><!--RIGHTWARDS DOUBLE DASH ARROW -->
+<!ENTITY rbbrk            "&#x02773;" ><!--LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT -->
+<!ENTITY rbrace           "&#x0007D;" ><!--RIGHT CURLY BRACKET -->
+<!ENTITY rbrack           "&#x0005D;" ><!--RIGHT SQUARE BRACKET -->
+<!ENTITY rbrke            "&#x0298C;" ><!--RIGHT SQUARE BRACKET WITH UNDERBAR -->
+<!ENTITY rbrksld          "&#x0298E;" ><!--RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER -->
+<!ENTITY rbrkslu          "&#x02990;" ><!--RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER -->
+<!ENTITY rcaron           "&#x00159;" ><!--LATIN SMALL LETTER R WITH CARON -->
+<!ENTITY rcedil           "&#x00157;" ><!--LATIN SMALL LETTER R WITH CEDILLA -->
+<!ENTITY rceil            "&#x02309;" ><!--RIGHT CEILING -->
+<!ENTITY rcub             "&#x0007D;" ><!--RIGHT CURLY BRACKET -->
+<!ENTITY rcy              "&#x00440;" ><!--CYRILLIC SMALL LETTER ER -->
+<!ENTITY rdca             "&#x02937;" ><!--ARROW POINTING DOWNWARDS THEN CURVING RIGHTWARDS -->
+<!ENTITY rdldhar          "&#x02969;" ><!--RIGHTWARDS HARPOON WITH BARB DOWN ABOVE LEFTWARDS HARPOON WITH BARB DOWN -->
+<!ENTITY rdquo            "&#x0201D;" ><!--RIGHT DOUBLE QUOTATION MARK -->
+<!ENTITY rdquor           "&#x0201D;" ><!--RIGHT DOUBLE QUOTATION MARK -->
+<!ENTITY rdsh             "&#x021B3;" ><!--DOWNWARDS ARROW WITH TIP RIGHTWARDS -->
+<!ENTITY real             "&#x0211C;" ><!--BLACK-LETTER CAPITAL R -->
+<!ENTITY realine          "&#x0211B;" ><!--SCRIPT CAPITAL R -->
+<!ENTITY realpart         "&#x0211C;" ><!--BLACK-LETTER CAPITAL R -->
+<!ENTITY reals            "&#x0211D;" ><!--DOUBLE-STRUCK CAPITAL R -->
+<!ENTITY rect             "&#x025AD;" ><!--WHITE RECTANGLE -->
+<!ENTITY reg              "&#x000AE;" ><!--REGISTERED SIGN -->
+<!ENTITY rfisht           "&#x0297D;" ><!--RIGHT FISH TAIL -->
+<!ENTITY rfloor           "&#x0230B;" ><!--RIGHT FLOOR -->
+<!ENTITY rfr              "&#x1D52F;" ><!--MATHEMATICAL FRAKTUR SMALL R -->
+<!ENTITY rhard            "&#x021C1;" ><!--RIGHTWARDS HARPOON WITH BARB DOWNWARDS -->
+<!ENTITY rharu            "&#x021C0;" ><!--RIGHTWARDS HARPOON WITH BARB UPWARDS -->
+<!ENTITY rharul           "&#x0296C;" ><!--RIGHTWARDS HARPOON WITH BARB UP ABOVE LONG DASH -->
+<!ENTITY rho              "&#x003C1;" ><!--GREEK SMALL LETTER RHO -->
+<!ENTITY rhov             "&#x003F1;" ><!--GREEK RHO SYMBOL -->
+<!ENTITY rightarrow       "&#x02192;" ><!--RIGHTWARDS ARROW -->
+<!ENTITY rightarrowtail   "&#x021A3;" ><!--RIGHTWARDS ARROW WITH TAIL -->
+<!ENTITY rightharpoondown "&#x021C1;" ><!--RIGHTWARDS HARPOON WITH BARB DOWNWARDS -->
+<!ENTITY rightharpoonup   "&#x021C0;" ><!--RIGHTWARDS HARPOON WITH BARB UPWARDS -->
+<!ENTITY rightleftarrows  "&#x021C4;" ><!--RIGHTWARDS ARROW OVER LEFTWARDS ARROW -->
+<!ENTITY rightleftharpoons "&#x021CC;" ><!--RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON -->
+<!ENTITY rightrightarrows "&#x021C9;" ><!--RIGHTWARDS PAIRED ARROWS -->
+<!ENTITY rightsquigarrow  "&#x0219D;" ><!--RIGHTWARDS WAVE ARROW -->
+<!ENTITY rightthreetimes  "&#x022CC;" ><!--RIGHT SEMIDIRECT PRODUCT -->
+<!ENTITY ring             "&#x002DA;" ><!--RING ABOVE -->
+<!ENTITY risingdotseq     "&#x02253;" ><!--IMAGE OF OR APPROXIMATELY EQUAL TO -->
+<!ENTITY rlarr            "&#x021C4;" ><!--RIGHTWARDS ARROW OVER LEFTWARDS ARROW -->
+<!ENTITY rlhar            "&#x021CC;" ><!--RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON -->
+<!ENTITY rlm              "&#x0200F;" ><!--RIGHT-TO-LEFT MARK -->
+<!ENTITY rmoust           "&#x023B1;" ><!--UPPER RIGHT OR LOWER LEFT CURLY BRACKET SECTION -->
+<!ENTITY rmoustache       "&#x023B1;" ><!--UPPER RIGHT OR LOWER LEFT CURLY BRACKET SECTION -->
+<!ENTITY rnmid            "&#x02AEE;" ><!--DOES NOT DIVIDE WITH REVERSED NEGATION SLASH -->
+<!ENTITY roang            "&#x027ED;" ><!--MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET -->
+<!ENTITY roarr            "&#x021FE;" ><!--RIGHTWARDS OPEN-HEADED ARROW -->
+<!ENTITY robrk            "&#x027E7;" ><!--MATHEMATICAL RIGHT WHITE SQUARE BRACKET -->
+<!ENTITY ropar            "&#x02986;" ><!--RIGHT WHITE PARENTHESIS -->
+<!ENTITY ropf             "&#x1D563;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL R -->
+<!ENTITY roplus           "&#x02A2E;" ><!--PLUS SIGN IN RIGHT HALF CIRCLE -->
+<!ENTITY rotimes          "&#x02A35;" ><!--MULTIPLICATION SIGN IN RIGHT HALF CIRCLE -->
+<!ENTITY rpar             "&#x00029;" ><!--RIGHT PARENTHESIS -->
+<!ENTITY rpargt           "&#x02994;" ><!--RIGHT ARC GREATER-THAN BRACKET -->
+<!ENTITY rppolint         "&#x02A12;" ><!--LINE INTEGRATION WITH RECTANGULAR PATH AROUND POLE -->
+<!ENTITY rrarr            "&#x021C9;" ><!--RIGHTWARDS PAIRED ARROWS -->
+<!ENTITY rsaquo           "&#x0203A;" ><!--SINGLE RIGHT-POINTING ANGLE QUOTATION MARK -->
+<!ENTITY rscr             "&#x1D4C7;" ><!--MATHEMATICAL SCRIPT SMALL R -->
+<!ENTITY rsh              "&#x021B1;" ><!--UPWARDS ARROW WITH TIP RIGHTWARDS -->
+<!ENTITY rsqb             "&#x0005D;" ><!--RIGHT SQUARE BRACKET -->
+<!ENTITY rsquo            "&#x02019;" ><!--RIGHT SINGLE QUOTATION MARK -->
+<!ENTITY rsquor           "&#x02019;" ><!--RIGHT SINGLE QUOTATION MARK -->
+<!ENTITY rthree           "&#x022CC;" ><!--RIGHT SEMIDIRECT PRODUCT -->
+<!ENTITY rtimes           "&#x022CA;" ><!--RIGHT NORMAL FACTOR SEMIDIRECT PRODUCT -->
+<!ENTITY rtri             "&#x025B9;" ><!--WHITE RIGHT-POINTING SMALL TRIANGLE -->
+<!ENTITY rtrie            "&#x022B5;" ><!--CONTAINS AS NORMAL SUBGROUP OR EQUAL TO -->
+<!ENTITY rtrif            "&#x025B8;" ><!--BLACK RIGHT-POINTING SMALL TRIANGLE -->
+<!ENTITY rtriltri         "&#x029CE;" ><!--RIGHT TRIANGLE ABOVE LEFT TRIANGLE -->
+<!ENTITY ruluhar          "&#x02968;" ><!--RIGHTWARDS HARPOON WITH BARB UP ABOVE LEFTWARDS HARPOON WITH BARB UP -->
+<!ENTITY rx               "&#x0211E;" ><!--PRESCRIPTION TAKE -->
+<!ENTITY sacute           "&#x0015B;" ><!--LATIN SMALL LETTER S WITH ACUTE -->
+<!ENTITY sbquo            "&#x0201A;" ><!--SINGLE LOW-9 QUOTATION MARK -->
+<!ENTITY sc               "&#x0227B;" ><!--SUCCEEDS -->
+<!ENTITY scE              "&#x02AB4;" ><!--SUCCEEDS ABOVE EQUALS SIGN -->
+<!ENTITY scap             "&#x02AB8;" ><!--SUCCEEDS ABOVE ALMOST EQUAL TO -->
+<!ENTITY scaron           "&#x00161;" ><!--LATIN SMALL LETTER S WITH CARON -->
+<!ENTITY sccue            "&#x0227D;" ><!--SUCCEEDS OR EQUAL TO -->
+<!ENTITY sce              "&#x02AB0;" ><!--SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN -->
+<!ENTITY scedil           "&#x0015F;" ><!--LATIN SMALL LETTER S WITH CEDILLA -->
+<!ENTITY scirc            "&#x0015D;" ><!--LATIN SMALL LETTER S WITH CIRCUMFLEX -->
+<!ENTITY scnE             "&#x02AB6;" ><!--SUCCEEDS ABOVE NOT EQUAL TO -->
+<!ENTITY scnap            "&#x02ABA;" ><!--SUCCEEDS ABOVE NOT ALMOST EQUAL TO -->
+<!ENTITY scnsim           "&#x022E9;" ><!--SUCCEEDS BUT NOT EQUIVALENT TO -->
+<!ENTITY scpolint         "&#x02A13;" ><!--LINE INTEGRATION WITH SEMICIRCULAR PATH AROUND POLE -->
+<!ENTITY scsim            "&#x0227F;" ><!--SUCCEEDS OR EQUIVALENT TO -->
+<!ENTITY scy              "&#x00441;" ><!--CYRILLIC SMALL LETTER ES -->
+<!ENTITY sdot             "&#x022C5;" ><!--DOT OPERATOR -->
+<!ENTITY sdotb            "&#x022A1;" ><!--SQUARED DOT OPERATOR -->
+<!ENTITY sdote            "&#x02A66;" ><!--EQUALS SIGN WITH DOT BELOW -->
+<!ENTITY seArr            "&#x021D8;" ><!--SOUTH EAST DOUBLE ARROW -->
+<!ENTITY searhk           "&#x02925;" ><!--SOUTH EAST ARROW WITH HOOK -->
+<!ENTITY searr            "&#x02198;" ><!--SOUTH EAST ARROW -->
+<!ENTITY searrow          "&#x02198;" ><!--SOUTH EAST ARROW -->
+<!ENTITY sect             "&#x000A7;" ><!--SECTION SIGN -->
+<!ENTITY semi             "&#x0003B;" ><!--SEMICOLON -->
+<!ENTITY seswar           "&#x02929;" ><!--SOUTH EAST ARROW AND SOUTH WEST ARROW -->
+<!ENTITY setminus         "&#x02216;" ><!--SET MINUS -->
+<!ENTITY setmn            "&#x02216;" ><!--SET MINUS -->
+<!ENTITY sext             "&#x02736;" ><!--SIX POINTED BLACK STAR -->
+<!ENTITY sfr              "&#x1D530;" ><!--MATHEMATICAL FRAKTUR SMALL S -->
+<!ENTITY sfrown           "&#x02322;" ><!--FROWN -->
+<!ENTITY sharp            "&#x0266F;" ><!--MUSIC SHARP SIGN -->
+<!ENTITY shchcy           "&#x00449;" ><!--CYRILLIC SMALL LETTER SHCHA -->
+<!ENTITY shcy             "&#x00448;" ><!--CYRILLIC SMALL LETTER SHA -->
+<!ENTITY shortmid         "&#x02223;" ><!--DIVIDES -->
+<!ENTITY shortparallel    "&#x02225;" ><!--PARALLEL TO -->
+<!ENTITY shy              "&#x000AD;" ><!--SOFT HYPHEN -->
+<!ENTITY sigma            "&#x003C3;" ><!--GREEK SMALL LETTER SIGMA -->
+<!ENTITY sigmaf           "&#x003C2;" ><!--GREEK SMALL LETTER FINAL SIGMA -->
+<!ENTITY sigmav           "&#x003C2;" ><!--GREEK SMALL LETTER FINAL SIGMA -->
+<!ENTITY sim              "&#x0223C;" ><!--TILDE OPERATOR -->
+<!ENTITY simdot           "&#x02A6A;" ><!--TILDE OPERATOR WITH DOT ABOVE -->
+<!ENTITY sime             "&#x02243;" ><!--ASYMPTOTICALLY EQUAL TO -->
+<!ENTITY simeq            "&#x02243;" ><!--ASYMPTOTICALLY EQUAL TO -->
+<!ENTITY simg             "&#x02A9E;" ><!--SIMILAR OR GREATER-THAN -->
+<!ENTITY simgE            "&#x02AA0;" ><!--SIMILAR ABOVE GREATER-THAN ABOVE EQUALS SIGN -->
+<!ENTITY siml             "&#x02A9D;" ><!--SIMILAR OR LESS-THAN -->
+<!ENTITY simlE            "&#x02A9F;" ><!--SIMILAR ABOVE LESS-THAN ABOVE EQUALS SIGN -->
+<!ENTITY simne            "&#x02246;" ><!--APPROXIMATELY BUT NOT ACTUALLY EQUAL TO -->
+<!ENTITY simplus          "&#x02A24;" ><!--PLUS SIGN WITH TILDE ABOVE -->
+<!ENTITY simrarr          "&#x02972;" ><!--TILDE OPERATOR ABOVE RIGHTWARDS ARROW -->
+<!ENTITY slarr            "&#x02190;" ><!--LEFTWARDS ARROW -->
+<!ENTITY smallsetminus    "&#x02216;" ><!--SET MINUS -->
+<!ENTITY smashp           "&#x02A33;" ><!--SMASH PRODUCT -->
+<!ENTITY smeparsl         "&#x029E4;" ><!--EQUALS SIGN AND SLANTED PARALLEL WITH TILDE ABOVE -->
+<!ENTITY smid             "&#x02223;" ><!--DIVIDES -->
+<!ENTITY smile            "&#x02323;" ><!--SMILE -->
+<!ENTITY smt              "&#x02AAA;" ><!--SMALLER THAN -->
+<!ENTITY smte             "&#x02AAC;" ><!--SMALLER THAN OR EQUAL TO -->
+<!ENTITY smtes            "&#x02AAC;&#x0FE00;" ><!--SMALLER THAN OR slanted EQUAL -->
+<!ENTITY softcy           "&#x0044C;" ><!--CYRILLIC SMALL LETTER SOFT SIGN -->
+<!ENTITY sol              "&#x0002F;" ><!--SOLIDUS -->
+<!ENTITY solb             "&#x029C4;" ><!--SQUARED RISING DIAGONAL SLASH -->
+<!ENTITY solbar           "&#x0233F;" ><!--APL FUNCTIONAL SYMBOL SLASH BAR -->
+<!ENTITY sopf             "&#x1D564;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL S -->
+<!ENTITY spades           "&#x02660;" ><!--BLACK SPADE SUIT -->
+<!ENTITY spadesuit        "&#x02660;" ><!--BLACK SPADE SUIT -->
+<!ENTITY spar             "&#x02225;" ><!--PARALLEL TO -->
+<!ENTITY sqcap            "&#x02293;" ><!--SQUARE CAP -->
+<!ENTITY sqcaps           "&#x02293;&#x0FE00;" ><!--SQUARE CAP with serifs -->
+<!ENTITY sqcup            "&#x02294;" ><!--SQUARE CUP -->
+<!ENTITY sqcups           "&#x02294;&#x0FE00;" ><!--SQUARE CUP with serifs -->
+<!ENTITY sqsub            "&#x0228F;" ><!--SQUARE IMAGE OF -->
+<!ENTITY sqsube           "&#x02291;" ><!--SQUARE IMAGE OF OR EQUAL TO -->
+<!ENTITY sqsubset         "&#x0228F;" ><!--SQUARE IMAGE OF -->
+<!ENTITY sqsubseteq       "&#x02291;" ><!--SQUARE IMAGE OF OR EQUAL TO -->
+<!ENTITY sqsup            "&#x02290;" ><!--SQUARE ORIGINAL OF -->
+<!ENTITY sqsupe           "&#x02292;" ><!--SQUARE ORIGINAL OF OR EQUAL TO -->
+<!ENTITY sqsupset         "&#x02290;" ><!--SQUARE ORIGINAL OF -->
+<!ENTITY sqsupseteq       "&#x02292;" ><!--SQUARE ORIGINAL OF OR EQUAL TO -->
+<!ENTITY squ              "&#x025A1;" ><!--WHITE SQUARE -->
+<!ENTITY square           "&#x025A1;" ><!--WHITE SQUARE -->
+<!ENTITY squarf           "&#x025AA;" ><!--BLACK SMALL SQUARE -->
+<!ENTITY squf             "&#x025AA;" ><!--BLACK SMALL SQUARE -->
+<!ENTITY srarr            "&#x02192;" ><!--RIGHTWARDS ARROW -->
+<!ENTITY sscr             "&#x1D4C8;" ><!--MATHEMATICAL SCRIPT SMALL S -->
+<!ENTITY ssetmn           "&#x02216;" ><!--SET MINUS -->
+<!ENTITY ssmile           "&#x02323;" ><!--SMILE -->
+<!ENTITY sstarf           "&#x022C6;" ><!--STAR OPERATOR -->
+<!ENTITY star             "&#x02606;" ><!--WHITE STAR -->
+<!ENTITY starf            "&#x02605;" ><!--BLACK STAR -->
+<!ENTITY straightepsilon  "&#x003F5;" ><!--GREEK LUNATE EPSILON SYMBOL -->
+<!ENTITY straightphi      "&#x003D5;" ><!--GREEK PHI SYMBOL -->
+<!ENTITY strns            "&#x000AF;" ><!--MACRON -->
+<!ENTITY sub              "&#x02282;" ><!--SUBSET OF -->
+<!ENTITY subE             "&#x02AC5;" ><!--SUBSET OF ABOVE EQUALS SIGN -->
+<!ENTITY subdot           "&#x02ABD;" ><!--SUBSET WITH DOT -->
+<!ENTITY sube             "&#x02286;" ><!--SUBSET OF OR EQUAL TO -->
+<!ENTITY subedot          "&#x02AC3;" ><!--SUBSET OF OR EQUAL TO WITH DOT ABOVE -->
+<!ENTITY submult          "&#x02AC1;" ><!--SUBSET WITH MULTIPLICATION SIGN BELOW -->
+<!ENTITY subnE            "&#x02ACB;" ><!--SUBSET OF ABOVE NOT EQUAL TO -->
+<!ENTITY subne            "&#x0228A;" ><!--SUBSET OF WITH NOT EQUAL TO -->
+<!ENTITY subplus          "&#x02ABF;" ><!--SUBSET WITH PLUS SIGN BELOW -->
+<!ENTITY subrarr          "&#x02979;" ><!--SUBSET ABOVE RIGHTWARDS ARROW -->
+<!ENTITY subset           "&#x02282;" ><!--SUBSET OF -->
+<!ENTITY subseteq         "&#x02286;" ><!--SUBSET OF OR EQUAL TO -->
+<!ENTITY subseteqq        "&#x02AC5;" ><!--SUBSET OF ABOVE EQUALS SIGN -->
+<!ENTITY subsetneq        "&#x0228A;" ><!--SUBSET OF WITH NOT EQUAL TO -->
+<!ENTITY subsetneqq       "&#x02ACB;" ><!--SUBSET OF ABOVE NOT EQUAL TO -->
+<!ENTITY subsim           "&#x02AC7;" ><!--SUBSET OF ABOVE TILDE OPERATOR -->
+<!ENTITY subsub           "&#x02AD5;" ><!--SUBSET ABOVE SUBSET -->
+<!ENTITY subsup           "&#x02AD3;" ><!--SUBSET ABOVE SUPERSET -->
+<!ENTITY succ             "&#x0227B;" ><!--SUCCEEDS -->
+<!ENTITY succapprox       "&#x02AB8;" ><!--SUCCEEDS ABOVE ALMOST EQUAL TO -->
+<!ENTITY succcurlyeq      "&#x0227D;" ><!--SUCCEEDS OR EQUAL TO -->
+<!ENTITY succeq           "&#x02AB0;" ><!--SUCCEEDS ABOVE SINGLE-LINE EQUALS SIGN -->
+<!ENTITY succnapprox      "&#x02ABA;" ><!--SUCCEEDS ABOVE NOT ALMOST EQUAL TO -->
+<!ENTITY succneqq         "&#x02AB6;" ><!--SUCCEEDS ABOVE NOT EQUAL TO -->
+<!ENTITY succnsim         "&#x022E9;" ><!--SUCCEEDS BUT NOT EQUIVALENT TO -->
+<!ENTITY succsim          "&#x0227F;" ><!--SUCCEEDS OR EQUIVALENT TO -->
+<!ENTITY sum              "&#x02211;" ><!--N-ARY SUMMATION -->
+<!ENTITY sung             "&#x0266A;" ><!--EIGHTH NOTE -->
+<!ENTITY sup              "&#x02283;" ><!--SUPERSET OF -->
+<!ENTITY sup1             "&#x000B9;" ><!--SUPERSCRIPT ONE -->
+<!ENTITY sup2             "&#x000B2;" ><!--SUPERSCRIPT TWO -->
+<!ENTITY sup3             "&#x000B3;" ><!--SUPERSCRIPT THREE -->
+<!ENTITY supE             "&#x02AC6;" ><!--SUPERSET OF ABOVE EQUALS SIGN -->
+<!ENTITY supdot           "&#x02ABE;" ><!--SUPERSET WITH DOT -->
+<!ENTITY supdsub          "&#x02AD8;" ><!--SUPERSET BESIDE AND JOINED BY DASH WITH SUBSET -->
+<!ENTITY supe             "&#x02287;" ><!--SUPERSET OF OR EQUAL TO -->
+<!ENTITY supedot          "&#x02AC4;" ><!--SUPERSET OF OR EQUAL TO WITH DOT ABOVE -->
+<!ENTITY suphsol          "&#x027C9;" ><!--SUPERSET PRECEDING SOLIDUS -->
+<!ENTITY suphsub          "&#x02AD7;" ><!--SUPERSET BESIDE SUBSET -->
+<!ENTITY suplarr          "&#x0297B;" ><!--SUPERSET ABOVE LEFTWARDS ARROW -->
+<!ENTITY supmult          "&#x02AC2;" ><!--SUPERSET WITH MULTIPLICATION SIGN BELOW -->
+<!ENTITY supnE            "&#x02ACC;" ><!--SUPERSET OF ABOVE NOT EQUAL TO -->
+<!ENTITY supne            "&#x0228B;" ><!--SUPERSET OF WITH NOT EQUAL TO -->
+<!ENTITY supplus          "&#x02AC0;" ><!--SUPERSET WITH PLUS SIGN BELOW -->
+<!ENTITY supset           "&#x02283;" ><!--SUPERSET OF -->
+<!ENTITY supseteq         "&#x02287;" ><!--SUPERSET OF OR EQUAL TO -->
+<!ENTITY supseteqq        "&#x02AC6;" ><!--SUPERSET OF ABOVE EQUALS SIGN -->
+<!ENTITY supsetneq        "&#x0228B;" ><!--SUPERSET OF WITH NOT EQUAL TO -->
+<!ENTITY supsetneqq       "&#x02ACC;" ><!--SUPERSET OF ABOVE NOT EQUAL TO -->
+<!ENTITY supsim           "&#x02AC8;" ><!--SUPERSET OF ABOVE TILDE OPERATOR -->
+<!ENTITY supsub           "&#x02AD4;" ><!--SUPERSET ABOVE SUBSET -->
+<!ENTITY supsup           "&#x02AD6;" ><!--SUPERSET ABOVE SUPERSET -->
+<!ENTITY swArr            "&#x021D9;" ><!--SOUTH WEST DOUBLE ARROW -->
+<!ENTITY swarhk           "&#x02926;" ><!--SOUTH WEST ARROW WITH HOOK -->
+<!ENTITY swarr            "&#x02199;" ><!--SOUTH WEST ARROW -->
+<!ENTITY swarrow          "&#x02199;" ><!--SOUTH WEST ARROW -->
+<!ENTITY swnwar           "&#x0292A;" ><!--SOUTH WEST ARROW AND NORTH WEST ARROW -->
+<!ENTITY szlig            "&#x000DF;" ><!--LATIN SMALL LETTER SHARP S -->
+<!ENTITY target           "&#x02316;" ><!--POSITION INDICATOR -->
+<!ENTITY tau              "&#x003C4;" ><!--GREEK SMALL LETTER TAU -->
+<!ENTITY tbrk             "&#x023B4;" ><!--TOP SQUARE BRACKET -->
+<!ENTITY tcaron           "&#x00165;" ><!--LATIN SMALL LETTER T WITH CARON -->
+<!ENTITY tcedil           "&#x00163;" ><!--LATIN SMALL LETTER T WITH CEDILLA -->
+<!ENTITY tcy              "&#x00442;" ><!--CYRILLIC SMALL LETTER TE -->
+<!ENTITY tdot             " &#x020DB;" ><!--COMBINING THREE DOTS ABOVE -->
+<!ENTITY telrec           "&#x02315;" ><!--TELEPHONE RECORDER -->
+<!ENTITY tfr              "&#x1D531;" ><!--MATHEMATICAL FRAKTUR SMALL T -->
+<!ENTITY there4           "&#x02234;" ><!--THEREFORE -->
+<!ENTITY therefore        "&#x02234;" ><!--THEREFORE -->
+<!ENTITY theta            "&#x003B8;" ><!--GREEK SMALL LETTER THETA -->
+<!ENTITY thetasym         "&#x003D1;" ><!--GREEK THETA SYMBOL -->
+<!ENTITY thetav           "&#x003D1;" ><!--GREEK THETA SYMBOL -->
+<!ENTITY thickapprox      "&#x02248;" ><!--ALMOST EQUAL TO -->
+<!ENTITY thicksim         "&#x0223C;" ><!--TILDE OPERATOR -->
+<!ENTITY thinsp           "&#x02009;" ><!--THIN SPACE -->
+<!ENTITY thkap            "&#x02248;" ><!--ALMOST EQUAL TO -->
+<!ENTITY thksim           "&#x0223C;" ><!--TILDE OPERATOR -->
+<!ENTITY thorn            "&#x000FE;" ><!--LATIN SMALL LETTER THORN -->
+<!ENTITY tilde            "&#x002DC;" ><!--SMALL TILDE -->
+<!ENTITY times            "&#x000D7;" ><!--MULTIPLICATION SIGN -->
+<!ENTITY timesb           "&#x022A0;" ><!--SQUARED TIMES -->
+<!ENTITY timesbar         "&#x02A31;" ><!--MULTIPLICATION SIGN WITH UNDERBAR -->
+<!ENTITY timesd           "&#x02A30;" ><!--MULTIPLICATION SIGN WITH DOT ABOVE -->
+<!ENTITY tint             "&#x0222D;" ><!--TRIPLE INTEGRAL -->
+<!ENTITY toea             "&#x02928;" ><!--NORTH EAST ARROW AND SOUTH EAST ARROW -->
+<!ENTITY top              "&#x022A4;" ><!--DOWN TACK -->
+<!ENTITY topbot           "&#x02336;" ><!--APL FUNCTIONAL SYMBOL I-BEAM -->
+<!ENTITY topcir           "&#x02AF1;" ><!--DOWN TACK WITH CIRCLE BELOW -->
+<!ENTITY topf             "&#x1D565;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL T -->
+<!ENTITY topfork          "&#x02ADA;" ><!--PITCHFORK WITH TEE TOP -->
+<!ENTITY tosa             "&#x02929;" ><!--SOUTH EAST ARROW AND SOUTH WEST ARROW -->
+<!ENTITY tprime           "&#x02034;" ><!--TRIPLE PRIME -->
+<!ENTITY trade            "&#x02122;" ><!--TRADE MARK SIGN -->
+<!ENTITY triangle         "&#x025B5;" ><!--WHITE UP-POINTING SMALL TRIANGLE -->
+<!ENTITY triangledown     "&#x025BF;" ><!--WHITE DOWN-POINTING SMALL TRIANGLE -->
+<!ENTITY triangleleft     "&#x025C3;" ><!--WHITE LEFT-POINTING SMALL TRIANGLE -->
+<!ENTITY trianglelefteq   "&#x022B4;" ><!--NORMAL SUBGROUP OF OR EQUAL TO -->
+<!ENTITY triangleq        "&#x0225C;" ><!--DELTA EQUAL TO -->
+<!ENTITY triangleright    "&#x025B9;" ><!--WHITE RIGHT-POINTING SMALL TRIANGLE -->
+<!ENTITY trianglerighteq  "&#x022B5;" ><!--CONTAINS AS NORMAL SUBGROUP OR EQUAL TO -->
+<!ENTITY tridot           "&#x025EC;" ><!--WHITE UP-POINTING TRIANGLE WITH DOT -->
+<!ENTITY trie             "&#x0225C;" ><!--DELTA EQUAL TO -->
+<!ENTITY triminus         "&#x02A3A;" ><!--MINUS SIGN IN TRIANGLE -->
+<!ENTITY triplus          "&#x02A39;" ><!--PLUS SIGN IN TRIANGLE -->
+<!ENTITY trisb            "&#x029CD;" ><!--TRIANGLE WITH SERIFS AT BOTTOM -->
+<!ENTITY tritime          "&#x02A3B;" ><!--MULTIPLICATION SIGN IN TRIANGLE -->
+<!ENTITY trpezium         "&#x023E2;" ><!--WHITE TRAPEZIUM -->
+<!ENTITY tscr             "&#x1D4C9;" ><!--MATHEMATICAL SCRIPT SMALL T -->
+<!ENTITY tscy             "&#x00446;" ><!--CYRILLIC SMALL LETTER TSE -->
+<!ENTITY tshcy            "&#x0045B;" ><!--CYRILLIC SMALL LETTER TSHE -->
+<!ENTITY tstrok           "&#x00167;" ><!--LATIN SMALL LETTER T WITH STROKE -->
+<!ENTITY twixt            "&#x0226C;" ><!--BETWEEN -->
+<!ENTITY twoheadleftarrow "&#x0219E;" ><!--LEFTWARDS TWO HEADED ARROW -->
+<!ENTITY twoheadrightarrow "&#x021A0;" ><!--RIGHTWARDS TWO HEADED ARROW -->
+<!ENTITY uArr             "&#x021D1;" ><!--UPWARDS DOUBLE ARROW -->
+<!ENTITY uHar             "&#x02963;" ><!--UPWARDS HARPOON WITH BARB LEFT BESIDE UPWARDS HARPOON WITH BARB RIGHT -->
+<!ENTITY uacute           "&#x000FA;" ><!--LATIN SMALL LETTER U WITH ACUTE -->
+<!ENTITY uarr             "&#x02191;" ><!--UPWARDS ARROW -->
+<!ENTITY ubrcy            "&#x0045E;" ><!--CYRILLIC SMALL LETTER SHORT U -->
+<!ENTITY ubreve           "&#x0016D;" ><!--LATIN SMALL LETTER U WITH BREVE -->
+<!ENTITY ucirc            "&#x000FB;" ><!--LATIN SMALL LETTER U WITH CIRCUMFLEX -->
+<!ENTITY ucy              "&#x00443;" ><!--CYRILLIC SMALL LETTER U -->
+<!ENTITY udarr            "&#x021C5;" ><!--UPWARDS ARROW LEFTWARDS OF DOWNWARDS ARROW -->
+<!ENTITY udblac           "&#x00171;" ><!--LATIN SMALL LETTER U WITH DOUBLE ACUTE -->
+<!ENTITY udhar            "&#x0296E;" ><!--UPWARDS HARPOON WITH BARB LEFT BESIDE DOWNWARDS HARPOON WITH BARB RIGHT -->
+<!ENTITY ufisht           "&#x0297E;" ><!--UP FISH TAIL -->
+<!ENTITY ufr              "&#x1D532;" ><!--MATHEMATICAL FRAKTUR SMALL U -->
+<!ENTITY ugrave           "&#x000F9;" ><!--LATIN SMALL LETTER U WITH GRAVE -->
+<!ENTITY uharl            "&#x021BF;" ><!--UPWARDS HARPOON WITH BARB LEFTWARDS -->
+<!ENTITY uharr            "&#x021BE;" ><!--UPWARDS HARPOON WITH BARB RIGHTWARDS -->
+<!ENTITY uhblk            "&#x02580;" ><!--UPPER HALF BLOCK -->
+<!ENTITY ulcorn           "&#x0231C;" ><!--TOP LEFT CORNER -->
+<!ENTITY ulcorner         "&#x0231C;" ><!--TOP LEFT CORNER -->
+<!ENTITY ulcrop           "&#x0230F;" ><!--TOP LEFT CROP -->
+<!ENTITY ultri            "&#x025F8;" ><!--UPPER LEFT TRIANGLE -->
+<!ENTITY umacr            "&#x0016B;" ><!--LATIN SMALL LETTER U WITH MACRON -->
+<!ENTITY uml              "&#x000A8;" ><!--DIAERESIS -->
+<!ENTITY uogon            "&#x00173;" ><!--LATIN SMALL LETTER U WITH OGONEK -->
+<!ENTITY uopf             "&#x1D566;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL U -->
+<!ENTITY uparrow          "&#x02191;" ><!--UPWARDS ARROW -->
+<!ENTITY updownarrow      "&#x02195;" ><!--UP DOWN ARROW -->
+<!ENTITY upharpoonleft    "&#x021BF;" ><!--UPWARDS HARPOON WITH BARB LEFTWARDS -->
+<!ENTITY upharpoonright   "&#x021BE;" ><!--UPWARDS HARPOON WITH BARB RIGHTWARDS -->
+<!ENTITY uplus            "&#x0228E;" ><!--MULTISET UNION -->
+<!ENTITY upsi             "&#x003C5;" ><!--GREEK SMALL LETTER UPSILON -->
+<!ENTITY upsih            "&#x003D2;" ><!--GREEK UPSILON WITH HOOK SYMBOL -->
+<!ENTITY upsilon          "&#x003C5;" ><!--GREEK SMALL LETTER UPSILON -->
+<!ENTITY upuparrows       "&#x021C8;" ><!--UPWARDS PAIRED ARROWS -->
+<!ENTITY urcorn           "&#x0231D;" ><!--TOP RIGHT CORNER -->
+<!ENTITY urcorner         "&#x0231D;" ><!--TOP RIGHT CORNER -->
+<!ENTITY urcrop           "&#x0230E;" ><!--TOP RIGHT CROP -->
+<!ENTITY uring            "&#x0016F;" ><!--LATIN SMALL LETTER U WITH RING ABOVE -->
+<!ENTITY urtri            "&#x025F9;" ><!--UPPER RIGHT TRIANGLE -->
+<!ENTITY uscr             "&#x1D4CA;" ><!--MATHEMATICAL SCRIPT SMALL U -->
+<!ENTITY utdot            "&#x022F0;" ><!--UP RIGHT DIAGONAL ELLIPSIS -->
+<!ENTITY utilde           "&#x00169;" ><!--LATIN SMALL LETTER U WITH TILDE -->
+<!ENTITY utri             "&#x025B5;" ><!--WHITE UP-POINTING SMALL TRIANGLE -->
+<!ENTITY utrif            "&#x025B4;" ><!--BLACK UP-POINTING SMALL TRIANGLE -->
+<!ENTITY uuarr            "&#x021C8;" ><!--UPWARDS PAIRED ARROWS -->
+<!ENTITY uuml             "&#x000FC;" ><!--LATIN SMALL LETTER U WITH DIAERESIS -->
+<!ENTITY uwangle          "&#x029A7;" ><!--OBLIQUE ANGLE OPENING DOWN -->
+<!ENTITY vArr             "&#x021D5;" ><!--UP DOWN DOUBLE ARROW -->
+<!ENTITY vBar             "&#x02AE8;" ><!--SHORT UP TACK WITH UNDERBAR -->
+<!ENTITY vBarv            "&#x02AE9;" ><!--SHORT UP TACK ABOVE SHORT DOWN TACK -->
+<!ENTITY vDash            "&#x022A8;" ><!--TRUE -->
+<!ENTITY vangrt           "&#x0299C;" ><!--RIGHT ANGLE VARIANT WITH SQUARE -->
+<!ENTITY varepsilon       "&#x003F5;" ><!--GREEK LUNATE EPSILON SYMBOL -->
+<!ENTITY varkappa         "&#x003F0;" ><!--GREEK KAPPA SYMBOL -->
+<!ENTITY varnothing       "&#x02205;" ><!--EMPTY SET -->
+<!ENTITY varphi           "&#x003D5;" ><!--GREEK PHI SYMBOL -->
+<!ENTITY varpi            "&#x003D6;" ><!--GREEK PI SYMBOL -->
+<!ENTITY varpropto        "&#x0221D;" ><!--PROPORTIONAL TO -->
+<!ENTITY varr             "&#x02195;" ><!--UP DOWN ARROW -->
+<!ENTITY varrho           "&#x003F1;" ><!--GREEK RHO SYMBOL -->
+<!ENTITY varsigma         "&#x003C2;" ><!--GREEK SMALL LETTER FINAL SIGMA -->
+<!ENTITY varsubsetneq     "&#x0228A;&#x0FE00;" ><!--SUBSET OF WITH NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY varsubsetneqq    "&#x02ACB;&#x0FE00;" ><!--SUBSET OF ABOVE NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY varsupsetneq     "&#x0228B;&#x0FE00;" ><!--SUPERSET OF WITH NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY varsupsetneqq    "&#x02ACC;&#x0FE00;" ><!--SUPERSET OF ABOVE NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY vartheta         "&#x003D1;" ><!--GREEK THETA SYMBOL -->
+<!ENTITY vartriangleleft  "&#x022B2;" ><!--NORMAL SUBGROUP OF -->
+<!ENTITY vartriangleright "&#x022B3;" ><!--CONTAINS AS NORMAL SUBGROUP -->
+<!ENTITY vcy              "&#x00432;" ><!--CYRILLIC SMALL LETTER VE -->
+<!ENTITY vdash            "&#x022A2;" ><!--RIGHT TACK -->
+<!ENTITY vee              "&#x02228;" ><!--LOGICAL OR -->
+<!ENTITY veebar           "&#x022BB;" ><!--XOR -->
+<!ENTITY veeeq            "&#x0225A;" ><!--EQUIANGULAR TO -->
+<!ENTITY vellip           "&#x022EE;" ><!--VERTICAL ELLIPSIS -->
+<!ENTITY verbar           "&#x0007C;" ><!--VERTICAL LINE -->
+<!ENTITY vert             "&#x0007C;" ><!--VERTICAL LINE -->
+<!ENTITY vfr              "&#x1D533;" ><!--MATHEMATICAL FRAKTUR SMALL V -->
+<!ENTITY vltri            "&#x022B2;" ><!--NORMAL SUBGROUP OF -->
+<!ENTITY vnsub            "&#x02282;&#x020D2;" ><!--SUBSET OF with vertical line -->
+<!ENTITY vnsup            "&#x02283;&#x020D2;" ><!--SUPERSET OF with vertical line -->
+<!ENTITY vopf             "&#x1D567;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL V -->
+<!ENTITY vprop            "&#x0221D;" ><!--PROPORTIONAL TO -->
+<!ENTITY vrtri            "&#x022B3;" ><!--CONTAINS AS NORMAL SUBGROUP -->
+<!ENTITY vscr             "&#x1D4CB;" ><!--MATHEMATICAL SCRIPT SMALL V -->
+<!ENTITY vsubnE           "&#x02ACB;&#x0FE00;" ><!--SUBSET OF ABOVE NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY vsubne           "&#x0228A;&#x0FE00;" ><!--SUBSET OF WITH NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY vsupnE           "&#x02ACC;&#x0FE00;" ><!--SUPERSET OF ABOVE NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY vsupne           "&#x0228B;&#x0FE00;" ><!--SUPERSET OF WITH NOT EQUAL TO - variant with stroke through bottom members -->
+<!ENTITY vzigzag          "&#x0299A;" ><!--VERTICAL ZIGZAG LINE -->
+<!ENTITY wcirc            "&#x00175;" ><!--LATIN SMALL LETTER W WITH CIRCUMFLEX -->
+<!ENTITY wedbar           "&#x02A5F;" ><!--LOGICAL AND WITH UNDERBAR -->
+<!ENTITY wedge            "&#x02227;" ><!--LOGICAL AND -->
+<!ENTITY wedgeq           "&#x02259;" ><!--ESTIMATES -->
+<!ENTITY weierp           "&#x02118;" ><!--SCRIPT CAPITAL P -->
+<!ENTITY wfr              "&#x1D534;" ><!--MATHEMATICAL FRAKTUR SMALL W -->
+<!ENTITY wopf             "&#x1D568;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL W -->
+<!ENTITY wp               "&#x02118;" ><!--SCRIPT CAPITAL P -->
+<!ENTITY wr               "&#x02240;" ><!--WREATH PRODUCT -->
+<!ENTITY wreath           "&#x02240;" ><!--WREATH PRODUCT -->
+<!ENTITY wscr             "&#x1D4CC;" ><!--MATHEMATICAL SCRIPT SMALL W -->
+<!ENTITY xcap             "&#x022C2;" ><!--N-ARY INTERSECTION -->
+<!ENTITY xcirc            "&#x025EF;" ><!--LARGE CIRCLE -->
+<!ENTITY xcup             "&#x022C3;" ><!--N-ARY UNION -->
+<!ENTITY xdtri            "&#x025BD;" ><!--WHITE DOWN-POINTING TRIANGLE -->
+<!ENTITY xfr              "&#x1D535;" ><!--MATHEMATICAL FRAKTUR SMALL X -->
+<!ENTITY xhArr            "&#x027FA;" ><!--LONG LEFT RIGHT DOUBLE ARROW -->
+<!ENTITY xharr            "&#x027F7;" ><!--LONG LEFT RIGHT ARROW -->
+<!ENTITY xi               "&#x003BE;" ><!--GREEK SMALL LETTER XI -->
+<!ENTITY xlArr            "&#x027F8;" ><!--LONG LEFTWARDS DOUBLE ARROW -->
+<!ENTITY xlarr            "&#x027F5;" ><!--LONG LEFTWARDS ARROW -->
+<!ENTITY xmap             "&#x027FC;" ><!--LONG RIGHTWARDS ARROW FROM BAR -->
+<!ENTITY xnis             "&#x022FB;" ><!--CONTAINS WITH VERTICAL BAR AT END OF HORIZONTAL STROKE -->
+<!ENTITY xodot            "&#x02A00;" ><!--N-ARY CIRCLED DOT OPERATOR -->
+<!ENTITY xopf             "&#x1D569;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL X -->
+<!ENTITY xoplus           "&#x02A01;" ><!--N-ARY CIRCLED PLUS OPERATOR -->
+<!ENTITY xotime           "&#x02A02;" ><!--N-ARY CIRCLED TIMES OPERATOR -->
+<!ENTITY xrArr            "&#x027F9;" ><!--LONG RIGHTWARDS DOUBLE ARROW -->
+<!ENTITY xrarr            "&#x027F6;" ><!--LONG RIGHTWARDS ARROW -->
+<!ENTITY xscr             "&#x1D4CD;" ><!--MATHEMATICAL SCRIPT SMALL X -->
+<!ENTITY xsqcup           "&#x02A06;" ><!--N-ARY SQUARE UNION OPERATOR -->
+<!ENTITY xuplus           "&#x02A04;" ><!--N-ARY UNION OPERATOR WITH PLUS -->
+<!ENTITY xutri            "&#x025B3;" ><!--WHITE UP-POINTING TRIANGLE -->
+<!ENTITY xvee             "&#x022C1;" ><!--N-ARY LOGICAL OR -->
+<!ENTITY xwedge           "&#x022C0;" ><!--N-ARY LOGICAL AND -->
+<!ENTITY yacute           "&#x000FD;" ><!--LATIN SMALL LETTER Y WITH ACUTE -->
+<!ENTITY yacy             "&#x0044F;" ><!--CYRILLIC SMALL LETTER YA -->
+<!ENTITY ycirc            "&#x00177;" ><!--LATIN SMALL LETTER Y WITH CIRCUMFLEX -->
+<!ENTITY ycy              "&#x0044B;" ><!--CYRILLIC SMALL LETTER YERU -->
+<!ENTITY yen              "&#x000A5;" ><!--YEN SIGN -->
+<!ENTITY yfr              "&#x1D536;" ><!--MATHEMATICAL FRAKTUR SMALL Y -->
+<!ENTITY yicy             "&#x00457;" ><!--CYRILLIC SMALL LETTER YI -->
+<!ENTITY yopf             "&#x1D56A;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL Y -->
+<!ENTITY yscr             "&#x1D4CE;" ><!--MATHEMATICAL SCRIPT SMALL Y -->
+<!ENTITY yucy             "&#x0044E;" ><!--CYRILLIC SMALL LETTER YU -->
+<!ENTITY yuml             "&#x000FF;" ><!--LATIN SMALL LETTER Y WITH DIAERESIS -->
+<!ENTITY zacute           "&#x0017A;" ><!--LATIN SMALL LETTER Z WITH ACUTE -->
+<!ENTITY zcaron           "&#x0017E;" ><!--LATIN SMALL LETTER Z WITH CARON -->
+<!ENTITY zcy              "&#x00437;" ><!--CYRILLIC SMALL LETTER ZE -->
+<!ENTITY zdot             "&#x0017C;" ><!--LATIN SMALL LETTER Z WITH DOT ABOVE -->
+<!ENTITY zeetrf           "&#x02128;" ><!--BLACK-LETTER CAPITAL Z -->
+<!ENTITY zeta             "&#x003B6;" ><!--GREEK SMALL LETTER ZETA -->
+<!ENTITY zfr              "&#x1D537;" ><!--MATHEMATICAL FRAKTUR SMALL Z -->
+<!ENTITY zhcy             "&#x00436;" ><!--CYRILLIC SMALL LETTER ZHE -->
+<!ENTITY zigrarr          "&#x021DD;" ><!--RIGHTWARDS SQUIGGLE ARROW -->
+<!ENTITY zopf             "&#x1D56B;" ><!--MATHEMATICAL DOUBLE-STRUCK SMALL Z -->
+<!ENTITY zscr             "&#x1D4CF;" ><!--MATHEMATICAL SCRIPT SMALL Z -->
+<!ENTITY zwj              "&#x0200D;" ><!--ZERO WIDTH JOINER -->
+<!ENTITY zwnj             "&#x0200C;" ><!--ZERO WIDTH NON-JOINER -->

--- a/cnxml/xml/mathml/schema/dtd/3.0/mathml3-qname.mod
+++ b/cnxml/xml/mathml/schema/dtd/3.0/mathml3-qname.mod
@@ -1,0 +1,295 @@
+
+<!-- ....................................................................... -->
+<!-- MathML Qualified Names Module  ........................................ -->
+<!-- file: mathml3-qname-1.mod
+
+     This is the Mathematical Markup Language (MathML) 2.0, an XML 
+     application for describing mathematical notation and capturing 
+     both its structure and content.
+
+     Copyright 1998-2014 W3C (MIT, INRIA, Keio, Beihang), All Rights Reserved.
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN"
+       SYSTEM "mathml3-qname.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- MathML Qualified Names
+
+     This module is contained in two parts, labeled Section 'A' and 'B':
+
+       Section A declares parameter entities to support namespace-
+       qualified names, namespace declarations, and name prefixing 
+       for MathML.
+    
+       Section B declares parameter entities used to provide
+       namespace-qualified names for all MathML element types.
+
+     This module is derived from the XHTML Qualified Names Template module.
+-->
+
+<!-- Section A: XHTML XML Namespace Framework :::::::::::::::::::: -->
+
+<!ENTITY % NS.prefixed     "IGNORE" >
+<!ENTITY % MATHML.prefixed "%NS.prefixed;" >
+
+<!-- XLink ............... -->
+
+<!ENTITY % XLINK.prefix         "xlink" >
+<!ENTITY % XLINK.xmlns "http://www.w3.org/1999/xlink" >
+<!ENTITY % XLINK.xmlns.attrib
+     "xmlns:%XLINK.prefix;  CDATA           #FIXED '%XLINK.xmlns;'"
+>
+
+<!-- W3C XML Schema ............... -->
+
+<!ENTITY % Schema.prefix         "xsi" >
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance" >
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA           #IMPLIED"
+>
+
+<!-- MathML .............. -->
+
+<!ENTITY % MATHML.xmlns    "http://www.w3.org/1998/Math/MathML" >
+<!ENTITY % MATHML.prefix   "m" >
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.xmlns.extra.attrib  "" >
+]]>
+<!ENTITY % MATHML.xmlns.extra.attrib 
+     "%XLINK.xmlns.attrib; 
+      %Schema.xmlns.attrib;" >
+
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx  "%MATHML.prefix;:" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns:%MATHML.prefix;  CDATA   #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+]]>
+<!ENTITY % MATHML.pfx  "" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns        CDATA           #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+
+<![%NS.prefixed;[
+<!ENTITY % XHTML.xmlns.extra.attrib 
+     "%MATHML.xmlns.attrib;" >
+]]>
+<!ENTITY % XHTML.xmlns.extra.attrib
+     "%XLINK.xmlns.attrib;
+      %Schema.xmlns.attrib;"
+>
+
+
+<!-- ignores subsequent instantiation of this module when
+     used as external subset rather than module fragment.
+     NOTE: Do not modify this parameter entity, otherwise
+     a recursive parsing situation may result.
+-->
+<!ENTITY % mathml-qname.module "IGNORE" >
+
+<!-- Section B: MathML Qualified Names ::::::::::::::::::::::::::::: -->
+
+<!-- 9. This section declares parameter entities used to provide
+        namespace-qualified names for all MathML element types.
+-->
+
+<!ENTITY % abs.qname "%MATHML.pfx;abs" >
+<!ENTITY % and.qname "%MATHML.pfx;and" >
+<!ENTITY % annotation.qname "%MATHML.pfx;annotation" >
+<!ENTITY % annotation-xml.qname "%MATHML.pfx;annotation-xml" >
+<!ENTITY % apply.qname "%MATHML.pfx;apply" >
+<!ENTITY % approx.qname "%MATHML.pfx;approx" >
+<!ENTITY % arccos.qname "%MATHML.pfx;arccos" >
+<!ENTITY % arccosh.qname "%MATHML.pfx;arccosh" >
+<!ENTITY % arccot.qname "%MATHML.pfx;arccot" >
+<!ENTITY % arccoth.qname "%MATHML.pfx;arccoth" >
+<!ENTITY % arccsc.qname "%MATHML.pfx;arccsc" >
+<!ENTITY % arccsch.qname "%MATHML.pfx;arccsch" >
+<!ENTITY % arcsec.qname "%MATHML.pfx;arcsec" >
+<!ENTITY % arcsech.qname "%MATHML.pfx;arcsech" >
+<!ENTITY % arcsin.qname "%MATHML.pfx;arcsin" >
+<!ENTITY % arcsinh.qname "%MATHML.pfx;arcsinh" >
+<!ENTITY % arctan.qname "%MATHML.pfx;arctan" >
+<!ENTITY % arctanh.qname "%MATHML.pfx;arctanh" >
+<!ENTITY % arg.qname "%MATHML.pfx;arg" >
+<!ENTITY % bind.qname "%MATHML.pfx;bind" >
+<!ENTITY % bvar.qname "%MATHML.pfx;bvar" >
+<!ENTITY % card.qname "%MATHML.pfx;card" >
+<!ENTITY % cartesianproduct.qname "%MATHML.pfx;cartesianproduct" >
+<!ENTITY % cbytes.qname "%MATHML.pfx;cbytes" >
+<!ENTITY % ceiling.qname "%MATHML.pfx;ceiling" >
+<!ENTITY % cerror.qname "%MATHML.pfx;cerror" >
+<!ENTITY % ci.qname "%MATHML.pfx;ci" >
+<!ENTITY % cn.qname "%MATHML.pfx;cn" >
+<!ENTITY % codomain.qname "%MATHML.pfx;codomain" >
+<!ENTITY % complexes.qname "%MATHML.pfx;complexes" >
+<!ENTITY % compose.qname "%MATHML.pfx;compose" >
+<!ENTITY % condition.qname "%MATHML.pfx;condition" >
+<!ENTITY % conjugate.qname "%MATHML.pfx;conjugate" >
+<!ENTITY % cos.qname "%MATHML.pfx;cos" >
+<!ENTITY % cosh.qname "%MATHML.pfx;cosh" >
+<!ENTITY % cot.qname "%MATHML.pfx;cot" >
+<!ENTITY % coth.qname "%MATHML.pfx;coth" >
+<!ENTITY % cs.qname "%MATHML.pfx;cs" >
+<!ENTITY % csc.qname "%MATHML.pfx;csc" >
+<!ENTITY % csch.qname "%MATHML.pfx;csch" >
+<!ENTITY % csymbol.qname "%MATHML.pfx;csymbol" >
+<!ENTITY % curl.qname "%MATHML.pfx;curl" >
+<!ENTITY % declare.qname "%MATHML.pfx;declare" >
+<!ENTITY % degree.qname "%MATHML.pfx;degree" >
+<!ENTITY % determinant.qname "%MATHML.pfx;determinant" >
+<!ENTITY % diff.qname "%MATHML.pfx;diff" >
+<!ENTITY % divergence.qname "%MATHML.pfx;divergence" >
+<!ENTITY % divide.qname "%MATHML.pfx;divide" >
+<!ENTITY % domain.qname "%MATHML.pfx;domain" >
+<!ENTITY % domainofapplication.qname "%MATHML.pfx;domainofapplication" >
+<!ENTITY % emptyset.qname "%MATHML.pfx;emptyset" >
+<!ENTITY % eq.qname "%MATHML.pfx;eq" >
+<!ENTITY % equivalent.qname "%MATHML.pfx;equivalent" >
+<!ENTITY % eulergamma.qname "%MATHML.pfx;eulergamma" >
+<!ENTITY % exists.qname "%MATHML.pfx;exists" >
+<!ENTITY % exp.qname "%MATHML.pfx;exp" >
+<!ENTITY % exponentiale.qname "%MATHML.pfx;exponentiale" >
+<!ENTITY % factorial.qname "%MATHML.pfx;factorial" >
+<!ENTITY % factorof.qname "%MATHML.pfx;factorof" >
+<!ENTITY % false.qname "%MATHML.pfx;false" >
+<!ENTITY % floor.qname "%MATHML.pfx;floor" >
+<!ENTITY % fn.qname "%MATHML.pfx;fn" >
+<!ENTITY % forall.qname "%MATHML.pfx;forall" >
+<!ENTITY % gcd.qname "%MATHML.pfx;gcd" >
+<!ENTITY % geq.qname "%MATHML.pfx;geq" >
+<!ENTITY % grad.qname "%MATHML.pfx;grad" >
+<!ENTITY % gt.qname "%MATHML.pfx;gt" >
+<!ENTITY % ident.qname "%MATHML.pfx;ident" >
+<!ENTITY % image.qname "%MATHML.pfx;image" >
+<!ENTITY % imaginary.qname "%MATHML.pfx;imaginary" >
+<!ENTITY % imaginaryi.qname "%MATHML.pfx;imaginaryi" >
+<!ENTITY % implies.qname "%MATHML.pfx;implies" >
+<!ENTITY % in.qname "%MATHML.pfx;in" >
+<!ENTITY % infinity.qname "%MATHML.pfx;infinity" >
+<!ENTITY % int.qname "%MATHML.pfx;int" >
+<!ENTITY % integers.qname "%MATHML.pfx;integers" >
+<!ENTITY % intersect.qname "%MATHML.pfx;intersect" >
+<!ENTITY % interval.qname "%MATHML.pfx;interval" >
+<!ENTITY % inverse.qname "%MATHML.pfx;inverse" >
+<!ENTITY % lambda.qname "%MATHML.pfx;lambda" >
+<!ENTITY % laplacian.qname "%MATHML.pfx;laplacian" >
+<!ENTITY % lcm.qname "%MATHML.pfx;lcm" >
+<!ENTITY % leq.qname "%MATHML.pfx;leq" >
+<!ENTITY % limit.qname "%MATHML.pfx;limit" >
+<!ENTITY % list.qname "%MATHML.pfx;list" >
+<!ENTITY % ln.qname "%MATHML.pfx;ln" >
+<!ENTITY % log.qname "%MATHML.pfx;log" >
+<!ENTITY % logbase.qname "%MATHML.pfx;logbase" >
+<!ENTITY % lowlimit.qname "%MATHML.pfx;lowlimit" >
+<!ENTITY % lt.qname "%MATHML.pfx;lt" >
+<!ENTITY % maction.qname "%MATHML.pfx;maction" >
+<!ENTITY % maligngroup.qname "%MATHML.pfx;maligngroup" >
+<!ENTITY % malignmark.qname "%MATHML.pfx;malignmark" >
+<!ENTITY % math.qname "%MATHML.pfx;math" >
+<!ENTITY % matrix.qname "%MATHML.pfx;matrix" >
+<!ENTITY % matrixrow.qname "%MATHML.pfx;matrixrow" >
+<!ENTITY % max.qname "%MATHML.pfx;max" >
+<!ENTITY % mean.qname "%MATHML.pfx;mean" >
+<!ENTITY % median.qname "%MATHML.pfx;median" >
+<!ENTITY % menclose.qname "%MATHML.pfx;menclose" >
+<!ENTITY % merror.qname "%MATHML.pfx;merror" >
+<!ENTITY % mfenced.qname "%MATHML.pfx;mfenced" >
+<!ENTITY % mfrac.qname "%MATHML.pfx;mfrac" >
+<!ENTITY % mglyph.qname "%MATHML.pfx;mglyph" >
+<!ENTITY % mi.qname "%MATHML.pfx;mi" >
+<!ENTITY % min.qname "%MATHML.pfx;min" >
+<!ENTITY % minus.qname "%MATHML.pfx;minus" >
+<!ENTITY % mlabeledtr.qname "%MATHML.pfx;mlabeledtr" >
+<!ENTITY % mlongdiv.qname "%MATHML.pfx;mlongdiv" >
+<!ENTITY % mmultiscripts.qname "%MATHML.pfx;mmultiscripts" >
+<!ENTITY % mn.qname "%MATHML.pfx;mn" >
+<!ENTITY % mo.qname "%MATHML.pfx;mo" >
+<!ENTITY % mode.qname "%MATHML.pfx;mode" >
+<!ENTITY % moment.qname "%MATHML.pfx;moment" >
+<!ENTITY % momentabout.qname "%MATHML.pfx;momentabout" >
+<!ENTITY % mover.qname "%MATHML.pfx;mover" >
+<!ENTITY % mpadded.qname "%MATHML.pfx;mpadded" >
+<!ENTITY % mphantom.qname "%MATHML.pfx;mphantom" >
+<!ENTITY % mprescripts.qname "%MATHML.pfx;mprescripts" >
+<!ENTITY % mroot.qname "%MATHML.pfx;mroot" >
+<!ENTITY % mrow.qname "%MATHML.pfx;mrow" >
+<!ENTITY % ms.qname "%MATHML.pfx;ms" >
+<!ENTITY % mscarries.qname "%MATHML.pfx;mscarries" >
+<!ENTITY % mscarry.qname "%MATHML.pfx;mscarry" >
+<!ENTITY % msgroup.qname "%MATHML.pfx;msgroup" >
+<!ENTITY % msline.qname "%MATHML.pfx;msline" >
+<!ENTITY % mspace.qname "%MATHML.pfx;mspace" >
+<!ENTITY % msqrt.qname "%MATHML.pfx;msqrt" >
+<!ENTITY % msrow.qname "%MATHML.pfx;msrow" >
+<!ENTITY % mstack.qname "%MATHML.pfx;mstack" >
+<!ENTITY % mstyle.qname "%MATHML.pfx;mstyle" >
+<!ENTITY % msub.qname "%MATHML.pfx;msub" >
+<!ENTITY % msubsup.qname "%MATHML.pfx;msubsup" >
+<!ENTITY % msup.qname "%MATHML.pfx;msup" >
+<!ENTITY % mtable.qname "%MATHML.pfx;mtable" >
+<!ENTITY % mtd.qname "%MATHML.pfx;mtd" >
+<!ENTITY % mtext.qname "%MATHML.pfx;mtext" >
+<!ENTITY % mtr.qname "%MATHML.pfx;mtr" >
+<!ENTITY % munder.qname "%MATHML.pfx;munder" >
+<!ENTITY % munderover.qname "%MATHML.pfx;munderover" >
+<!ENTITY % naturalnumbers.qname "%MATHML.pfx;naturalnumbers" >
+<!ENTITY % neq.qname "%MATHML.pfx;neq" >
+<!ENTITY % none.qname "%MATHML.pfx;none" >
+<!ENTITY % not.qname "%MATHML.pfx;not" >
+<!ENTITY % notanumber.qname "%MATHML.pfx;notanumber" >
+<!ENTITY % notin.qname "%MATHML.pfx;notin" >
+<!ENTITY % notprsubset.qname "%MATHML.pfx;notprsubset" >
+<!ENTITY % notsubset.qname "%MATHML.pfx;notsubset" >
+<!ENTITY % or.qname "%MATHML.pfx;or" >
+<!ENTITY % otherwise.qname "%MATHML.pfx;otherwise" >
+<!ENTITY % outerproduct.qname "%MATHML.pfx;outerproduct" >
+<!ENTITY % partialdiff.qname "%MATHML.pfx;partialdiff" >
+<!ENTITY % pi.qname "%MATHML.pfx;pi" >
+<!ENTITY % piece.qname "%MATHML.pfx;piece" >
+<!ENTITY % piecewise.qname "%MATHML.pfx;piecewise" >
+<!ENTITY % plus.qname "%MATHML.pfx;plus" >
+<!ENTITY % power.qname "%MATHML.pfx;power" >
+<!ENTITY % primes.qname "%MATHML.pfx;primes" >
+<!ENTITY % product.qname "%MATHML.pfx;product" >
+<!ENTITY % prsubset.qname "%MATHML.pfx;prsubset" >
+<!ENTITY % quotient.qname "%MATHML.pfx;quotient" >
+<!ENTITY % rationals.qname "%MATHML.pfx;rationals" >
+<!ENTITY % real.qname "%MATHML.pfx;real" >
+<!ENTITY % reals.qname "%MATHML.pfx;reals" >
+<!ENTITY % reln.qname "%MATHML.pfx;reln" >
+<!ENTITY % rem.qname "%MATHML.pfx;rem" >
+<!ENTITY % root.qname "%MATHML.pfx;root" >
+<!ENTITY % scalarproduct.qname "%MATHML.pfx;scalarproduct" >
+<!ENTITY % sdev.qname "%MATHML.pfx;sdev" >
+<!ENTITY % sec.qname "%MATHML.pfx;sec" >
+<!ENTITY % sech.qname "%MATHML.pfx;sech" >
+<!ENTITY % selector.qname "%MATHML.pfx;selector" >
+<!ENTITY % semantics.qname "%MATHML.pfx;semantics" >
+<!ENTITY % sep.qname "%MATHML.pfx;sep" >
+<!ENTITY % set.qname "%MATHML.pfx;set" >
+<!ENTITY % setdiff.qname "%MATHML.pfx;setdiff" >
+<!ENTITY % share.qname "%MATHML.pfx;share" >
+<!ENTITY % sin.qname "%MATHML.pfx;sin" >
+<!ENTITY % sinh.qname "%MATHML.pfx;sinh" >
+<!ENTITY % subset.qname "%MATHML.pfx;subset" >
+<!ENTITY % sum.qname "%MATHML.pfx;sum" >
+<!ENTITY % tan.qname "%MATHML.pfx;tan" >
+<!ENTITY % tanh.qname "%MATHML.pfx;tanh" >
+<!ENTITY % tendsto.qname "%MATHML.pfx;tendsto" >
+<!ENTITY % times.qname "%MATHML.pfx;times" >
+<!ENTITY % transpose.qname "%MATHML.pfx;transpose" >
+<!ENTITY % true.qname "%MATHML.pfx;true" >
+<!ENTITY % union.qname "%MATHML.pfx;union" >
+<!ENTITY % uplimit.qname "%MATHML.pfx;uplimit" >
+<!ENTITY % variance.qname "%MATHML.pfx;variance" >
+<!ENTITY % vector.qname "%MATHML.pfx;vector" >
+<!ENTITY % vectorproduct.qname "%MATHML.pfx;vectorproduct" >
+<!ENTITY % xor.qname "%MATHML.pfx;xor" >

--- a/cnxml/xml/mathml/schema/dtd/3.0/mathml3.dtd
+++ b/cnxml/xml/mathml/schema/dtd/3.0/mathml3.dtd
@@ -1,0 +1,1632 @@
+
+<!-- MathML 3.0 DTD  ....................................................... -->
+<!-- file: mathml3.dtd
+-->
+
+<!-- MathML 3.0 DTD
+
+     This is the Mathematical Markup Language (MathML) 3.0, an XML
+     application for describing mathematical notation and capturing
+     both its structure and content.
+
+     Copyright &#xa9; 1998-2014 W3C&#xae; (MIT, ERCIM, Keio, Beihang), All Rights 
+     Reserved. W3C liability, trademark, document use and software
+     licensing rules apply. 
+
+     Permission to use, copy, modify and distribute the MathML 3.0 DTD and
+     its accompanying documentation for any purpose and without fee is
+     hereby granted in perpetuity, provided that the above copyright notice
+     and this paragraph appear in all copies.  The copyright holders make
+     no representation about the suitability of the DTD for any purpose.
+
+     It is provided "as is" without expressed or implied warranty.
+
+     This entity may be identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//DTD MathML 3.0//EN"
+       SYSTEM "mathml3.dtd"
+
+-->
+
+<!-- MathML Qualified Names module ............................... -->
+<!ENTITY % mathml-qname.module "INCLUDE" >
+<![%mathml-qname.module;[
+<!ENTITY % mathml-qname.mod
+     PUBLIC "-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN"
+            "mathml3-qname.mod" >
+%mathml-qname.mod;]]>
+
+<!-- if %NS.prefixed; is INCLUDE, include all NS attributes, 
+     otherwise just those associated with MathML
+-->
+<![%NS.prefixed;[
+  <!ENTITY % MATHML.NamespaceDecl.attrib 
+         "%NamespaceDecl.attrib;"
+>
+]]>
+<!ENTITY % MATHML.NamespaceDecl.attrib 
+     "%MATHML.xmlns.attrib;"
+>
+
+
+<!-- MathML Character Entities .............................................. -->
+<!ENTITY % mathml-charent.module "INCLUDE" >
+<![%mathml-charent.module;[
+
+<!ENTITY % htmlmathmlent PUBLIC "-//W3C//ENTITIES HTML MathML Set//EN//XML" "htmlmathml-f.ent">
+%htmlmathmlent;
+
+<!-- end of MathML Character Entity section -->]]>
+
+<!-- MathML3 DTD makes id type CDATA (so ids can be repeated in different
+     MathML expressions in the same document).
+     These parameter entities may be declared to be ID and IDREF respectively
+     before including this DTD to match the MathML2 DTD.
+-->
+<!ENTITY % MMLIDTYPE "CDATA">
+<!ENTITY % MMLIDREFTYPE "CDATA">
+
+
+<!ENTITY % MalignExpression "%maligngroup.qname;|%malignmark.qname;">
+
+<!ENTITY % TokenExpression "%mi.qname;|%mn.qname;|%mo.qname;|%mtext.qname;
+                            |%mspace.qname;|%ms.qname;">
+
+<!ENTITY % PresentationExpression "%TokenExpression;|%MalignExpression;
+                                   |%mrow.qname;|%mfrac.qname;|%msqrt.qname;
+                                   |%mroot.qname;|%mstyle.qname;
+                                   |%merror.qname;|%mpadded.qname;
+                                   |%mphantom.qname;|%mfenced.qname;
+                                   |%menclose.qname;|%msub.qname;|%msup.qname;
+                                   |%msubsup.qname;|%munder.qname;
+                                   |%mover.qname;|%munderover.qname;
+                                   |%mmultiscripts.qname;|%mtable.qname;
+                                   |%mstack.qname;|%mlongdiv.qname;
+                                   |%maction.qname;">
+
+<!-- end of mathml3-strict-content.rng -->
+
+<!ENTITY % cn.content "(#PCDATA|%mglyph.qname;|%sep.qname;
+                        |%PresentationExpression;)*">
+
+<!-- start of mathml3-content.rng -->
+
+<!-- start of mathml3-strict-content.rng -->
+
+<!ELEMENT %cn.qname; %cn.content;>
+
+<!ENTITY % ci.content "(#PCDATA|%mglyph.qname;
+                        |%PresentationExpression;)*">
+
+<!ELEMENT %ci.qname; %ci.content;>
+
+<!ENTITY % csymbol.content "(#PCDATA|%mglyph.qname;
+                             |%PresentationExpression;)*">
+
+<!ELEMENT %csymbol.qname; %csymbol.content;>
+
+<!ENTITY % SymbolName "#PCDATA">
+
+<!ENTITY % BvarQ "(%bvar.qname;)*">
+
+<!ENTITY % DomainQ "(%domainofapplication.qname;|%condition.qname;
+                     |(%lowlimit.qname;,%uplimit.qname;?))*">
+
+<!ENTITY % constant-arith.mmlclass "%exponentiale.qname;|%imaginaryi.qname;
+                                 |%notanumber.qname;|%true.qname;
+                                 |%false.qname;|%pi.qname;|%eulergamma.qname;
+                                 |%infinity.qname;">
+
+<!ENTITY % constant-set.mmlclass "%integers.qname;|%reals.qname;
+                               |%rationals.qname;|%naturalnumbers.qname;
+                               |%complexes.qname;|%primes.qname;
+                               |%emptyset.qname;">
+
+<!ENTITY % binary-linalg.mmlclass "%vectorproduct.qname;|%scalarproduct.qname;
+                                |%outerproduct.qname;">
+
+<!ENTITY % nary-linalg.mmlclass "%selector.qname;">
+
+<!ENTITY % unary-linalg.mmlclass "%determinant.qname;|%transpose.qname;">
+
+<!ENTITY % nary-constructor.mmlclass "%vector.qname;|%matrix.qname;
+                                   |%matrixrow.qname;">
+
+<!ENTITY % nary-stats.mmlclass "%mean.qname;|%sdev.qname;|%variance.qname;
+                             |%median.qname;|%mode.qname;">
+
+<!ENTITY % unary-elementary.mmlclass "%sin.qname;|%cos.qname;|%tan.qname;
+                                   |%sec.qname;|%csc.qname;|%cot.qname;
+                                   |%sinh.qname;|%cosh.qname;|%tanh.qname;
+                                   |%sech.qname;|%csch.qname;|%coth.qname;
+                                   |%arcsin.qname;|%arccos.qname;
+                                   |%arctan.qname;|%arccosh.qname;
+                                   |%arccot.qname;|%arccoth.qname;
+                                   |%arccsc.qname;|%arccsch.qname;
+                                   |%arcsec.qname;|%arcsech.qname;
+                                   |%arcsinh.qname;|%arctanh.qname;">
+
+<!ENTITY % limit.mmlclass "%limit.qname;">
+
+<!ENTITY % product.mmlclass "%product.qname;">
+
+<!ENTITY % sum.mmlclass "%sum.qname;">
+
+<!ENTITY % unary-set.mmlclass "%card.qname;">
+
+<!ENTITY % nary-set-reln.mmlclass "%subset.qname;|%prsubset.qname;">
+
+<!ENTITY % binary-set.mmlclass "%in.qname;|%notin.qname;|%notsubset.qname;
+                             |%notprsubset.qname;|%setdiff.qname;">
+
+<!ENTITY % nary-set.mmlclass "%union.qname;|%intersect.qname;
+                           |%cartesianproduct.qname;">
+
+<!ENTITY % nary-setlist-constructor.mmlclass "%set.qname;|%list.qname;">
+
+<!ENTITY % unary-veccalc.mmlclass "%divergence.qname;|%grad.qname;|%curl.qname;
+                                |%laplacian.qname;">
+
+<!ENTITY % partialdiff.mmlclass "%partialdiff.qname;">
+
+<!ENTITY % Differential-Operator.mmlclass "%diff.qname;">
+
+<!ENTITY % int.mmlclass "%int.qname;">
+
+<!ENTITY % binary-reln.mmlclass "%neq.qname;|%approx.qname;|%factorof.qname;
+                              |%tendsto.qname;">
+
+<!ENTITY % nary-reln.mmlclass "%eq.qname;|%gt.qname;|%lt.qname;|%geq.qname;
+                            |%leq.qname;">
+
+<!ENTITY % quantifier.mmlclass "%forall.qname;|%exists.qname;">
+
+<!ENTITY % binary-logical.mmlclass "%implies.qname;|%equivalent.qname;">
+
+<!ENTITY % unary-logical.mmlclass "%not.qname;">
+
+<!ENTITY % nary-logical.mmlclass "%and.qname;|%or.qname;|%xor.qname;">
+
+<!ENTITY % nary-arith.mmlclass "%plus.qname;|%times.qname;|%gcd.qname;
+                             |%lcm.qname;">
+
+<!ENTITY % nary-minmax.mmlclass "%max.qname;|%min.qname;">
+
+<!ENTITY % unary-arith.mmlclass "%factorial.qname;|%abs.qname;|%conjugate.qname;
+                              |%arg.qname;|%real.qname;|%imaginary.qname;
+                              |%floor.qname;|%ceiling.qname;|%exp.qname;">
+
+<!ENTITY % binary-arith.mmlclass "%quotient.qname;|%divide.qname;|%minus.qname;
+                               |%power.qname;|%rem.qname;|%root.qname;">
+
+<!ENTITY % nary-functional.mmlclass "%compose.qname;">
+
+<!ENTITY % lambda.mmlclass "%lambda.qname;">
+
+<!ENTITY % unary-functional.mmlclass "%inverse.qname;|%ident.qname;
+                                   |%domain.qname;|%codomain.qname;
+                                   |%image.qname;|%ln.qname;|%log.qname;
+                                   |%moment.qname;">
+
+<!ENTITY % interval.mmlclass "%interval.qname;">
+
+<!ENTITY % DeprecatedContExp "%reln.qname;|%fn.qname;|%declare.qname;">
+
+<!ENTITY % CommonDeprecatedAtt "
+  other CDATA #IMPLIED">
+
+<!ENTITY % Qualifier "(%DomainQ;)|%degree.qname;|%momentabout.qname;
+                      |%logbase.qname;">
+
+<!ENTITY % ContExp "%piecewise.qname;|%DeprecatedContExp;|%interval.mmlclass;
+                    |%unary-functional.mmlclass;|%lambda.mmlclass;
+                    |%nary-functional.mmlclass;|%binary-arith.mmlclass;
+                    |%unary-arith.mmlclass;|%nary-minmax.mmlclass;
+                    |%nary-arith.mmlclass;|%nary-logical.mmlclass;
+                    |%unary-logical.mmlclass;|%binary-logical.mmlclass;
+                    |%quantifier.mmlclass;|%nary-reln.mmlclass;
+                    |%binary-reln.mmlclass;|%int.mmlclass;
+                    |%Differential-Operator.mmlclass;|%partialdiff.mmlclass;
+                    |%unary-veccalc.mmlclass;
+                    |%nary-setlist-constructor.mmlclass;|%nary-set.mmlclass;
+                    |%binary-set.mmlclass;|%nary-set-reln.mmlclass;
+                    |%unary-set.mmlclass;|%sum.mmlclass;|%product.mmlclass;
+                    |%limit.mmlclass;|%unary-elementary.mmlclass;
+                    |%nary-stats.mmlclass;|%nary-constructor.mmlclass;
+                    |%unary-linalg.mmlclass;|%nary-linalg.mmlclass;
+                    |%binary-linalg.mmlclass;|%constant-set.mmlclass;
+                    |%constant-arith.mmlclass;|%semantics.qname;|%cn.qname;
+                    |%ci.qname;|%csymbol.qname;|%apply.qname;|%bind.qname;
+                    |%share.qname;|%cerror.qname;|%cbytes.qname;|%cs.qname;">
+
+<!ENTITY % CommonAtt "
+  %MATHML.NamespaceDecl.attrib;
+  %XLINK.prefix;:href CDATA #IMPLIED
+  %XLINK.prefix;:type CDATA #IMPLIED
+  xml:lang CDATA #IMPLIED
+  xml:space (default|preserve) #IMPLIED
+  id %MMLIDTYPE; #IMPLIED
+  xref %MMLIDREFTYPE; #IMPLIED
+  class CDATA #IMPLIED
+  style CDATA #IMPLIED
+  href CDATA #IMPLIED
+  %CommonDeprecatedAtt;">
+
+<!ENTITY % apply.content "(%ContExp;),(%BvarQ;),(%Qualifier;)*,
+                          (%ContExp;)*">
+
+<!ELEMENT %apply.qname; (%apply.content;)>
+<!ATTLIST %apply.qname;
+  %CommonAtt;>
+
+<!ENTITY % bind.content "%apply.content;">
+
+<!ELEMENT %bind.qname; (%bind.content;)>
+<!ATTLIST %bind.qname;
+  %CommonAtt;>
+
+<!ENTITY % src "
+  src CDATA #IMPLIED">
+
+<!ELEMENT %share.qname; EMPTY>
+<!ATTLIST %share.qname;
+  %CommonAtt;
+  %src;>
+
+<!ELEMENT %cerror.qname; (%csymbol.qname;,(%ContExp;)*)>
+
+<!ATTLIST %cerror.qname;
+  %CommonAtt;>
+
+<!ELEMENT %cbytes.qname; (#PCDATA)>
+
+<!ENTITY % base64 "CDATA">
+
+<!ELEMENT %cs.qname; (#PCDATA)>
+
+<!ENTITY % DefEncAtt "
+  encoding CDATA #IMPLIED
+  definitionURL CDATA #IMPLIED">
+
+<!ATTLIST %cn.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED
+  base CDATA #IMPLIED>
+
+<!ATTLIST %ci.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED>
+
+<!ENTITY % ci.type "
+  type CDATA #REQUIRED">
+
+<!ATTLIST %csymbol.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED
+  cd CDATA #IMPLIED>
+
+<!ELEMENT %bvar.qname; ((%degree.qname;,(%ci.qname;|%semantics.qname;))
+                      |((%ci.qname;|%semantics.qname;),(%degree.qname;)?))>
+<!ATTLIST %bvar.qname;
+  %CommonAtt;>
+
+<!ATTLIST %cbytes.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ATTLIST %cs.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ENTITY % base "
+  base CDATA #REQUIRED">
+
+<!ELEMENT %sep.qname; EMPTY>
+
+<!ELEMENT %domainofapplication.qname; (%ContExp;)>
+
+<!ELEMENT %condition.qname; (%ContExp;)>
+
+<!ELEMENT %uplimit.qname; (%ContExp;)>
+
+<!ELEMENT %lowlimit.qname; (%ContExp;)>
+
+<!ELEMENT %degree.qname; (%ContExp;)>
+
+<!ELEMENT %momentabout.qname; (%ContExp;)>
+
+<!ELEMENT %logbase.qname; (%ContExp;)>
+
+<!ENTITY % type "
+  type CDATA #REQUIRED">
+
+<!ENTITY % order "
+  order (numeric|lexicographic) #REQUIRED">
+
+<!ENTITY % closure "
+  closure CDATA #REQUIRED">
+
+<!ELEMENT %piecewise.qname; (%piece.qname;|%otherwise.qname;)*>
+<!ATTLIST %piecewise.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %piece.qname; ((%ContExp;),(%ContExp;))>
+<!ATTLIST %piece.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %otherwise.qname; (%ContExp;)>
+<!ATTLIST %otherwise.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %reln.qname; (%ContExp;)*>
+
+<!ELEMENT %fn.qname; (%ContExp;)>
+
+<!ELEMENT %declare.qname; (%ContExp;)+>
+<!ATTLIST %declare.qname;
+  type CDATA #IMPLIED
+  scope CDATA #IMPLIED
+  nargs CDATA #IMPLIED
+  occurrence (prefix|infix|function-model) #IMPLIED
+  %DefEncAtt;>
+
+<!ELEMENT %interval.qname; ((%ContExp;),(%ContExp;))>
+<!ATTLIST %interval.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  closure CDATA #IMPLIED>
+
+<!ELEMENT %inverse.qname; EMPTY>
+<!ATTLIST %inverse.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %ident.qname; EMPTY>
+<!ATTLIST %ident.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %domain.qname; EMPTY>
+<!ATTLIST %domain.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %codomain.qname; EMPTY>
+<!ATTLIST %codomain.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %image.qname; EMPTY>
+<!ATTLIST %image.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %ln.qname; EMPTY>
+<!ATTLIST %ln.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %log.qname; EMPTY>
+<!ATTLIST %log.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %moment.qname; EMPTY>
+<!ATTLIST %moment.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %lambda.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;))>
+<!ATTLIST %lambda.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %compose.qname; EMPTY>
+<!ATTLIST %compose.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %quotient.qname; EMPTY>
+<!ATTLIST %quotient.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %divide.qname; EMPTY>
+<!ATTLIST %divide.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %minus.qname; EMPTY>
+<!ATTLIST %minus.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %power.qname; EMPTY>
+<!ATTLIST %power.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %rem.qname; EMPTY>
+<!ATTLIST %rem.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %root.qname; EMPTY>
+<!ATTLIST %root.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %factorial.qname; EMPTY>
+<!ATTLIST %factorial.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %abs.qname; EMPTY>
+<!ATTLIST %abs.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %conjugate.qname; EMPTY>
+<!ATTLIST %conjugate.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arg.qname; EMPTY>
+<!ATTLIST %arg.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %real.qname; EMPTY>
+<!ATTLIST %real.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %imaginary.qname; EMPTY>
+<!ATTLIST %imaginary.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %floor.qname; EMPTY>
+<!ATTLIST %floor.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %ceiling.qname; EMPTY>
+<!ATTLIST %ceiling.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %exp.qname; EMPTY>
+<!ATTLIST %exp.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %max.qname; EMPTY>
+<!ATTLIST %max.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %min.qname; EMPTY>
+<!ATTLIST %min.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %plus.qname; EMPTY>
+<!ATTLIST %plus.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %times.qname; EMPTY>
+<!ATTLIST %times.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %gcd.qname; EMPTY>
+<!ATTLIST %gcd.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %lcm.qname; EMPTY>
+<!ATTLIST %lcm.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %and.qname; EMPTY>
+<!ATTLIST %and.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %or.qname; EMPTY>
+<!ATTLIST %or.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %xor.qname; EMPTY>
+<!ATTLIST %xor.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %not.qname; EMPTY>
+<!ATTLIST %not.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %implies.qname; EMPTY>
+<!ATTLIST %implies.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %equivalent.qname; EMPTY>
+<!ATTLIST %equivalent.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %forall.qname; EMPTY>
+<!ATTLIST %forall.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %exists.qname; EMPTY>
+<!ATTLIST %exists.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %eq.qname; EMPTY>
+<!ATTLIST %eq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %gt.qname; EMPTY>
+<!ATTLIST %gt.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %lt.qname; EMPTY>
+<!ATTLIST %lt.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %geq.qname; EMPTY>
+<!ATTLIST %geq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %leq.qname; EMPTY>
+<!ATTLIST %leq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %neq.qname; EMPTY>
+<!ATTLIST %neq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %approx.qname; EMPTY>
+<!ATTLIST %approx.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %factorof.qname; EMPTY>
+<!ATTLIST %factorof.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %tendsto.qname; EMPTY>
+<!ATTLIST %tendsto.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED>
+
+<!ELEMENT %int.qname; EMPTY>
+<!ATTLIST %int.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %diff.qname; EMPTY>
+<!ATTLIST %diff.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %partialdiff.qname; EMPTY>
+<!ATTLIST %partialdiff.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %divergence.qname; EMPTY>
+<!ATTLIST %divergence.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %grad.qname; EMPTY>
+<!ATTLIST %grad.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %curl.qname; EMPTY>
+<!ATTLIST %curl.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %laplacian.qname; EMPTY>
+<!ATTLIST %laplacian.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %set.qname; ((%BvarQ;)*,(%DomainQ;)*,(%ContExp;)*)>
+<!ATTLIST %set.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED>
+
+<!ELEMENT %list.qname; ((%BvarQ;)*,(%DomainQ;)*,(%ContExp;)*)>
+<!ATTLIST %list.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  order (numeric|lexicographic) #IMPLIED>
+
+<!ELEMENT %union.qname; EMPTY>
+<!ATTLIST %union.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %intersect.qname; EMPTY>
+<!ATTLIST %intersect.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cartesianproduct.qname; EMPTY>
+<!ATTLIST %cartesianproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %in.qname; EMPTY>
+<!ATTLIST %in.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notin.qname; EMPTY>
+<!ATTLIST %notin.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notsubset.qname; EMPTY>
+<!ATTLIST %notsubset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notprsubset.qname; EMPTY>
+<!ATTLIST %notprsubset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %setdiff.qname; EMPTY>
+<!ATTLIST %setdiff.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %subset.qname; EMPTY>
+<!ATTLIST %subset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %prsubset.qname; EMPTY>
+<!ATTLIST %prsubset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %card.qname; EMPTY>
+<!ATTLIST %card.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sum.qname; EMPTY>
+<!ATTLIST %sum.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %product.qname; EMPTY>
+<!ATTLIST %product.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %limit.qname; EMPTY>
+<!ATTLIST %limit.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sin.qname; EMPTY>
+<!ATTLIST %sin.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cos.qname; EMPTY>
+<!ATTLIST %cos.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %tan.qname; EMPTY>
+<!ATTLIST %tan.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sec.qname; EMPTY>
+<!ATTLIST %sec.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %csc.qname; EMPTY>
+<!ATTLIST %csc.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cot.qname; EMPTY>
+<!ATTLIST %cot.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sinh.qname; EMPTY>
+<!ATTLIST %sinh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cosh.qname; EMPTY>
+<!ATTLIST %cosh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %tanh.qname; EMPTY>
+<!ATTLIST %tanh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sech.qname; EMPTY>
+<!ATTLIST %sech.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %csch.qname; EMPTY>
+<!ATTLIST %csch.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %coth.qname; EMPTY>
+<!ATTLIST %coth.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsin.qname; EMPTY>
+<!ATTLIST %arcsin.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccos.qname; EMPTY>
+<!ATTLIST %arccos.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arctan.qname; EMPTY>
+<!ATTLIST %arctan.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccosh.qname; EMPTY>
+<!ATTLIST %arccosh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccot.qname; EMPTY>
+<!ATTLIST %arccot.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccoth.qname; EMPTY>
+<!ATTLIST %arccoth.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccsc.qname; EMPTY>
+<!ATTLIST %arccsc.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccsch.qname; EMPTY>
+<!ATTLIST %arccsch.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsec.qname; EMPTY>
+<!ATTLIST %arcsec.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsech.qname; EMPTY>
+<!ATTLIST %arcsech.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsinh.qname; EMPTY>
+<!ATTLIST %arcsinh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arctanh.qname; EMPTY>
+<!ATTLIST %arctanh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %mean.qname; EMPTY>
+<!ATTLIST %mean.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sdev.qname; EMPTY>
+<!ATTLIST %sdev.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %variance.qname; EMPTY>
+<!ATTLIST %variance.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %median.qname; EMPTY>
+<!ATTLIST %median.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %mode.qname; EMPTY>
+<!ATTLIST %mode.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %vector.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;)*)>
+<!ATTLIST %vector.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %matrix.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;)*)>
+<!ATTLIST %matrix.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %matrixrow.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;)*)>
+<!ATTLIST %matrixrow.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %determinant.qname; EMPTY>
+<!ATTLIST %determinant.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %transpose.qname; EMPTY>
+<!ATTLIST %transpose.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %selector.qname; EMPTY>
+<!ATTLIST %selector.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %vectorproduct.qname; EMPTY>
+<!ATTLIST %vectorproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %scalarproduct.qname; EMPTY>
+<!ATTLIST %scalarproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %outerproduct.qname; EMPTY>
+<!ATTLIST %outerproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %integers.qname; EMPTY>
+<!ATTLIST %integers.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %reals.qname; EMPTY>
+<!ATTLIST %reals.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %rationals.qname; EMPTY>
+<!ATTLIST %rationals.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %naturalnumbers.qname; EMPTY>
+<!ATTLIST %naturalnumbers.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %complexes.qname; EMPTY>
+<!ATTLIST %complexes.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %primes.qname; EMPTY>
+<!ATTLIST %primes.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %emptyset.qname; EMPTY>
+<!ATTLIST %emptyset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %exponentiale.qname; EMPTY>
+<!ATTLIST %exponentiale.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %imaginaryi.qname; EMPTY>
+<!ATTLIST %imaginaryi.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notanumber.qname; EMPTY>
+<!ATTLIST %notanumber.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %true.qname; EMPTY>
+<!ATTLIST %true.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %false.qname; EMPTY>
+<!ATTLIST %false.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %pi.qname; EMPTY>
+<!ATTLIST %pi.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %eulergamma.qname; EMPTY>
+<!ATTLIST %eulergamma.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %infinity.qname; EMPTY>
+<!ATTLIST %infinity.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!-- end of mathml3-common.rng -->
+
+<!ENTITY % MathExpression "%ContExp;|%PresentationExpression;">
+
+<!-- end of mathml3-content.rng -->
+
+<!-- start of mathml3-presentation.rng -->
+
+<!ENTITY % ImpliedMrow "(%MathExpression;)*">
+
+<!ENTITY % TableRowExpression "%mtr.qname;|%mlabeledtr.qname;">
+
+<!ENTITY % TableCellExpression "%mtd.qname;">
+
+<!ENTITY % MstackExpression "%MathExpression;|%mscarries.qname;
+                             |%msline.qname;|%msrow.qname;|%msgroup.qname;">
+
+<!ENTITY % MsrowExpression "%MathExpression;|%none.qname;">
+
+<!ENTITY % MultiScriptExpression "(%MathExpression;|%none.qname;),
+                                  (%MathExpression;|%none.qname;)">
+
+<!ENTITY % mpadded-length "CDATA">
+
+<!ENTITY % linestyle "none|solid|dashed">
+
+<!ENTITY % verticalalign "top|bottom|center|baseline|axis">
+
+<!ENTITY % columnalignstyle "left|center|right">
+
+<!ENTITY % notationstyle "longdiv|actuarial|radical|box|roundedbox
+                          |circle|left|right|top|bottom|updiagonalstrike
+                          |downdiagonalstrike|verticalstrike
+                          |horizontalstrike|madruwb">
+
+<!ENTITY % idref "#PCDATA">
+
+<!ENTITY % unsigned-integer "CDATA">
+
+<!ENTITY % integer "CDATA">
+
+<!ENTITY % number "CDATA">
+
+<!ENTITY % character "CDATA">
+
+<!ENTITY % color "CDATA">
+
+<!ENTITY % group-alignment "left|center|right|decimalpoint">
+
+<!ENTITY % group-alignment-list "#PCDATA">
+
+<!ENTITY % group-alignment-list-list "#PCDATA">
+
+<!ENTITY % positive-integer "CDATA">
+
+<!ENTITY % token.content "#PCDATA|%mglyph.qname;|%malignmark.qname;">
+
+<!ELEMENT %mi.qname; (%token.content;)*>
+
+<!ENTITY % length "CDATA">
+
+<!ENTITY % DeprecatedTokenAtt "
+  fontfamily CDATA #IMPLIED
+  fontweight (normal|bold) #IMPLIED
+  fontstyle (normal|italic) #IMPLIED
+  fontsize %length; #IMPLIED
+  color %color; #IMPLIED
+  background CDATA #IMPLIED">
+
+<!ENTITY % TokenAtt "
+  mathvariant (normal|bold|italic|bold-italic|double-struck|bold-fraktur
+               |script|bold-script|fraktur|sans-serif|bold-sans-serif
+               |sans-serif-italic|sans-serif-bold-italic|monospace
+               |initial|tailed|looped|stretched) #IMPLIED
+  mathsize CDATA #IMPLIED
+  dir (ltr|rtl) #IMPLIED
+  %DeprecatedTokenAtt;">
+
+<!ENTITY % CommonPresAtt "
+  mathcolor %color; #IMPLIED
+  mathbackground CDATA #IMPLIED">
+
+<!ATTLIST %mi.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;>
+
+<!ELEMENT %mn.qname; (%token.content;)*>
+
+<!ATTLIST %mn.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;>
+
+<!ELEMENT %mo.qname; (%token.content;)*>
+
+<!ATTLIST %mo.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;
+  form (prefix|infix|postfix) #IMPLIED
+  fence (true|false) #IMPLIED
+  separator (true|false) #IMPLIED
+  lspace %length; #IMPLIED
+  rspace %length; #IMPLIED
+  stretchy (true|false) #IMPLIED
+  symmetric (true|false) #IMPLIED
+  maxsize CDATA #IMPLIED
+  minsize %length; #IMPLIED
+  largeop (true|false) #IMPLIED
+  movablelimits (true|false) #IMPLIED
+  accent (true|false) #IMPLIED
+  linebreak (auto|newline|nobreak|goodbreak|badbreak) #IMPLIED
+  lineleading %length; #IMPLIED
+  linebreakstyle (before|after|duplicate|infixlinebreakstyle) #IMPLIED
+  linebreakmultchar CDATA #IMPLIED
+  indentalign (left|center|right|auto|id) #IMPLIED
+  indentshift %length; #IMPLIED
+  indenttarget CDATA #IMPLIED
+  indentalignfirst (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshiftfirst CDATA #IMPLIED
+  indentalignlast (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshiftlast CDATA #IMPLIED>
+
+<!ELEMENT %mtext.qname; (%token.content;)*>
+
+<!ATTLIST %mtext.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;>
+
+<!ELEMENT %mspace.qname; EMPTY>
+
+<!ATTLIST %mspace.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;
+  width %length; #IMPLIED
+  height %length; #IMPLIED
+  depth %length; #IMPLIED
+  linebreak (auto|newline|nobreak|goodbreak|badbreak
+             |indentingnewline) #IMPLIED
+  indentalign (left|center|right|auto|id) #IMPLIED
+  indentshift %length; #IMPLIED
+  indenttarget CDATA #IMPLIED
+  indentalignfirst (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshiftfirst CDATA #IMPLIED
+  indentalignlast (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshiftlast CDATA #IMPLIED>
+
+<!ELEMENT %ms.qname; (%token.content;)*>
+
+<!ATTLIST %ms.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;
+  lquote CDATA #IMPLIED
+  rquote CDATA #IMPLIED>
+
+<!ENTITY % mglyph.deprecatedattributes "
+  index %integer; #IMPLIED
+  mathvariant (normal|bold|italic|bold-italic|double-struck|bold-fraktur
+               |script|bold-script|fraktur|sans-serif|bold-sans-serif
+               |sans-serif-italic|sans-serif-bold-italic|monospace
+               |initial|tailed|looped|stretched) #IMPLIED
+  mathsize CDATA #IMPLIED
+  %DeprecatedTokenAtt;">
+
+<!ENTITY % mglyph.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  src CDATA #IMPLIED
+  width %length; #IMPLIED
+  height %length; #IMPLIED
+  valign %length; #IMPLIED
+  alt CDATA #IMPLIED">
+
+<!ELEMENT %mglyph.qname; EMPTY>
+<!ATTLIST %mglyph.qname;
+  %mglyph.attributes;
+  %mglyph.deprecatedattributes;>
+
+<!ELEMENT %msline.qname; EMPTY>
+
+<!ATTLIST %msline.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED
+  length %unsigned-integer; #IMPLIED
+  leftoverhang %length; #IMPLIED
+  rightoverhang %length; #IMPLIED
+  mslinethickness CDATA #IMPLIED>
+
+<!ELEMENT %none.qname; EMPTY>
+
+<!ATTLIST %none.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mprescripts.qname; EMPTY>
+
+<!ATTLIST %mprescripts.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %malignmark.qname; EMPTY>
+
+<!ATTLIST %malignmark.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  edge (left|right) #IMPLIED>
+
+<!ELEMENT %maligngroup.qname; EMPTY>
+
+<!ATTLIST %maligngroup.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  groupalign (left|center|right|decimalpoint) #IMPLIED>
+
+<!ELEMENT %mrow.qname; (%MathExpression;)*>
+
+<!ATTLIST %mrow.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  dir (ltr|rtl) #IMPLIED>
+
+<!ELEMENT %mfrac.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %mfrac.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  linethickness CDATA #IMPLIED
+  numalign (left|center|right) #IMPLIED
+  denomalign (left|center|right) #IMPLIED
+  bevelled (true|false) #IMPLIED>
+
+<!ELEMENT %msqrt.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %msqrt.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mroot.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %mroot.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mstyle.qname; (%ImpliedMrow;)>
+
+<!ENTITY % mstyle.deprecatedattributes "
+  %DeprecatedTokenAtt;
+  veryverythinmathspace %length; #IMPLIED
+  verythinmathspace %length; #IMPLIED
+  thinmathspace %length; #IMPLIED
+  mediummathspace %length; #IMPLIED
+  thickmathspace %length; #IMPLIED
+  verythickmathspace %length; #IMPLIED
+  veryverythickmathspace %length; #IMPLIED">
+
+<!ENTITY % mstyle.generalattributes "
+  accent (true|false) #IMPLIED
+  accentunder (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED
+  alignmentscope CDATA #IMPLIED
+  bevelled (true|false) #IMPLIED
+  charalign (left|center|right) #IMPLIED
+  charspacing CDATA #IMPLIED
+  close CDATA #IMPLIED
+  columnalign CDATA #IMPLIED
+  columnlines CDATA #IMPLIED
+  columnspacing CDATA #IMPLIED
+  columnspan %positive-integer; #IMPLIED
+  columnwidth CDATA #IMPLIED
+  crossout CDATA #IMPLIED
+  denomalign (left|center|right) #IMPLIED
+  depth %length; #IMPLIED
+  dir (ltr|rtl) #IMPLIED
+  edge (left|right) #IMPLIED
+  equalcolumns (true|false) #IMPLIED
+  equalrows (true|false) #IMPLIED
+  fence (true|false) #IMPLIED
+  form (prefix|infix|postfix) #IMPLIED
+  frame (%linestyle;) #IMPLIED
+  framespacing CDATA #IMPLIED
+  groupalign CDATA #IMPLIED
+  height %length; #IMPLIED
+  indentalign (left|center|right|auto|id) #IMPLIED
+  indentalignfirst (left|center|right|auto|id|indentalign) #IMPLIED
+  indentalignlast (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshift %length; #IMPLIED
+  indentshiftfirst CDATA #IMPLIED
+  indentshiftlast CDATA #IMPLIED
+  indenttarget CDATA #IMPLIED
+  largeop (true|false) #IMPLIED
+  leftoverhang %length; #IMPLIED
+  length %unsigned-integer; #IMPLIED
+  linebreak (auto|newline|nobreak|goodbreak|badbreak) #IMPLIED
+  linebreakmultchar CDATA #IMPLIED
+  linebreakstyle (before|after|duplicate|infixlinebreakstyle) #IMPLIED
+  lineleading %length; #IMPLIED
+  linethickness CDATA #IMPLIED
+  location (w|nw|n|ne|e|se|s|sw) #IMPLIED
+  longdivstyle CDATA #IMPLIED
+  lquote CDATA #IMPLIED
+  lspace %length; #IMPLIED
+  mathsize CDATA #IMPLIED
+  mathvariant (normal|bold|italic|bold-italic|double-struck|bold-fraktur
+               |script|bold-script|fraktur|sans-serif|bold-sans-serif
+               |sans-serif-italic|sans-serif-bold-italic|monospace
+               |initial|tailed|looped|stretched) #IMPLIED
+  maxsize CDATA #IMPLIED
+  minlabelspacing %length; #IMPLIED
+  minsize %length; #IMPLIED
+  movablelimits (true|false) #IMPLIED
+  mslinethickness CDATA #IMPLIED
+  notation CDATA #IMPLIED
+  numalign (left|center|right) #IMPLIED
+  open CDATA #IMPLIED
+  position %integer; #IMPLIED
+  rightoverhang %length; #IMPLIED
+  rowalign CDATA #IMPLIED
+  rowlines CDATA #IMPLIED
+  rowspacing CDATA #IMPLIED
+  rowspan %positive-integer; #IMPLIED
+  rquote CDATA #IMPLIED
+  rspace %length; #IMPLIED
+  selection %positive-integer; #IMPLIED
+  separator (true|false) #IMPLIED
+  separators CDATA #IMPLIED
+  shift %integer; #IMPLIED
+  side (left|right|leftoverlap|rightoverlap) #IMPLIED
+  stackalign (left|center|right|decimalpoint) #IMPLIED
+  stretchy (true|false) #IMPLIED
+  subscriptshift %length; #IMPLIED
+  superscriptshift %length; #IMPLIED
+  symmetric (true|false) #IMPLIED
+  valign %length; #IMPLIED
+  width %length; #IMPLIED">
+
+<!ENTITY % mstyle.specificattributes "
+  scriptlevel %integer; #IMPLIED
+  displaystyle (true|false) #IMPLIED
+  scriptsizemultiplier %number; #IMPLIED
+  scriptminsize %length; #IMPLIED
+  infixlinebreakstyle (before|after|duplicate) #IMPLIED
+  decimalpoint %character; #IMPLIED">
+
+<!ATTLIST %mstyle.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %mstyle.specificattributes;
+  %mstyle.generalattributes;
+  %mstyle.deprecatedattributes;>
+
+<!ELEMENT %merror.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %merror.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mpadded.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %mpadded.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  height %mpadded-length; #IMPLIED
+  depth %mpadded-length; #IMPLIED
+  width %mpadded-length; #IMPLIED
+  lspace %mpadded-length; #IMPLIED
+  voffset %mpadded-length; #IMPLIED>
+
+<!ELEMENT %mphantom.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %mphantom.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mfenced.qname; (%MathExpression;)*>
+
+<!ATTLIST %mfenced.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  open CDATA #IMPLIED
+  close CDATA #IMPLIED
+  separators CDATA #IMPLIED>
+
+<!ELEMENT %menclose.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %menclose.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  notation CDATA #IMPLIED>
+
+<!ELEMENT %msub.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %msub.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  subscriptshift %length; #IMPLIED>
+
+<!ELEMENT %msup.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %msup.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  superscriptshift %length; #IMPLIED>
+
+<!ENTITY % msubsup.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  subscriptshift %length; #IMPLIED
+  superscriptshift %length; #IMPLIED">
+
+<!ELEMENT %msubsup.qname; ((%MathExpression;),(%MathExpression;),
+                         (%MathExpression;))>
+<!ATTLIST %msubsup.qname;
+  %msubsup.attributes;>
+
+<!ELEMENT %munder.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %munder.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  accentunder (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED>
+
+<!ELEMENT %mover.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %mover.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  accent (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED>
+
+<!ELEMENT %munderover.qname; ((%MathExpression;),(%MathExpression;),
+                            (%MathExpression;))>
+
+<!ATTLIST %munderover.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  accent (true|false) #IMPLIED
+  accentunder (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED>
+
+<!ELEMENT %mmultiscripts.qname; ((%MathExpression;),
+                               (%MultiScriptExpression;)*,
+                               (%mprescripts.qname;,
+                                (%MultiScriptExpression;)*)?)>
+
+<!ATTLIST %mmultiscripts.qname;
+  %msubsup.attributes;>
+
+<!ELEMENT %mtable.qname; (%TableRowExpression;)*>
+
+<!ATTLIST %mtable.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  align CDATA #IMPLIED
+  rowalign CDATA #IMPLIED
+  columnalign CDATA #IMPLIED
+  groupalign CDATA #IMPLIED
+  alignmentscope CDATA #IMPLIED
+  columnwidth CDATA #IMPLIED
+  width CDATA #IMPLIED
+  rowspacing CDATA #IMPLIED
+  columnspacing CDATA #IMPLIED
+  rowlines CDATA #IMPLIED
+  columnlines CDATA #IMPLIED
+  frame (%linestyle;) #IMPLIED
+  framespacing CDATA #IMPLIED
+  equalrows (true|false) #IMPLIED
+  equalcolumns (true|false) #IMPLIED
+  displaystyle (true|false) #IMPLIED
+  side (left|right|leftoverlap|rightoverlap) #IMPLIED
+  minlabelspacing %length; #IMPLIED>
+
+<!ELEMENT %mlabeledtr.qname; (%TableCellExpression;)+>
+
+<!ENTITY % mtr.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  rowalign (top|bottom|center|baseline|axis) #IMPLIED
+  columnalign CDATA #IMPLIED
+  groupalign CDATA #IMPLIED">
+
+<!ATTLIST %mlabeledtr.qname;
+  %mtr.attributes;>
+
+<!ELEMENT %mtr.qname; (%TableCellExpression;)*>
+<!ATTLIST %mtr.qname;
+  %mtr.attributes;>
+
+<!ELEMENT %mtd.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %mtd.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  rowspan %positive-integer; #IMPLIED
+  columnspan %positive-integer; #IMPLIED
+  rowalign (top|bottom|center|baseline|axis) #IMPLIED
+  columnalign (%columnalignstyle;) #IMPLIED
+  groupalign CDATA #IMPLIED>
+
+<!ELEMENT %mstack.qname; (%MstackExpression;)*>
+
+<!ATTLIST %mstack.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  align CDATA #IMPLIED
+  stackalign (left|center|right|decimalpoint) #IMPLIED
+  charalign (left|center|right) #IMPLIED
+  charspacing CDATA #IMPLIED>
+
+<!ELEMENT %mlongdiv.qname; ((%MstackExpression;),(%MstackExpression;),
+                          (%MstackExpression;)+)>
+
+<!ENTITY % msgroup.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED
+  shift %integer; #IMPLIED">
+
+<!ATTLIST %mlongdiv.qname;
+  %msgroup.attributes;
+  longdivstyle CDATA #IMPLIED>
+
+<!ELEMENT %msgroup.qname; (%MstackExpression;)*>
+<!ATTLIST %msgroup.qname;
+  %msgroup.attributes;>
+
+<!ELEMENT %msrow.qname; (%MsrowExpression;)*>
+
+<!ATTLIST %msrow.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED>
+
+<!ELEMENT %mscarries.qname; (%MsrowExpression;|%mscarry.qname;)*>
+
+<!ATTLIST %mscarries.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED
+  location (w|nw|n|ne|e|se|s|sw) #IMPLIED
+  crossout CDATA #IMPLIED
+  scriptsizemultiplier %number; #IMPLIED>
+
+<!ELEMENT %mscarry.qname; (%MsrowExpression;)*>
+
+<!ATTLIST %mscarry.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  location (w|nw|n|ne|e|se|s|sw) #IMPLIED
+  crossout CDATA #IMPLIED>
+
+<!ELEMENT %maction.qname; (%MathExpression;)+>
+
+<!ATTLIST %maction.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  actiontype CDATA #REQUIRED
+  selection %positive-integer; #IMPLIED>
+
+<!-- end of mathml3-presentation.rng -->
+
+<!-- start of mathml3-common.rng -->
+
+<!ELEMENT %math.qname; (%MathExpression;)*>
+
+<!ENTITY % NonMathMLAtt "">
+
+<!ENTITY % math.deprecatedattributes "
+  mode CDATA #IMPLIED
+  macros CDATA #IMPLIED">
+
+<!ATTLIST %math.qname;
+  %CommonAtt;
+  display (block|inline) #IMPLIED
+  maxwidth %length; #IMPLIED
+  overflow (linebreak|scroll|elide|truncate|scale) #IMPLIED
+  altimg CDATA #IMPLIED
+  altimg-width %length; #IMPLIED
+  altimg-height %length; #IMPLIED
+  altimg-valign CDATA #IMPLIED
+  alttext CDATA #IMPLIED
+  cdgroup CDATA #IMPLIED
+  %math.deprecatedattributes;
+  %CommonPresAtt;
+  %mstyle.specificattributes;
+  %mstyle.generalattributes;>
+
+<!ENTITY % name "
+  name CDATA #REQUIRED">
+
+<!ENTITY % cd "
+  cd CDATA #REQUIRED">
+
+<!ENTITY % annotation.attributes "
+  %CommonAtt;
+  cd CDATA #IMPLIED
+  name CDATA #IMPLIED
+  %DefEncAtt;
+  src CDATA #IMPLIED">
+
+<!ELEMENT %annotation.qname; (#PCDATA)>
+<!ATTLIST %annotation.qname;
+  %annotation.attributes;>
+
+<!ENTITY % annotation-xml.model "(%MathExpression;)*">
+
+<!ENTITY % anyElement "">
+
+<!ELEMENT %annotation-xml.qname; (%annotation-xml.model;)>
+<!ATTLIST %annotation-xml.qname;
+  %annotation.attributes;>
+
+<!ELEMENT %semantics.qname; ((%MathExpression;),
+                           (%annotation.qname;|%annotation-xml.qname;)*)>
+
+<!ATTLIST %semantics.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  cd CDATA #IMPLIED
+  name CDATA #IMPLIED>

--- a/cnxml/xml/mathml/schema/rng/3.0/mathml3-common.rng
+++ b/cnxml/xml/mathml/schema/rng/3.0/mathml3-common.rng
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="math"/>
+  </start>
+  <define name="math">
+    <element name="math">
+      <ref name="math.attributes"/>
+      <zeroOrMore>
+        <ref name="MathExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="MathExpression">
+    <ref name="semantics"/>
+  </define>
+  <define name="NonMathMLAtt">
+    <attribute>
+      <anyName>
+        <except>
+          <nsName ns=""/>
+          <nsName/>
+        </except>
+      </anyName>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="CommonDeprecatedAtt">
+    <optional>
+      <attribute name="other"/>
+    </optional>
+  </define>
+  <define name="CommonAtt">
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xref"/>
+    </optional>
+    <optional>
+      <attribute name="class">
+        <data type="NMTOKENS"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="style">
+        <data type="string"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="href">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <ref name="CommonDeprecatedAtt"/>
+    <zeroOrMore>
+      <ref name="NonMathMLAtt"/>
+    </zeroOrMore>
+  </define>
+  <define name="math.attributes">
+    <ref name="CommonAtt"/>
+    <optional>
+      <attribute name="display">
+        <choice>
+          <value>block</value>
+          <value>inline</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maxwidth">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="overflow">
+        <choice>
+          <value>linebreak</value>
+          <value>scroll</value>
+          <value>elide</value>
+          <value>truncate</value>
+          <value>scale</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg-width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg-height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="altimg-valign">
+        <choice>
+          <ref name="length"/>
+          <value>top</value>
+          <value>middle</value>
+          <value>bottom</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alttext"/>
+    </optional>
+    <optional>
+      <attribute name="cdgroup">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <ref name="math.deprecatedattributes"/>
+  </define>
+  <!--
+    the mathml3-presentation schema  adds additional attributes
+    to the math element, all those valid on mstyle
+  -->
+  <define name="math.deprecatedattributes">
+    <optional>
+      <attribute name="mode">
+        <data type="string"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="macros">
+        <data type="string"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="name">
+    <attribute name="name">
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="cd">
+    <attribute name="cd">
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="src">
+    <optional>
+      <attribute name="src">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="annotation">
+    <element name="annotation">
+      <ref name="annotation.attributes"/>
+      <text/>
+    </element>
+  </define>
+  <define name="annotation-xml.model">
+    <zeroOrMore>
+      <choice>
+        <ref name="MathExpression"/>
+        <ref name="anyElement"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="anyElement">
+    <element>
+      <anyName>
+        <except>
+          <nsName/>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="annotation-xml">
+    <element name="annotation-xml">
+      <ref name="annotation.attributes"/>
+      <ref name="annotation-xml.model"/>
+    </element>
+  </define>
+  <define name="annotation.attributes">
+    <ref name="CommonAtt"/>
+    <optional>
+      <ref name="cd"/>
+    </optional>
+    <optional>
+      <ref name="name"/>
+    </optional>
+    <ref name="DefEncAtt"/>
+    <optional>
+      <ref name="src"/>
+    </optional>
+  </define>
+  <define name="DefEncAtt">
+    <optional>
+      <attribute name="encoding">
+        <data type="string"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="definitionURL">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="semantics">
+    <element name="semantics">
+      <ref name="semantics.attributes"/>
+      <ref name="MathExpression"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="annotation"/>
+          <ref name="annotation-xml"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="semantics.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="DefEncAtt"/>
+    <optional>
+      <ref name="cd"/>
+    </optional>
+    <optional>
+      <ref name="name"/>
+    </optional>
+  </define>
+  <define name="length">
+    <data type="string">
+      <param name="pattern">\s*((-?[0-9]*([0-9]\.?|\.[0-9])[0-9]*(e[mx]|in|cm|mm|p[xtc]|%)?)|(negative)?((very){0,2}thi(n|ck)|medium)mathspace)\s*</param>
+    </data>
+  </define>
+</grammar>

--- a/cnxml/xml/mathml/schema/rng/3.0/mathml3-content.rng
+++ b/cnxml/xml/mathml/schema/rng/3.0/mathml3-content.rng
@@ -1,0 +1,1544 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <!--
+        This is the Mathematical Markup Language (MathML) 3.0, an XML
+        application for describing mathematical notation and capturing
+        both its structure and content.
+    
+        Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+    
+        Use and distribution of this code are permitted under the terms
+        W3C Software Notice and License
+        http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+  -->
+  <include href="mathml3-strict-content.rng">
+    <define name="cn.content">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="mglyph"/>
+          <ref name="sep"/>
+          <ref name="PresentationExpression"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="cn.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="base"/>
+      </optional>
+    </define>
+    <define name="ci.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="ci.type"/>
+      </optional>
+    </define>
+    <define name="ci.type">
+      <attribute name="type"/>
+    </define>
+    <define name="ci.content">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="mglyph"/>
+          <ref name="PresentationExpression"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="csymbol.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <optional>
+        <ref name="cd"/>
+      </optional>
+    </define>
+    <define name="csymbol.content">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="mglyph"/>
+          <ref name="PresentationExpression"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="bvar">
+      <element name="bvar">
+        <ref name="CommonAtt"/>
+        <interleave>
+          <choice>
+            <ref name="ci"/>
+            <ref name="semantics-ci"/>
+          </choice>
+          <optional>
+            <ref name="degree"/>
+          </optional>
+        </interleave>
+      </element>
+    </define>
+    <define name="cbytes.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+    </define>
+    <define name="cs.attributes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+    </define>
+    <define name="apply.content">
+      <choice>
+        <oneOrMore>
+          <ref name="ContExp"/>
+        </oneOrMore>
+        <group>
+          <ref name="ContExp"/>
+          <ref name="BvarQ"/>
+          <zeroOrMore>
+            <ref name="Qualifier"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="ContExp"/>
+          </zeroOrMore>
+        </group>
+      </choice>
+    </define>
+    <define name="bind.content">
+      <ref name="apply.content"/>
+    </define>
+  </include>
+  <define name="base">
+    <attribute name="base"/>
+  </define>
+  <define name="sep">
+    <element name="sep">
+      <empty/>
+    </element>
+  </define>
+  <define name="PresentationExpression" combine="choice">
+    <notAllowed/>
+  </define>
+  <define name="DomainQ">
+    <zeroOrMore>
+      <choice>
+        <ref name="domainofapplication"/>
+        <ref name="condition"/>
+        <ref name="interval"/>
+        <group>
+          <ref name="lowlimit"/>
+          <optional>
+            <ref name="uplimit"/>
+          </optional>
+        </group>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="domainofapplication">
+    <element name="domainofapplication">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="condition">
+    <element name="condition">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="uplimit">
+    <element name="uplimit">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="lowlimit">
+    <element name="lowlimit">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="Qualifier">
+    <choice>
+      <ref name="DomainQ"/>
+      <ref name="degree"/>
+      <ref name="momentabout"/>
+      <ref name="logbase"/>
+    </choice>
+  </define>
+  <define name="degree">
+    <element name="degree">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="momentabout">
+    <element name="momentabout">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="logbase">
+    <element name="logbase">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="type">
+    <attribute name="type"/>
+  </define>
+  <define name="order">
+    <attribute name="order">
+      <choice>
+        <value>numeric</value>
+        <value>lexicographic</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="closure">
+    <attribute name="closure"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="piecewise"/>
+  </define>
+  <define name="piecewise">
+    <element name="piecewise">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="piece"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="otherwise"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="piece">
+    <element name="piece">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="ContExp"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="otherwise">
+    <element name="otherwise">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="DeprecatedContExp">
+    <choice>
+      <ref name="reln"/>
+      <ref name="fn"/>
+      <ref name="declare"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="DeprecatedContExp"/>
+  </define>
+  <define name="reln">
+    <element name="reln">
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="fn">
+    <element name="fn">
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="declare">
+    <element name="declare">
+      <optional>
+        <attribute name="type">
+          <data type="string"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="scope">
+          <data type="string"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="nargs">
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="occurrence">
+          <choice>
+            <value>prefix</value>
+            <value>infix</value>
+            <value>function-model</value>
+          </choice>
+        </attribute>
+      </optional>
+      <ref name="DefEncAtt"/>
+      <oneOrMore>
+        <ref name="ContExp"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="interval.class">
+    <ref name="interval"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="interval.class"/>
+  </define>
+  <define name="interval">
+    <element name="interval">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="closure"/>
+      </optional>
+      <ref name="ContExp"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="unary-functional.class">
+    <choice>
+      <ref name="inverse"/>
+      <ref name="ident"/>
+      <ref name="domain"/>
+      <ref name="codomain"/>
+      <ref name="image"/>
+      <ref name="ln"/>
+      <ref name="log"/>
+      <ref name="moment"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-functional.class"/>
+  </define>
+  <define name="inverse">
+    <element name="inverse">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ident">
+    <element name="ident">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="domain">
+    <element name="domain">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="codomain">
+    <element name="codomain">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="image">
+    <element name="image">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ln">
+    <element name="ln">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="log">
+    <element name="log">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="moment">
+    <element name="moment">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="lambda.class">
+    <ref name="lambda"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="lambda.class"/>
+  </define>
+  <define name="lambda">
+    <element name="lambda">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <ref name="ContExp"/>
+    </element>
+  </define>
+  <define name="nary-functional.class">
+    <ref name="compose"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-functional.class"/>
+  </define>
+  <define name="compose">
+    <element name="compose">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-arith.class">
+    <choice>
+      <ref name="quotient"/>
+      <ref name="divide"/>
+      <ref name="minus"/>
+      <ref name="power"/>
+      <ref name="rem"/>
+      <ref name="root"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-arith.class"/>
+  </define>
+  <define name="quotient">
+    <element name="quotient">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="divide">
+    <element name="divide">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="minus">
+    <element name="minus">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="power">
+    <element name="power">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="rem">
+    <element name="rem">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="root">
+    <element name="root">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-arith.class">
+    <choice>
+      <ref name="factorial"/>
+      <ref name="minus"/>
+      <ref name="root"/>
+      <ref name="abs"/>
+      <ref name="conjugate"/>
+      <ref name="arg"/>
+      <ref name="real"/>
+      <ref name="imaginary"/>
+      <ref name="floor"/>
+      <ref name="ceiling"/>
+      <ref name="exp"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-arith.class"/>
+  </define>
+  <define name="factorial">
+    <element name="factorial">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="abs">
+    <element name="abs">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="conjugate">
+    <element name="conjugate">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arg">
+    <element name="arg">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="real">
+    <element name="real">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="imaginary">
+    <element name="imaginary">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="floor">
+    <element name="floor">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="ceiling">
+    <element name="ceiling">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="exp">
+    <element name="exp">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-minmax.class">
+    <choice>
+      <ref name="max"/>
+      <ref name="min"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-minmax.class"/>
+  </define>
+  <define name="max">
+    <element name="max">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="min">
+    <element name="min">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-arith.class">
+    <choice>
+      <ref name="plus"/>
+      <ref name="times"/>
+      <ref name="gcd"/>
+      <ref name="lcm"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-arith.class"/>
+  </define>
+  <define name="plus">
+    <element name="plus">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="times">
+    <element name="times">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="gcd">
+    <element name="gcd">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="lcm">
+    <element name="lcm">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-logical.class">
+    <choice>
+      <ref name="and"/>
+      <ref name="or"/>
+      <ref name="xor"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-logical.class"/>
+  </define>
+  <define name="and">
+    <element name="and">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="or">
+    <element name="or">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="xor">
+    <element name="xor">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-logical.class">
+    <ref name="not"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-logical.class"/>
+  </define>
+  <define name="not">
+    <element name="not">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-logical.class">
+    <choice>
+      <ref name="implies"/>
+      <ref name="equivalent"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-logical.class"/>
+  </define>
+  <define name="implies">
+    <element name="implies">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="equivalent">
+    <element name="equivalent">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="quantifier.class">
+    <choice>
+      <ref name="forall"/>
+      <ref name="exists"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="quantifier.class"/>
+  </define>
+  <define name="forall">
+    <element name="forall">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="exists">
+    <element name="exists">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-reln.class">
+    <choice>
+      <ref name="eq"/>
+      <ref name="gt"/>
+      <ref name="lt"/>
+      <ref name="geq"/>
+      <ref name="leq"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-reln.class"/>
+  </define>
+  <define name="eq">
+    <element name="eq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="gt">
+    <element name="gt">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="lt">
+    <element name="lt">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="geq">
+    <element name="geq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="leq">
+    <element name="leq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-reln.class">
+    <choice>
+      <ref name="neq"/>
+      <ref name="approx"/>
+      <ref name="factorof"/>
+      <ref name="tendsto"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-reln.class"/>
+  </define>
+  <define name="neq">
+    <element name="neq">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="approx">
+    <element name="approx">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="factorof">
+    <element name="factorof">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="tendsto">
+    <element name="tendsto">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="type"/>
+      </optional>
+      <empty/>
+    </element>
+  </define>
+  <define name="int.class">
+    <ref name="int"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="int.class"/>
+  </define>
+  <define name="int">
+    <element name="int">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="Differential-Operator.class">
+    <ref name="diff"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="Differential-Operator.class"/>
+  </define>
+  <define name="diff">
+    <element name="diff">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="partialdiff.class">
+    <ref name="partialdiff"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="partialdiff.class"/>
+  </define>
+  <define name="partialdiff">
+    <element name="partialdiff">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-veccalc.class">
+    <choice>
+      <ref name="divergence"/>
+      <ref name="grad"/>
+      <ref name="curl"/>
+      <ref name="laplacian"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-veccalc.class"/>
+  </define>
+  <define name="divergence">
+    <element name="divergence">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="grad">
+    <element name="grad">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="curl">
+    <element name="curl">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="laplacian">
+    <element name="laplacian">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-setlist-constructor.class">
+    <choice>
+      <ref name="set"/>
+      <ref name="list"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-setlist-constructor.class"/>
+  </define>
+  <define name="set">
+    <element name="set">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="type"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="BvarQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="DomainQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="list">
+    <element name="list">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <optional>
+        <ref name="order"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="BvarQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="DomainQ"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="nary-set.class">
+    <choice>
+      <ref name="union"/>
+      <ref name="intersect"/>
+      <ref name="cartesianproduct"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-set.class"/>
+  </define>
+  <define name="union">
+    <element name="union">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="intersect">
+    <element name="intersect">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cartesianproduct">
+    <element name="cartesianproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-set.class">
+    <choice>
+      <ref name="in"/>
+      <ref name="notin"/>
+      <ref name="notsubset"/>
+      <ref name="notprsubset"/>
+      <ref name="setdiff"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-set.class"/>
+  </define>
+  <define name="in">
+    <element name="in">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notin">
+    <element name="notin">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notsubset">
+    <element name="notsubset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notprsubset">
+    <element name="notprsubset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="setdiff">
+    <element name="setdiff">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-set-reln.class">
+    <choice>
+      <ref name="subset"/>
+      <ref name="prsubset"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-set-reln.class"/>
+  </define>
+  <define name="subset">
+    <element name="subset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="prsubset">
+    <element name="prsubset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-set.class">
+    <ref name="card"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-set.class"/>
+  </define>
+  <define name="card">
+    <element name="card">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sum.class">
+    <ref name="sum"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="sum.class"/>
+  </define>
+  <define name="sum">
+    <element name="sum">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="product.class">
+    <ref name="product"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="product.class"/>
+  </define>
+  <define name="product">
+    <element name="product">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="limit.class">
+    <ref name="limit"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="limit.class"/>
+  </define>
+  <define name="limit">
+    <element name="limit">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="unary-elementary.class">
+    <choice>
+      <ref name="sin"/>
+      <ref name="cos"/>
+      <ref name="tan"/>
+      <ref name="sec"/>
+      <ref name="csc"/>
+      <ref name="cot"/>
+      <ref name="sinh"/>
+      <ref name="cosh"/>
+      <ref name="tanh"/>
+      <ref name="sech"/>
+      <ref name="csch"/>
+      <ref name="coth"/>
+      <ref name="arcsin"/>
+      <ref name="arccos"/>
+      <ref name="arctan"/>
+      <ref name="arccosh"/>
+      <ref name="arccot"/>
+      <ref name="arccoth"/>
+      <ref name="arccsc"/>
+      <ref name="arccsch"/>
+      <ref name="arcsec"/>
+      <ref name="arcsech"/>
+      <ref name="arcsinh"/>
+      <ref name="arctanh"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-elementary.class"/>
+  </define>
+  <define name="sin">
+    <element name="sin">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cos">
+    <element name="cos">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="tan">
+    <element name="tan">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sec">
+    <element name="sec">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="csc">
+    <element name="csc">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cot">
+    <element name="cot">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sinh">
+    <element name="sinh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cosh">
+    <element name="cosh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="tanh">
+    <element name="tanh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sech">
+    <element name="sech">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="csch">
+    <element name="csch">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="coth">
+    <element name="coth">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsin">
+    <element name="arcsin">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccos">
+    <element name="arccos">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arctan">
+    <element name="arctan">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccosh">
+    <element name="arccosh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccot">
+    <element name="arccot">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccoth">
+    <element name="arccoth">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccsc">
+    <element name="arccsc">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arccsch">
+    <element name="arccsch">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsec">
+    <element name="arcsec">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsech">
+    <element name="arcsech">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arcsinh">
+    <element name="arcsinh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="arctanh">
+    <element name="arctanh">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-stats.class">
+    <choice>
+      <ref name="mean"/>
+      <ref name="sdev"/>
+      <ref name="variance"/>
+      <ref name="median"/>
+      <ref name="mode"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-stats.class"/>
+  </define>
+  <define name="mean">
+    <element name="mean">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="sdev">
+    <element name="sdev">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="variance">
+    <element name="variance">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="median">
+    <element name="median">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mode">
+    <element name="mode">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-constructor.class">
+    <choice>
+      <ref name="vector"/>
+      <ref name="matrix"/>
+      <ref name="matrixrow"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-constructor.class"/>
+  </define>
+  <define name="vector">
+    <element name="vector">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="matrix">
+    <element name="matrix">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="matrixrow">
+    <element name="matrixrow">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <ref name="BvarQ"/>
+      <ref name="DomainQ"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="unary-linalg.class">
+    <choice>
+      <ref name="determinant"/>
+      <ref name="transpose"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="unary-linalg.class"/>
+  </define>
+  <define name="determinant">
+    <element name="determinant">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="transpose">
+    <element name="transpose">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="nary-linalg.class">
+    <ref name="selector"/>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="nary-linalg.class"/>
+  </define>
+  <define name="selector">
+    <element name="selector">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="binary-linalg.class">
+    <choice>
+      <ref name="vectorproduct"/>
+      <ref name="scalarproduct"/>
+      <ref name="outerproduct"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="binary-linalg.class"/>
+  </define>
+  <define name="vectorproduct">
+    <element name="vectorproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="scalarproduct">
+    <element name="scalarproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="outerproduct">
+    <element name="outerproduct">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="constant-set.class">
+    <choice>
+      <ref name="integers"/>
+      <ref name="reals"/>
+      <ref name="rationals"/>
+      <ref name="naturalnumbers"/>
+      <ref name="complexes"/>
+      <ref name="primes"/>
+      <ref name="emptyset"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="constant-set.class"/>
+  </define>
+  <define name="integers">
+    <element name="integers">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="reals">
+    <element name="reals">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="rationals">
+    <element name="rationals">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="naturalnumbers">
+    <element name="naturalnumbers">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="complexes">
+    <element name="complexes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="primes">
+    <element name="primes">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="emptyset">
+    <element name="emptyset">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="constant-arith.class">
+    <choice>
+      <ref name="exponentiale"/>
+      <ref name="imaginaryi"/>
+      <ref name="notanumber"/>
+      <ref name="true"/>
+      <ref name="false"/>
+      <ref name="pi"/>
+      <ref name="eulergamma"/>
+      <ref name="infinity"/>
+    </choice>
+  </define>
+  <define name="ContExp" combine="choice">
+    <ref name="constant-arith.class"/>
+  </define>
+  <define name="exponentiale">
+    <element name="exponentiale">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="imaginaryi">
+    <element name="imaginaryi">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="notanumber">
+    <element name="notanumber">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="true">
+    <element name="true">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="false">
+    <element name="false">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="pi">
+    <element name="pi">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="eulergamma">
+    <element name="eulergamma">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="infinity">
+    <element name="infinity">
+      <ref name="CommonAtt"/>
+      <ref name="DefEncAtt"/>
+      <empty/>
+    </element>
+  </define>
+</grammar>

--- a/cnxml/xml/mathml/schema/rng/3.0/mathml3-presentation.rng
+++ b/cnxml/xml/mathml/schema/rng/3.0/mathml3-presentation.rng
@@ -1,0 +1,2324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="MathExpression" combine="choice">
+    <ref name="PresentationExpression"/>
+  </define>
+  <define name="ImpliedMrow">
+    <zeroOrMore>
+      <ref name="MathExpression"/>
+    </zeroOrMore>
+  </define>
+  <define name="TableRowExpression">
+    <choice>
+      <ref name="mtr"/>
+      <ref name="mlabeledtr"/>
+    </choice>
+  </define>
+  <define name="TableCellExpression">
+    <ref name="mtd"/>
+  </define>
+  <define name="MstackExpression">
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="mscarries"/>
+      <ref name="msline"/>
+      <ref name="msrow"/>
+      <ref name="msgroup"/>
+    </choice>
+  </define>
+  <define name="MsrowExpression">
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="none"/>
+    </choice>
+  </define>
+  <define name="MultiScriptExpression">
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="none"/>
+    </choice>
+    <choice>
+      <ref name="MathExpression"/>
+      <ref name="none"/>
+    </choice>
+  </define>
+  <define name="mpadded-length">
+    <data type="string">
+      <param name="pattern">\s*([\+\-]?[0-9]*([0-9]\.?|\.[0-9])[0-9]*\s*((%?\s*(height|depth|width)?)|e[mx]|in|cm|mm|p[xtc]|((negative)?((very){0,2}thi(n|ck)|medium)mathspace))?)\s*</param>
+    </data>
+  </define>
+  <define name="linestyle">
+    <choice>
+      <value>none</value>
+      <value>solid</value>
+      <value>dashed</value>
+    </choice>
+  </define>
+  <define name="verticalalign">
+    <choice>
+      <value>top</value>
+      <value>bottom</value>
+      <value>center</value>
+      <value>baseline</value>
+      <value>axis</value>
+    </choice>
+  </define>
+  <define name="columnalignstyle">
+    <choice>
+      <value>left</value>
+      <value>center</value>
+      <value>right</value>
+    </choice>
+  </define>
+  <define name="notationstyle">
+    <choice>
+      <value>longdiv</value>
+      <value>actuarial</value>
+      <value>radical</value>
+      <value>box</value>
+      <value>roundedbox</value>
+      <value>circle</value>
+      <value>left</value>
+      <value>right</value>
+      <value>top</value>
+      <value>bottom</value>
+      <value>updiagonalstrike</value>
+      <value>downdiagonalstrike</value>
+      <value>verticalstrike</value>
+      <value>horizontalstrike</value>
+      <value>madruwb</value>
+    </choice>
+  </define>
+  <define name="idref">
+    <text/>
+  </define>
+  <define name="unsigned-integer">
+    <data type="unsignedLong"/>
+  </define>
+  <define name="integer">
+    <data type="integer"/>
+  </define>
+  <define name="number">
+    <data type="decimal"/>
+  </define>
+  <define name="character">
+    <data type="string">
+      <param name="pattern">\s*\S\s*</param>
+    </data>
+  </define>
+  <define name="color">
+    <data type="string">
+      <param name="pattern">\s*((#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?)|[aA][qQ][uU][aA]|[bB][lL][aA][cC][kK]|[bB][lL][uU][eE]|[fF][uU][cC][hH][sS][iI][aA]|[gG][rR][aA][yY]|[gG][rR][eE][eE][nN]|[lL][iI][mM][eE]|[mM][aA][rR][oO][oO][nN]|[nN][aA][vV][yY]|[oO][lL][iI][vV][eE]|[pP][uU][rR][pP][lL][eE]|[rR][eE][dD]|[sS][iI][lL][vV][eE][rR]|[tT][eE][aA][lL]|[wW][hH][iI][tT][eE]|[yY][eE][lL][lL][oO][wW])\s*</param>
+    </data>
+  </define>
+  <define name="group-alignment">
+    <choice>
+      <value>left</value>
+      <value>center</value>
+      <value>right</value>
+      <value>decimalpoint</value>
+    </choice>
+  </define>
+  <define name="group-alignment-list">
+    <list>
+      <oneOrMore>
+        <ref name="group-alignment"/>
+      </oneOrMore>
+    </list>
+  </define>
+  <define name="group-alignment-list-list">
+    <data type="string">
+      <param name="pattern">(\s*\{\s*(left|center|right|decimalpoint)(\s+(left|center|right|decimalpoint))*\})*\s*</param>
+    </data>
+  </define>
+  <define name="positive-integer">
+    <data type="positiveInteger"/>
+  </define>
+  <define name="TokenExpression">
+    <choice>
+      <ref name="mi"/>
+      <ref name="mn"/>
+      <ref name="mo"/>
+      <ref name="mtext"/>
+      <ref name="mspace"/>
+      <ref name="ms"/>
+    </choice>
+  </define>
+  <define name="token.content">
+    <choice>
+      <ref name="mglyph"/>
+      <ref name="malignmark"/>
+      <text/>
+    </choice>
+  </define>
+  <define name="mi">
+    <element name="mi">
+      <ref name="mi.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mi.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+  </define>
+  <define name="mn">
+    <element name="mn">
+      <ref name="mn.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mn.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+  </define>
+  <define name="mo">
+    <element name="mo">
+      <ref name="mo.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mo.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+    <optional>
+      <attribute name="form">
+        <choice>
+          <value>prefix</value>
+          <value>infix</value>
+          <value>postfix</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fence">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="separator">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stretchy">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="symmetric">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maxsize">
+        <choice>
+          <ref name="length"/>
+          <value>infinity</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="largeop">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="movablelimits">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreak">
+        <choice>
+          <value>auto</value>
+          <value>newline</value>
+          <value>nobreak</value>
+          <value>goodbreak</value>
+          <value>badbreak</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lineleading">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreakstyle">
+        <choice>
+          <value>before</value>
+          <value>after</value>
+          <value>duplicate</value>
+          <value>infixlinebreakstyle</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreakmultchar"/>
+    </optional>
+    <optional>
+      <attribute name="indentalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indenttarget">
+        <ref name="idref"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignfirst">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftfirst">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignlast">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftlast">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mtext">
+    <element name="mtext">
+      <ref name="mtext.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mtext.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+  </define>
+  <define name="mspace">
+    <element name="mspace">
+      <ref name="mspace.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mspace.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+    <optional>
+      <attribute name="width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="depth">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreak">
+        <choice>
+          <value>auto</value>
+          <value>newline</value>
+          <value>nobreak</value>
+          <value>goodbreak</value>
+          <value>badbreak</value>
+          <value>indentingnewline</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indenttarget">
+        <ref name="idref"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignfirst">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftfirst">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignlast">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftlast">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="ms">
+    <element name="ms">
+      <ref name="ms.attributes"/>
+      <zeroOrMore>
+        <ref name="token.content"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="ms.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="TokenAtt"/>
+    <optional>
+      <attribute name="lquote"/>
+    </optional>
+    <optional>
+      <attribute name="rquote"/>
+    </optional>
+  </define>
+  <define name="mglyph">
+    <element name="mglyph">
+      <ref name="mglyph.attributes"/>
+      <ref name="mglyph.deprecatedattributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mglyph.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="src">
+        <data type="anyURI"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="valign">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alt"/>
+    </optional>
+  </define>
+  <define name="mglyph.deprecatedattributes">
+    <optional>
+      <attribute name="index">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathvariant">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>italic</value>
+          <value>bold-italic</value>
+          <value>double-struck</value>
+          <value>bold-fraktur</value>
+          <value>script</value>
+          <value>bold-script</value>
+          <value>fraktur</value>
+          <value>sans-serif</value>
+          <value>bold-sans-serif</value>
+          <value>sans-serif-italic</value>
+          <value>sans-serif-bold-italic</value>
+          <value>monospace</value>
+          <value>initial</value>
+          <value>tailed</value>
+          <value>looped</value>
+          <value>stretched</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathsize">
+        <choice>
+          <value>small</value>
+          <value>normal</value>
+          <value>big</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="DeprecatedTokenAtt"/>
+  </define>
+  <define name="msline">
+    <element name="msline">
+      <ref name="msline.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="msline.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="length">
+        <ref name="unsigned-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="leftoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rightoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mslinethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="none">
+    <element name="none">
+      <ref name="none.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="none.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mprescripts">
+    <element name="mprescripts">
+      <ref name="mprescripts.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="mprescripts.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="CommonPresAtt">
+    <optional>
+      <attribute name="mathcolor">
+        <ref name="color"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathbackground">
+        <choice>
+          <ref name="color"/>
+          <value>transparent</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="TokenAtt">
+    <optional>
+      <attribute name="mathvariant">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>italic</value>
+          <value>bold-italic</value>
+          <value>double-struck</value>
+          <value>bold-fraktur</value>
+          <value>script</value>
+          <value>bold-script</value>
+          <value>fraktur</value>
+          <value>sans-serif</value>
+          <value>bold-sans-serif</value>
+          <value>sans-serif-italic</value>
+          <value>sans-serif-bold-italic</value>
+          <value>monospace</value>
+          <value>initial</value>
+          <value>tailed</value>
+          <value>looped</value>
+          <value>stretched</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathsize">
+        <choice>
+          <value>small</value>
+          <value>normal</value>
+          <value>big</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dir">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="DeprecatedTokenAtt"/>
+  </define>
+  <define name="DeprecatedTokenAtt">
+    <optional>
+      <attribute name="fontfamily"/>
+    </optional>
+    <optional>
+      <attribute name="fontweight">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fontstyle">
+        <choice>
+          <value>normal</value>
+          <value>italic</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fontsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="color">
+        <ref name="color"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="background">
+        <choice>
+          <ref name="color"/>
+          <value>transparent</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="MalignExpression">
+    <choice>
+      <ref name="maligngroup"/>
+      <ref name="malignmark"/>
+    </choice>
+  </define>
+  <define name="malignmark">
+    <element name="malignmark">
+      <ref name="malignmark.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="malignmark.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="edge">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="maligngroup">
+    <element name="maligngroup">
+      <ref name="maligngroup.attributes"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="maligngroup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="groupalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="PresentationExpression">
+    <choice>
+      <ref name="TokenExpression"/>
+      <ref name="MalignExpression"/>
+      <ref name="mrow"/>
+      <ref name="mfrac"/>
+      <ref name="msqrt"/>
+      <ref name="mroot"/>
+      <ref name="mstyle"/>
+      <ref name="merror"/>
+      <ref name="mpadded"/>
+      <ref name="mphantom"/>
+      <ref name="mfenced"/>
+      <ref name="menclose"/>
+      <ref name="msub"/>
+      <ref name="msup"/>
+      <ref name="msubsup"/>
+      <ref name="munder"/>
+      <ref name="mover"/>
+      <ref name="munderover"/>
+      <ref name="mmultiscripts"/>
+      <ref name="mtable"/>
+      <ref name="mstack"/>
+      <ref name="mlongdiv"/>
+      <ref name="maction"/>
+    </choice>
+  </define>
+  <define name="mrow">
+    <element name="mrow">
+      <ref name="mrow.attributes"/>
+      <zeroOrMore>
+        <ref name="MathExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mrow.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="dir">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mfrac">
+    <element name="mfrac">
+      <ref name="mfrac.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mfrac.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="linethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="numalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="denomalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="bevelled">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msqrt">
+    <element name="msqrt">
+      <ref name="msqrt.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="msqrt.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mroot">
+    <element name="mroot">
+      <ref name="mroot.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mroot.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mstyle">
+    <element name="mstyle">
+      <ref name="mstyle.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mstyle.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <ref name="mstyle.specificattributes"/>
+    <ref name="mstyle.generalattributes"/>
+    <ref name="mstyle.deprecatedattributes"/>
+  </define>
+  <define name="mstyle.specificattributes">
+    <optional>
+      <attribute name="scriptlevel">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="displaystyle">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="scriptsizemultiplier">
+        <ref name="number"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="scriptminsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="infixlinebreakstyle">
+        <choice>
+          <value>before</value>
+          <value>after</value>
+          <value>duplicate</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="decimalpoint">
+        <ref name="character"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mstyle.generalattributes">
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alignmentscope">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="bevelled">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charspacing">
+        <choice>
+          <ref name="length"/>
+          <value>loose</value>
+          <value>medium</value>
+          <value>tight</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="close"/>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <list>
+          <oneOrMore>
+            <ref name="columnalignstyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnwidth">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>auto</value>
+              <ref name="length"/>
+              <value>fit</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="crossout">
+        <list>
+          <zeroOrMore>
+            <choice>
+              <value>none</value>
+              <value>updiagonalstrike</value>
+              <value>downdiagonalstrike</value>
+              <value>verticalstrike</value>
+              <value>horizontalstrike</value>
+            </choice>
+          </zeroOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="denomalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="depth">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dir">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="edge">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalcolumns">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalrows">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fence">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="form">
+        <choice>
+          <value>prefix</value>
+          <value>infix</value>
+          <value>postfix</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="frame">
+        <ref name="linestyle"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="framespacing">
+        <list>
+          <ref name="length"/>
+          <ref name="length"/>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list-list"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignfirst">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentalignlast">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>auto</value>
+          <value>id</value>
+          <value>indentalign</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftfirst">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indentshiftlast">
+        <choice>
+          <ref name="length"/>
+          <value>indentshift</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="indenttarget">
+        <ref name="idref"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="largeop">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="leftoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="length">
+        <ref name="unsigned-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreak">
+        <choice>
+          <value>auto</value>
+          <value>newline</value>
+          <value>nobreak</value>
+          <value>goodbreak</value>
+          <value>badbreak</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linebreakmultchar"/>
+    </optional>
+    <optional>
+      <attribute name="linebreakstyle">
+        <choice>
+          <value>before</value>
+          <value>after</value>
+          <value>duplicate</value>
+          <value>infixlinebreakstyle</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lineleading">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="linethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="location">
+        <choice>
+          <value>w</value>
+          <value>nw</value>
+          <value>n</value>
+          <value>ne</value>
+          <value>e</value>
+          <value>se</value>
+          <value>s</value>
+          <value>sw</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="longdivstyle">
+        <choice>
+          <value>lefttop</value>
+          <value>stackedrightright</value>
+          <value>mediumstackedrightright</value>
+          <value>shortstackedrightright</value>
+          <value>righttop</value>
+          <value>left/\right</value>
+          <value>left)(right</value>
+          <value>:right=right</value>
+          <value>stackedleftleft</value>
+          <value>stackedleftlinetop</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lquote"/>
+    </optional>
+    <optional>
+      <attribute name="lspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathsize">
+        <choice>
+          <value>small</value>
+          <value>normal</value>
+          <value>big</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathvariant">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>italic</value>
+          <value>bold-italic</value>
+          <value>double-struck</value>
+          <value>bold-fraktur</value>
+          <value>script</value>
+          <value>bold-script</value>
+          <value>fraktur</value>
+          <value>sans-serif</value>
+          <value>bold-sans-serif</value>
+          <value>sans-serif-italic</value>
+          <value>sans-serif-bold-italic</value>
+          <value>monospace</value>
+          <value>initial</value>
+          <value>tailed</value>
+          <value>looped</value>
+          <value>stretched</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maxsize">
+        <choice>
+          <ref name="length"/>
+          <value>infinity</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minlabelspacing">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minsize">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="movablelimits">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mslinethickness">
+        <choice>
+          <ref name="length"/>
+          <value>thin</value>
+          <value>medium</value>
+          <value>thick</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="notation"/>
+    </optional>
+    <optional>
+      <attribute name="numalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="open"/>
+    </optional>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rightoverhang">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowalign">
+        <list>
+          <oneOrMore>
+            <ref name="verticalalign"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rquote"/>
+    </optional>
+    <optional>
+      <attribute name="rspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="selection">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="separator">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="separators"/>
+    </optional>
+    <optional>
+      <attribute name="shift">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="side">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>leftoverlap</value>
+          <value>rightoverlap</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stackalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stretchy">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="subscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="superscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="symmetric">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="valign">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mstyle.deprecatedattributes">
+    <ref name="DeprecatedTokenAtt"/>
+    <optional>
+      <attribute name="veryverythinmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="verythinmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="thinmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mediummathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="thickmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="verythickmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="veryverythickmathspace">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="math.attributes" combine="interleave">
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="math.attributes" combine="interleave">
+    <ref name="mstyle.specificattributes"/>
+  </define>
+  <define name="math.attributes" combine="interleave">
+    <ref name="mstyle.generalattributes"/>
+  </define>
+  <define name="merror">
+    <element name="merror">
+      <ref name="merror.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="merror.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mpadded">
+    <element name="mpadded">
+      <ref name="mpadded.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mpadded.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="height">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="depth">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lspace">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="voffset">
+        <ref name="mpadded-length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mphantom">
+    <element name="mphantom">
+      <ref name="mphantom.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mphantom.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+  </define>
+  <define name="mfenced">
+    <element name="mfenced">
+      <ref name="mfenced.attributes"/>
+      <zeroOrMore>
+        <ref name="MathExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mfenced.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="open"/>
+    </optional>
+    <optional>
+      <attribute name="close"/>
+    </optional>
+    <optional>
+      <attribute name="separators"/>
+    </optional>
+  </define>
+  <define name="menclose">
+    <element name="menclose">
+      <ref name="menclose.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="menclose.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="notation"/>
+    </optional>
+  </define>
+  <define name="msub">
+    <element name="msub">
+      <ref name="msub.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="msub.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="subscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msup">
+    <element name="msup">
+      <ref name="msup.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="msup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="superscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msubsup">
+    <element name="msubsup">
+      <ref name="msubsup.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="msubsup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="subscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="superscriptshift">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="munder">
+    <element name="munder">
+      <ref name="munder.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="munder.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mover">
+    <element name="mover">
+      <ref name="mover.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="mover.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="munderover">
+    <element name="munderover">
+      <ref name="munderover.attributes"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+      <ref name="MathExpression"/>
+    </element>
+  </define>
+  <define name="munderover.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="accent">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accentunder">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="align">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>center</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mmultiscripts">
+    <element name="mmultiscripts">
+      <ref name="mmultiscripts.attributes"/>
+      <ref name="MathExpression"/>
+      <zeroOrMore>
+        <ref name="MultiScriptExpression"/>
+      </zeroOrMore>
+      <optional>
+        <ref name="mprescripts"/>
+        <zeroOrMore>
+          <ref name="MultiScriptExpression"/>
+        </zeroOrMore>
+      </optional>
+    </element>
+  </define>
+  <define name="mmultiscripts.attributes">
+    <ref name="msubsup.attributes"/>
+  </define>
+  <define name="mtable">
+    <element name="mtable">
+      <ref name="mtable.attributes"/>
+      <zeroOrMore>
+        <ref name="TableRowExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mtable.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="align">
+        <data type="string">
+          <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
+        </data>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowalign">
+        <list>
+          <oneOrMore>
+            <ref name="verticalalign"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <list>
+          <oneOrMore>
+            <ref name="columnalignstyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list-list"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alignmentscope">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>true</value>
+              <value>false</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnwidth">
+        <list>
+          <oneOrMore>
+            <choice>
+              <value>auto</value>
+              <ref name="length"/>
+              <value>fit</value>
+            </choice>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <choice>
+          <value>auto</value>
+          <ref name="length"/>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspacing">
+        <list>
+          <oneOrMore>
+            <ref name="length"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnlines">
+        <list>
+          <oneOrMore>
+            <ref name="linestyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="frame">
+        <ref name="linestyle"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="framespacing">
+        <list>
+          <ref name="length"/>
+          <ref name="length"/>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalrows">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="equalcolumns">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="displaystyle">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="side">
+        <choice>
+          <value>left</value>
+          <value>right</value>
+          <value>leftoverlap</value>
+          <value>rightoverlap</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="minlabelspacing">
+        <ref name="length"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mlabeledtr">
+    <element name="mlabeledtr">
+      <ref name="mlabeledtr.attributes"/>
+      <oneOrMore>
+        <ref name="TableCellExpression"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mlabeledtr.attributes">
+    <ref name="mtr.attributes"/>
+  </define>
+  <define name="mtr">
+    <element name="mtr">
+      <ref name="mtr.attributes"/>
+      <zeroOrMore>
+        <ref name="TableCellExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mtr.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="rowalign">
+        <choice>
+          <value>top</value>
+          <value>bottom</value>
+          <value>center</value>
+          <value>baseline</value>
+          <value>axis</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <list>
+          <oneOrMore>
+            <ref name="columnalignstyle"/>
+          </oneOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list-list"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mtd">
+    <element name="mtd">
+      <ref name="mtd.attributes"/>
+      <ref name="ImpliedMrow"/>
+    </element>
+  </define>
+  <define name="mtd.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="rowspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnspan">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rowalign">
+        <choice>
+          <value>top</value>
+          <value>bottom</value>
+          <value>center</value>
+          <value>baseline</value>
+          <value>axis</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="columnalign">
+        <ref name="columnalignstyle"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="groupalign">
+        <ref name="group-alignment-list"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mstack">
+    <element name="mstack">
+      <ref name="mstack.attributes"/>
+      <zeroOrMore>
+        <ref name="MstackExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mstack.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="align">
+        <data type="string">
+          <param name="pattern">\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*</param>
+        </data>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stackalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+          <value>decimalpoint</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charalign">
+        <choice>
+          <value>left</value>
+          <value>center</value>
+          <value>right</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="charspacing">
+        <choice>
+          <ref name="length"/>
+          <value>loose</value>
+          <value>medium</value>
+          <value>tight</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mlongdiv">
+    <element name="mlongdiv">
+      <ref name="mlongdiv.attributes"/>
+      <ref name="MstackExpression"/>
+      <ref name="MstackExpression"/>
+      <oneOrMore>
+        <ref name="MstackExpression"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="mlongdiv.attributes">
+    <ref name="msgroup.attributes"/>
+    <optional>
+      <attribute name="longdivstyle">
+        <choice>
+          <value>lefttop</value>
+          <value>stackedrightright</value>
+          <value>mediumstackedrightright</value>
+          <value>shortstackedrightright</value>
+          <value>righttop</value>
+          <value>left/\right</value>
+          <value>left)(right</value>
+          <value>:right=right</value>
+          <value>stackedleftleft</value>
+          <value>stackedleftlinetop</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msgroup">
+    <element name="msgroup">
+      <ref name="msgroup.attributes"/>
+      <zeroOrMore>
+        <ref name="MstackExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="msgroup.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="shift">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="msrow">
+    <element name="msrow">
+      <ref name="msrow.attributes"/>
+      <zeroOrMore>
+        <ref name="MsrowExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="msrow.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mscarries">
+    <element name="mscarries">
+      <ref name="mscarries.attributes"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="MsrowExpression"/>
+          <ref name="mscarry"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mscarries.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="position">
+        <ref name="integer"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="location">
+        <choice>
+          <value>w</value>
+          <value>nw</value>
+          <value>n</value>
+          <value>ne</value>
+          <value>e</value>
+          <value>se</value>
+          <value>s</value>
+          <value>sw</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="crossout">
+        <list>
+          <zeroOrMore>
+            <choice>
+              <value>none</value>
+              <value>updiagonalstrike</value>
+              <value>downdiagonalstrike</value>
+              <value>verticalstrike</value>
+              <value>horizontalstrike</value>
+            </choice>
+          </zeroOrMore>
+        </list>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="scriptsizemultiplier">
+        <ref name="number"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="mscarry">
+    <element name="mscarry">
+      <ref name="mscarry.attributes"/>
+      <zeroOrMore>
+        <ref name="MsrowExpression"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="mscarry.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <optional>
+      <attribute name="location">
+        <choice>
+          <value>w</value>
+          <value>nw</value>
+          <value>n</value>
+          <value>ne</value>
+          <value>e</value>
+          <value>se</value>
+          <value>s</value>
+          <value>sw</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="crossout">
+        <list>
+          <zeroOrMore>
+            <choice>
+              <value>none</value>
+              <value>updiagonalstrike</value>
+              <value>downdiagonalstrike</value>
+              <value>verticalstrike</value>
+              <value>horizontalstrike</value>
+            </choice>
+          </zeroOrMore>
+        </list>
+      </attribute>
+    </optional>
+  </define>
+  <define name="maction">
+    <element name="maction">
+      <ref name="maction.attributes"/>
+      <oneOrMore>
+        <ref name="MathExpression"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="maction.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="CommonPresAtt"/>
+    <attribute name="actiontype"/>
+    <optional>
+      <attribute name="selection">
+        <ref name="positive-integer"/>
+      </attribute>
+    </optional>
+  </define>
+</grammar>

--- a/cnxml/xml/mathml/schema/rng/3.0/mathml3-strict-content.rng
+++ b/cnxml/xml/mathml/schema/rng/3.0/mathml3-strict-content.rng
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2014 W3C (MIT, ERCIM, Keio, Beihang)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="ContExp">
+    <choice>
+      <ref name="semantics-contexp"/>
+      <ref name="cn"/>
+      <ref name="ci"/>
+      <ref name="csymbol"/>
+      <ref name="apply"/>
+      <ref name="bind"/>
+      <ref name="share"/>
+      <ref name="cerror"/>
+      <ref name="cbytes"/>
+      <ref name="cs"/>
+    </choice>
+  </define>
+  <define name="cn">
+    <element name="cn">
+      <ref name="cn.attributes"/>
+      <ref name="cn.content"/>
+    </element>
+  </define>
+  <define name="cn.content">
+    <text/>
+  </define>
+  <define name="cn.attributes">
+    <ref name="CommonAtt"/>
+    <attribute name="type">
+      <choice>
+        <value>integer</value>
+        <value>real</value>
+        <value>double</value>
+        <value>hexdouble</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="semantics-ci">
+    <element name="semantics">
+      <ref name="semantics.attributes"/>
+      <choice>
+        <ref name="ci"/>
+        <ref name="semantics-ci"/>
+      </choice>
+      <zeroOrMore>
+        <choice>
+          <ref name="annotation"/>
+          <ref name="annotation-xml"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="semantics-contexp">
+    <element name="semantics">
+      <ref name="semantics.attributes"/>
+      <ref name="ContExp"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="annotation"/>
+          <ref name="annotation-xml"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="ci">
+    <element name="ci">
+      <ref name="ci.attributes"/>
+      <ref name="ci.content"/>
+    </element>
+  </define>
+  <define name="ci.attributes">
+    <ref name="CommonAtt"/>
+    <optional>
+      <ref name="ci.type"/>
+    </optional>
+  </define>
+  <define name="ci.type">
+    <attribute name="type">
+      <choice>
+        <value>integer</value>
+        <value>rational</value>
+        <value>real</value>
+        <value>complex</value>
+        <value>complex-polar</value>
+        <value>complex-cartesian</value>
+        <value>constant</value>
+        <value>function</value>
+        <value>vector</value>
+        <value>list</value>
+        <value>set</value>
+        <value>matrix</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="ci.content">
+    <text/>
+  </define>
+  <define name="csymbol">
+    <element name="csymbol">
+      <ref name="csymbol.attributes"/>
+      <ref name="csymbol.content"/>
+    </element>
+  </define>
+  <define name="SymbolName">
+    <data type="NCName"/>
+  </define>
+  <define name="csymbol.attributes">
+    <ref name="CommonAtt"/>
+    <ref name="cd"/>
+  </define>
+  <define name="csymbol.content">
+    <ref name="SymbolName"/>
+  </define>
+  <define name="BvarQ">
+    <zeroOrMore>
+      <ref name="bvar"/>
+    </zeroOrMore>
+  </define>
+  <define name="bvar">
+    <element name="bvar">
+      <ref name="CommonAtt"/>
+      <choice>
+        <ref name="ci"/>
+        <ref name="semantics-ci"/>
+      </choice>
+    </element>
+  </define>
+  <define name="apply">
+    <element name="apply">
+      <ref name="CommonAtt"/>
+      <ref name="apply.content"/>
+    </element>
+  </define>
+  <define name="apply.content">
+    <oneOrMore>
+      <ref name="ContExp"/>
+    </oneOrMore>
+  </define>
+  <define name="bind">
+    <element name="bind">
+      <ref name="CommonAtt"/>
+      <ref name="bind.content"/>
+    </element>
+  </define>
+  <define name="bind.content">
+    <ref name="ContExp"/>
+    <zeroOrMore>
+      <ref name="bvar"/>
+    </zeroOrMore>
+    <ref name="ContExp"/>
+  </define>
+  <define name="share">
+    <element name="share">
+      <ref name="CommonAtt"/>
+      <ref name="src"/>
+      <empty/>
+    </element>
+  </define>
+  <define name="cerror">
+    <element name="cerror">
+      <ref name="cerror.attributes"/>
+      <ref name="csymbol"/>
+      <zeroOrMore>
+        <ref name="ContExp"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="cerror.attributes">
+    <ref name="CommonAtt"/>
+  </define>
+  <define name="cbytes">
+    <element name="cbytes">
+      <ref name="cbytes.attributes"/>
+      <ref name="base64"/>
+    </element>
+  </define>
+  <define name="cbytes.attributes">
+    <ref name="CommonAtt"/>
+  </define>
+  <define name="base64">
+    <data type="base64Binary"/>
+  </define>
+  <define name="cs">
+    <element name="cs">
+      <ref name="cs.attributes"/>
+      <text/>
+    </element>
+  </define>
+  <define name="cs.attributes">
+    <ref name="CommonAtt"/>
+  </define>
+  <define name="MathExpression" combine="choice">
+    <ref name="ContExp"/>
+  </define>
+</grammar>

--- a/cnxml/xml/mathml/schema/rng/3.0/mathml3.rng
+++ b/cnxml/xml/mathml/schema/rng/3.0/mathml3.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+      This is the Mathematical Markup Language (MathML) 3.0, an XML
+      application for describing mathematical notation and capturing
+      both its structure and content.
+  
+      Copyright 1998-2010 W3C (MIT, ERCIM, Keio)
+  
+      Use and distribution of this code are permitted under the terms
+      W3C Software Notice and License
+      http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+-->
+<grammar ns="http://www.w3.org/1998/Math/MathML" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="mathml3-content.rng">
+    <a:documentation>Content  MathML</a:documentation>
+  </include>
+  <include href="mathml3-presentation.rng">
+    <a:documentation>Presentation MathML</a:documentation>
+  </include>
+  <include href="mathml3-common.rng">
+    <a:documentation>math and semantics common to both Content and Presentation</a:documentation>
+  </include>
+</grammar>


### PR DESCRIPTION
While MathML 3.0 is backwards compatible with MathML 2.0 (modulo deprecations), it's actually impossible to switch CNXML 0.7 to MathML 3.0 without breaking existing content, because the RelaxNG schema used for MathML 2.0 _is not correct_. It defines each (presentation) element as

```xml
<element name="pname">
    <ref name="attlist-pelement"/>
    <ref name="PresExpression"/>
</element>

<define name="PresExpression">
    <zeroOrMore>
        <choice>
            <ref name="Presentation"/>
            <ref name="ContInPres"/>
        </choice>
    </zeroOrMore>
</define>
```

while MathML specification (both version 2.0 and 3.0) specifies [exact number of children][1] allowed per element. `<msub>` for example is [defined][2] to have _exactly two children_: `<msub> base subscript </msub>`. This means that CNXML 0.7 allows arbitrary invalid MathML. In fact, even the test case `valid.cnxml` includes invalid MathML:

```xml
<m:msub>
    <m:mi>v</m:mi>
    <m:mn>0</m:mn>
    <m:mn>2</m:mn>
</m:msub>
```

and

```xml
<m:msub>
    <m:mn>0</m:mn>
</m:msub>
```

are both present in that file.

The official RelaxNG schema for MathML 3.0 (the one included in PR) on the other hand is correct and _rejects_ those fragments. This means that just upgrading MathML version will probably break many existing modules.

To circumvent that I created “CNXML 0.8”, which differs from 0.7 just by switching to MathML 3.0. Verification has been changed to use `cnxml/schema/rng/any`, which then dispatches to either `cnxml/schema/rng/0.7` or `cnxml/schema/rng/0.8`, depending on the value of `cnxml-version`.

The additional `-i` switch to jing is there to disable checking for ID uniqueness. Unfortunately MathML RelaxNG includes wildcard selector, which jing rejects as invalid RelaxNG when used without `-i`. You can read more about this issue [in this blog post by James Clark][3].

[1]: https://www.w3.org/TR/MathML3/chapter3.html#presm.table-reqarg
[2]: https://www.w3.org/TR/MathML3/chapter3.html#presm.msub
[3]: http://blog.jclark.com/2009/01/relax-ng-and-xmlid.html