### PR TITLE
Add back in the uninstall step in the travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ before_install:
   - pip install codecov
 install:
   # Install test requirements
-  - pip install -e ".[test]"
-  # Now install it as a standalone distribution
-  - pip install .
+  - pip install ".[test]"
 script:
   - py.test
 after_success:


### PR DESCRIPTION
This should not have been removed. The point of this line is to uninstall the development version (i.e. -e option to pip). This smoke tests the package manifest is accurately includes the files that need to be available in the packaged version.