### PR TITLE
Add tests for cnxml <md:derived-from ...> validation

### DIFF
--- a/cnxml/tests/data/invalid-derived-from.cnxml
+++ b/cnxml/tests/data/invalid-derived-from.cnxml
@@ -1,0 +1,2010 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" id="imported-from-openoffice" module-id="imported-from-openoffice" cnxml-version="0.7">
+  <title>Projectile Motion</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <!-- WARNING! The 'metadata' section is read only. Do not edit below.
+       Changes to the metadata section in the source will not be saved. -->
+  <md:repository>http://legacy.cnx.org/content</md:repository>
+  <md:content-url>http://legacy.cnx.org/content/m42042/latest/</md:content-url>
+  <md:content-id>m42042</md:content-id>
+  <md:title>Projectile Motion</md:title>
+  <md:version>1.12</md:version>
+  <md:created>2011/12/21 11:28:12 -0600</md:created>
+  <md:revised>2014/10/28 11:35:40.941 GMT-5</md:revised>
+  <md:actors>
+    <md:person userid="cnxcap">
+      <md:firstname>College</md:firstname>
+      <md:surname>Physics</md:surname>
+      <md:fullname>OSC Physics Maintainer</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+    <md:organization userid="OpenStaxCollege">
+      <md:shortname>OpenStax College</md:shortname>
+      <md:fullname>OpenStax College</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:organization>
+    <md:person userid="OSCRiceUniversity">
+      <md:firstname>Rice</md:firstname>
+      <md:surname>University</md:surname>
+      <md:fullname>Rice University</md:fullname>
+      <md:email>daniel@openstaxcollege.org</md:email>
+    </md:person>
+  </md:actors>
+  <md:roles>
+    <md:role type="author">OpenStaxCollege</md:role>
+    <md:role type="maintainer">OpenStaxCollege cnxcap</md:role>
+    <md:role type="licensor">OSCRiceUniversity</md:role>
+  </md:roles>
+  <md:license url="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License 4.0</md:license>
+  <!-- For information on license requirements for use or modification, see license url in the
+       above <md:license> element.
+       For information on formatting required attribution, see the URL:
+         CONTENT_URL/content_info#cnx_cite_header
+       where CONTENT_URL is the value provided above in the <md:content-url> element.
+  -->
+  <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
+  <md:repository>http://legacy-staging.cnx.org/content</md:repository>
+  <md:content-url>http://legacy-staging.cnx.org/content/m48590/1.11</md:content-url>
+  <md:content-id>m48590</md:content-id>
+  <md:title>Introduction</md:title>
+  <md:version>1.11</md:version>
+  <md:created>2014/01/01 13:57:36 -0600</md:created>
+  <md:revised>2015/06/24 10:59:20 -0500</md:revised>
+  <md:actors>
+    <md:person userid="cnxecon">
+      <md:firstname>OpenStax</md:firstname>
+      <md:surname>College</md:surname>
+      <md:fullname>OpenStax Economics</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+    <md:organization userid="OpenStaxCollege">
+      <md:shortname>OpenStax</md:shortname>
+      <md:fullname>OpenStax</md:fullname>
+      <md:email>info@openstax.org</md:email>
+    </md:organization>
+    <md:person userid="OSCRiceUniversity">
+      <md:firstname>Rice</md:firstname>
+      <md:surname>University</md:surname>
+      <md:fullname>Rice University</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+  </md:actors>
+  <md:roles>
+    <md:role type="author">OpenStaxCollege</md:role>
+    <md:role type="maintainer">OpenStaxCollege cnxecon</md:role>
+    <md:role type="licensor">OSCRiceUniversity</md:role>
+  </md:roles>
+  <md:license url="http://creativecommons.org/licenses/by/4.0/" />
+  <!-- For information on license requirements for use or modification, see license url in the
+       above <md:license> element.
+       For information on formatting required attribution, see the URL:
+         CONTENT_URL/content_info#cnx_cite_header
+       where CONTENT_URL is the value provided above in the <md:content-url> element.
+  -->
+  </md:derived-from>
+  <md:keywordlist>
+    <md:keyword>Air resistance</md:keyword>
+    <md:keyword>Kinematics</md:keyword>
+    <md:keyword>Motion</md:keyword>
+    <md:keyword>Projectile</md:keyword>
+    <md:keyword>Projectile motion</md:keyword>
+    <md:keyword>Range</md:keyword>
+    <md:keyword>Trajectory</md:keyword>
+  </md:keywordlist>
+  <md:subjectlist>
+    <md:subject>Science and Technology</md:subject>
+  </md:subjectlist>
+  <md:abstract><list>
+<item>Identify and explain the properties of a projectile, such as acceleration due to gravity, range, maximum height, and trajectory.</item>
+<item>Determine the location and velocity of a projectile at different points in its trajectory.</item>
+<item>Apply the principle of independence of motion to solve projectile motion problems.</item>
+</list></md:abstract>
+  <md:language>en</md:language>
+  <!-- WARNING! The 'metadata' section is read only. Do not edit above.
+       Changes to the metadata section in the source will not be saved. -->
+</metadata>
+
+<content>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple: 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical, 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math>. Both accelerations are constant, so the kinematic equations can be used.</para><note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1767845"><label/><title>Review of Kinematic Equations (constant <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow></m:mrow></m:mrow></m:semantics></m:math>)</title>
+    
+    <equation id="eip-891"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:msub>
+                            <m:mi>x</m:mi>
+                            
+                              <m:mrow>
+                                <m:mn>0</m:mn>
+                              </m:mrow>
+                            
+                          </m:msub>
+                          <m:mrow>
+                            <m:mi/>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:mover accent="true">
+                            <m:mi>v</m:mi>
+                            <m:mo stretchy="true">-</m:mo>
+                          </m:mover>
+                          <m:mi>t</m:mi>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{x=`x rSub { size 8{0} } `+` { bar  {v}}t} {}</m:annotation>
+                </m:semantics>
+              </m:math> </equation><equation id="eip-557"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mover accent="true">
+                              <m:mi>v</m:mi>
+                              <m:mo stretchy="true">-</m:mo>
+                            </m:mover>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:mfrac>
+                            <m:mrow>
+                              <m:msub>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:mi>v</m:mi>
+                            </m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mfrac>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{ { bar  {v}}=` {  {v rSub { size 8{0} } +v}  over  {2} } } {}</m:annotation>
+                </m:semantics>
+              </m:math> 
+</equation><equation id="eip-405"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mi>v</m:mi>
+                          <m:mo stretchy="false">=</m:mo>
+                          <m:mrow>
+                            <m:msub>
+                              <m:mi>v</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>0</m:mn>
+                                </m:mrow>
+                              
+                            </m:msub>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mstyle fontstyle="italic">
+                              <m:mrow>
+                                <m:mtext>at</m:mtext>
+                              </m:mrow>
+                            </m:mstyle>
+                          </m:mrow>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{v=v rSub { size 8{0} } + ital "at"} {}</m:annotation>
+                </m:semantics>
+              </m:math>
+</equation><equation id="eip-556"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mrow>
+                              <m:msub>
+                                <m:mi>x</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:msub>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                            </m:mrow>
+                          </m:mrow>
+                          <m:mrow>
+                            <m:mi>t</m:mi>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mfrac>
+                              <m:mn>1</m:mn>
+                              <m:mn>2</m:mn>
+                            </m:mfrac>
+                          </m:mrow>
+                            <m:mrow>
+                              <m:msup>
+                                <m:mtext fontstyle="italic">at</m:mtext>
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+</m:msup>
+                            </m:mrow>
+                        
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{0} } t+ {  {1}  over  {2} }  ital "at" rSup { size 8{2} } } {}</m:annotation>
+                </m:semantics>
+              </m:math> </equation><equation id="eip-389"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:msup>
+                              <m:mi>v</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>2</m:mn>
+                                </m:mrow>
+                              
+                            </m:msup>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mrow>
+                              <m:msubsup>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msubsup>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:mn>2</m:mn><m:mi>a</m:mi>
+                            </m:mrow>
+                          </m:mrow>
+                          <m:mo stretchy="false">(</m:mo>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:msub>
+                              <m:mi>x</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>0</m:mn>
+                                </m:mrow>
+                              
+                            </m:msub>
+                          </m:mrow>
+                          <m:mo stretchy="false">)</m:mo>
+                        </m:mrow>
+                      </m:mrow>
+                    <m:mtext>.</m:mtext>
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{v rSup { size 8{2} } =v rSub { size 8{0} }  rSup { size 8{2} } +2a \( x - x rSub { size 8{0} }  \) } {}</m:annotation>
+                </m:semantics>
+              </m:math> 
+</equation></note><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2242290"><media id="import-auto-id1402609" alt="A soccer player is kicking a soccer ball. The ball travels in a projectile motion and reaches a point whose vertical distance is y and horizontal distance is x. The displacement between the kicking point and the final point is s. The angle made by this displacement vector with x axis is theta.">
+        <image mime-type="image/jpg" src="Figure_03_04_01.jpg" width="350"/>
+      </media>
+      
+    <caption>The total displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> of a soccer ball at a point along its path. The vector <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> has components <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> along the horizontal and vertical axes. Its magnitude is <m:math><m:semantics><m:mrow><m:mrow><m:mi>s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math>, and it makes an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> with the horizontal.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-36">Given these assumptions, the following steps are then used to analyze projectile motion:</para>
+
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction, as shown in <link target-id="import-auto-id1815222"/>. Initial values are denoted with a subscript 0, as usual.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-205"><emphasis effect="italics"><emphasis>Step 2.</emphasis></emphasis>  <emphasis effect="italics">Treat the motion as two independent one-dimensional motions, one horizontal and the other vertical.</emphasis> The kinematic equations for horizontal and vertical motion take the following forms:
+</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-338"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Horizontal Motion</m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>a</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mn>0</m:mn>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal Motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-362"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>x</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-627"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math>
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-293"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Vertical Motion</m:mtext>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mtext>assuming positive is up</m:mtext>
+<m:mspace width="0.25em"/>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:mrow>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>a</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">=</m:mo>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mi>g</m:mi>
+                      </m:mrow>
+                    </m:mrow>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mn>9.</m:mn>
+                      </m:mrow>
+                     
+                      <m:mtext>80</m:mtext>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:msup>
+                    <m:mtext>m/s</m:mtext>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Vertical Motion " \( "assuming positive is up "a rSub { size 8{y} } = - g= - 9/"80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-131"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:mfrac>
+                        <m:mn>1</m:mn>
+                        <m:mn>2</m:mn>
+                      </m:mfrac>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-305"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:msub>
+                    <m:mi>v</m:mi>
+                    
+                      <m:mrow>
+                        <m:mi>y</m:mi>
+                      </m:mrow>
+                    
+                  </m:msub>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mstyle fontstyle="italic">
+                      <m:mrow>
+                        <m:mtext>gt</m:mtext>
+                      </m:mrow>
+                    </m:mstyle>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-542"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi fontstyle="italic">gt</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+         
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-243"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-708"><emphasis effect="italics"><emphasis>Step 3.</emphasis></emphasis>  <emphasis effect="italics"> Solve for the unknowns in the two separate motions&#8212;one horizontal and one vertical.</emphasis> Note that the only common variable between the motions is time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>. The problem solving procedures here are the same as for one-dimensional <term>kinematics</term> and are illustrated in the solved examples below.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-979"><emphasis effect="italics"><emphasis>Step 4.</emphasis></emphasis>  <emphasis effect="italics">Recombine the two motions to find the total displacement</emphasis> <m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">s</m:mtext></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math><emphasis effect="italics"> and velocity </emphasis><m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">v</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>. Because the <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are perpendicular, we determine these vectors by using the techniques outlined in the <link document="m42128">Vector Addition and Subtraction: Analytical Methods</link> and employing <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>A</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>A</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>A</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+        and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( A rSub { size 8{y} } /A rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math> in the following form, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is the direction of the displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is the direction of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>:
+</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-245"><emphasis>Total displacement and velocity</emphasis></para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-743"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>s</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msup>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-373"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>&#952;</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:mi>x</m:mi>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-679"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>v</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-264"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1815222"><media id="import-auto-id2275311" alt="In part a the figure shows projectile motion of a ball with initial velocity of v zero at an angle of theta zero with the horizontal x axis. The horizontal component v x and the vertical component v y at various positions of ball in the projectile path is shown. In part b only the horizontal velocity component v sub x is shown whose magnitude is constant at various positions in the path. In part c only vertical velocity component v sub y is shown. The vertical velocity component v sub y is upwards till it reaches the maximum point and then its direction changes to downwards. In part d resultant v of horizontal velocity component v sub x and downward vertical velocity component v sub y is found which makes an angle theta with the horizontal x axis. The direction of resultant velocity v is towards south east.">
+          <image mime-type="image/jpg" src="Figure_03_04_02.jpg" height="600"/>
+        </media>
+        
+  <caption>(a) We analyze two-dimensional projectile motion by breaking it into two independent one-dimensional motions along the vertical and horizontal axes. (b) The horizontal motion is simple, because <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is thus constant. (c) The velocity in the vertical direction begins to decrease as the object rises; at its highest point, the vertical velocity is zero. As the object falls towards the Earth again, the vertical velocity increases again in magnitude but points in the opposite direction to the initial vertical velocity. (d) The <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are recombined to give the total velocity at any given point on the trajectory.</caption></figure><example id="fs-id2175010">
+    <title>A Fireworks Projectile Explodes High and Away</title>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and  
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero and solve for the desired quantities.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-774"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1669571">By &#8220;height&#8221; we mean the altitude or vertical position <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> above the starting point. The highest point in any trajectory, called the apex, is reached when <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ v rSub { size 8{y} } =0} {}</m:annotation></m:semantics></m:math>. Since we know the initial and final velocities as well as the initial position, we use the following equation to find <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>:
+
+</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-734"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id934168"><media id="import-auto-id1576299" alt="The x y graph shows the trajectory of fireworks shell. The initial velocity of the shell v zero is at angle theta zero equal to seventy five degrees with the horizontal x axis. The fuse is set to explode the shell at the highest point of the trajectory which is at a height h equal to two hundred thirty three meters and at a horizontal distance x equal to one hundred twenty five meters from the origin.">
+        <image mime-type="image/jpg" src="Figure_03_04_03a.jpg" height="250"/>
+      </media>
+      
+    <caption>The trajectory of a fireworks shell. The fuse is set to explode the shell at the highest point in its trajectory, which is found to be at a height of 233 m and 125 m away horizontally.</caption></figure><para id="import-auto-id1163607">Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> are both zero, the equation simplifies to</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-42"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mn>0</m:mn><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn></m:mrow></m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gy.</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{0=v rSub { size 8{0y} }  rSup { size 8{2} }  - 2 ital "gy."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2114969">Solving for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> gives</para>
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-256"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                         
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                     <m:mrow> <m:mn>2</m:mn><m:mi>g</m:mi></m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>75.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-677"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70.0 m/s</m:mtext><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>sin 75&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>67.6 m/s.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } = \( "70" "." 0" m/s" \)  \( "sin""75" { size 12{ circ } }  \) ="67" "." 6" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2271493">and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-512"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>y</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mfrac>
+                    <m:mrow>
+                      <m:mo stretchy="false">(</m:mo>
+                      <m:mtext>67</m:mtext>
+                      <m:mtext>.6 m/s</m:mtext>
+                      <m:msup>
+                        <m:mo stretchy="false">)</m:mo>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                    <m:mrow>
+                      <m:mn>2</m:mn>
+                      <m:mo stretchy="false">(</m:mo>
+                      <m:mn>9</m:mn>
+                      <m:mtext>.</m:mtext>
+                      <m:mtext>80 m</m:mtext>
+                      <m:msup>
+                        <m:mtext>/s</m:mtext>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">)</m:mo>
+                    </m:mrow>
+                  </m:mfrac>
+                </m:mrow>
+
+              </m:mrow>
+            <m:mo>,</m:mo>
+                   </m:mrow>
+
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  { \( "67" "." 6" m/s" \)  rSup { size 8{2} } }  over  {2 \( 9 "." "80"" m/s" rSup { size 8{2} }  \) } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1919502">so that</para>
+    
+    <equation id="eip-310"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>233</m:mtext></m:mrow><m:mo stretchy="false"> </m:mo><m:mtext> m.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y="233"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-429"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2165781">Note that because up is positive, the initial velocity is positive, as is the maximum height, but the acceleration due to gravity is negative. Note also that the maximum height depends only on the vertical component of the initial velocity, so that any projectile with a 67.6 m/s initial vertical component of velocity will reach a maximum height of 233 m (neglecting air resistance). The numbers in this example are reasonable for large fireworks displays, the shells of which do reach such heights before exploding. In practice, air resistance is not completely negligible, and so the initial velocity would have to be somewhat larger than that given to reach the same height.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-449"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1632028">As in many physics problems, there is more than one way to solve for the time to the highest point. In this case, the easiest method is to use <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation></m:semantics></m:math>. Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is zero, this equation reduces to simply</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-383"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            <m:mtext>.</m:mtext>
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1383088">Note that the final vertical velocity, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>, at the highest point is zero. Thus,</para>
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-50"><m:math>
+        <m:semantics>
+          <m:mrow>
+            <m:mrow>
+              <m:mtable columnalign="left">
+                <m:mtr><m:mtd>                            <m:mi>t</m:mi></m:mtd>
+<m:mtd>                            <m:mo stretchy="false">=</m:mo></m:mtd>
+<m:mtd>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+
+
+                            <m:mfrac>
+<m:mrow>
+                              <m:mn>2</m:mn>
+<m:mi>y</m:mi>
+
+</m:mrow>                                 
+                              <m:mrow>
+                                <m:mo stretchy="false">(</m:mo>
+                                <m:mrow>
+                                  <m:msub>
+                                    <m:mi>v</m:mi>
+                                    
+                                      <m:mrow>
+                                        <m:mn>0y</m:mn>
+                                      </m:mrow>
+                                    
+                                  </m:msub>
+                                  <m:mo stretchy="false">+</m:mo>
+                                  <m:msub>
+                                    <m:mi>v</m:mi>
+                                    
+                                      <m:mrow>
+                                        <m:mi>y</m:mi>
+                                      </m:mrow>
+                                    
+                                  </m:msub>
+                                </m:mrow>
+                                <m:mo stretchy="false">)</m:mo>
+                              </m:mrow>
+                            </m:mfrac>
+                          </m:mrow>
+                          <m:mo stretchy="false">=</m:mo>
+                          <m:mfrac>
+                            <m:mrow>
+                              <m:mrow>
+                                <m:mn>2</m:mn>
+                                <m:mo stretchy="false">(</m:mo>
+                                <m:mtext>233 m</m:mtext>
+                              </m:mrow>
+                               <m:mo stretchy="false">)</m:mo>
+                            </m:mrow>
+                            <m:mrow>
+                              <m:mo stretchy="false">(</m:mo>
+                              <m:mtext>67.6 m/s</m:mtext>
+                             
+                              <m:mo stretchy="false">)</m:mo>
+                            </m:mrow>
+                          </m:mfrac>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow></m:mtd>
+                </m:mtr>
+                <m:mtr><m:mtd/>
+<m:mtd><m:mo>=</m:mo></m:mtd>
+<m:mtd>
+                  <m:mrow>
+                   
+                    <m:mtext>6.90 s</m:mtext><m:mtext>.</m:mtext>
+                 
+                  </m:mrow></m:mtd>
+                </m:mtr>
+              </m:mtable>
+              <m:mrow/>
+            </m:mrow>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0">alignl { stack {
+ size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} # 
+=6 "." "90"" s" {} 
+} } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-31"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1848626">This time is also reasonable for large fireworks. When you are able to see the launch of fireworks, you will notice several seconds pass before the shell explodes. (Another way of finding the time is by using <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>, and solving the quadratic equation for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-939"><emphasis>Solution for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2262600">Because air resistance is negligible, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and the horizontal velocity is constant, as discussed above. The horizontal displacement is horizontal velocity multiplied by time as given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is equal to zero:</para><equation id="eip-675"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{x} } t ","} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1871833">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-component of the velocity, which is given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} }  "." } {}</m:annotation></m:semantics></m:math> Now,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-884"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 75.0&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>18</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>1 m/s.</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 12{0} } = \( "70" "." 0" m/s" \)  \( "cos""75.0&#186;"  \) ="18" "." 1" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2046887">The time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> for both motions is the same, and so <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-685"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mn>1 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mtext>90 s</m:mtext><m:mtext/><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>125 m.</m:mtext></m:mrow><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x= \( "18" "." 1" m/s" \)  \( 6 "." "90"" s" \) ="125"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-247"><emphasis>Discussion for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1857186">The horizontal motion is a constant velocity in the absence of air resistance. The horizontal displacement found here could be useful in keeping the fireworks fragments from falling on spectators. Once the shell explodes, air resistance has a major effect, and many fragments will land directly below.</para></example>
+    <para id="import-auto-id1986266">In solving part (a) of the preceding example, the expression we found for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is valid for any projectile motion where air resistance is negligible. Call the maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mi>h</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=h} {}</m:annotation></m:semantics></m:math>; then,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-803"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>h</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+<m:mrow>
+                      <m:mn>2</m:mn>
+<m:mi>g</m:mi>
+</m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1973673">This equation defines the <emphasis effect="italics"><emphasis effect="italics">maximum height of a projectile</emphasis></emphasis> and depends only on the vertical component of the initial velocity.</para>
+    <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1479427"><label/><title>Defining a Coordinate System</title>
+    
+    <para id="import-auto-id2275341">It is important to set up a coordinate system when analyzing projectile motion. One part of defining the coordinate system is to define an origin for the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions. Often, it is convenient to choose the initial position of the object as the origin such that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math>. It is also important to define the positive and negative directions in the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> directions. Typically, we define the positive vertical direction as upwards, and the positive horizontal direction is usually the direction of the object&#8217;s motion. When this is the case, the vertical acceleration, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>, takes a negative value (since it is directed downwards towards the Earth). However, it is occasionally useful to define the coordinates differently. For example, if you are analyzing the motion of a ball thrown downwards from the top of a cliff, it may make sense to define the positive direction downwards since the motion of the ball is solely in the downwards direction. If this is the case, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math> takes a positive value.</para>
+    </note><example id="fs-id708626">
+    <title>Calculating Projectile Motion: Hot Rock Projectile</title>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1916950">Kilauea in Hawaii is the world&#8217;s most continuously active volcano. Very active volcanoes characteristically eject red-hot rocks and lava rather than smoke and ash. Suppose a large rock is ejected from the volcano with a speed of 25.0 m/s and at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"35"&#176;} {}</m:annotation></m:semantics></m:math> above the horizontal, as shown in <link target-id="import-auto-id1817519"/>. The rock strikes the side of the volcano at an altitude 20.0 m lower than its starting point. (a) Calculate the time it takes the rock to follow this path. (b) What are the magnitude and direction of the rock&#8217;s velocity at impact?</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1817519"><media id="import-auto-id1817520" alt="The trajectory of a rock ejected from a volcano is shown. The initial velocity of rock v zero is equal to twenty five meters per second and it makes an angle of thirty five degrees with the horizontal x axis. The figure shows rock falling down a height of twenty meters below the volcano level. The velocity at this point is v which makes an angle of theta with horizontal x axis. The direction of v is south east.">
+        <image mime-type="image/jpg" src="Figure_03_04_04a.jpg" width="400"/>
+      </media>
+      
+    <caption>The trajectory of a rock ejected from the Kilauea volcano.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-770"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1823692">Again, resolving this two-dimensional motion into two independent one-dimensional motions will allow us to solve for the desired quantities. The time a projectile is in the air is governed by its vertical motion alone. We will solve for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> first. While the rock is rising and falling vertically, the horizontal motion continues at a constant velocity. This example asks for the final velocity. Thus, the vertical and horizontal results will be recombined to obtain <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> at the final time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> determined in the first part of the example.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-408"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1608071">While the rock is in the air, it rises and then falls to a final position 20.0 m lower than its starting altitude. We can find the time for this by using</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-895"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
+<m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1843834">If we take the initial position <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero, then the final position is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow></m:mrow><m:mtext>.0  m</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= - "20" "." 0" m" "." } {}</m:annotation></m:semantics></m:math> Now the initial vertical velocity is the vertical component of the initial velocity, found from  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> = (<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25" "." "0&#160;m/s"} {}</m:annotation></m:semantics></m:math>)(<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>sin 35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"sin 35"&#176;} {}</m:annotation></m:semantics></m:math>) = <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Substituting known values yields</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-722"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>0 m</m:mn><m:mrow><m:mtext/><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mn>3 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced></m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
+<m:mtext>.</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ - "20" "." 0" m"= \( "14" "." 3" m/s" \) t -  left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1561988">Rearranging terms gives a quadratic equation in <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form 
+<m:math>
+<m:semantics>
+<m:mrow><m:mrow><m:mrow><m:mrow><m:mrow>
+<m:msup>
+<m:mstyle fontstyle="italic">
+<m:mi>at</m:mi></m:mstyle><m:mn>2</m:mn>
+</m:msup>
+<m:mo stretchy="false">+</m:mo>
+
+<m:mstyle fontstyle="italic"><m:mi>bt</m:mi></m:mstyle>
+<m:mo stretchy="false">+</m:mo>
+<m:mi>c</m:mi>
+<m:mo stretchy="false">=</m:mo>
+<m:mn>0</m:mn>
+</m:mrow></m:mrow></m:mrow></m:mrow></m:mrow>
+<m:annotation encoding="StarMath 5.0"> size 12{ ital "at" rSup { size 8{2} } + ital "bt"+c=0} {}</m:annotation>
+</m:semantics>
+</m:math>, where the constants are 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>a</m:mi><m:mo>=</m:mo><m:mn>4.90</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math>, 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>b</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>14.3</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math>, and 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>c</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>20.0.</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math> Its solutions are given by the quadratic formula:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-880"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mo stretchy="false">&#8722;</m:mo>
+                          <m:mi>b</m:mi>
+                        </m:mrow>
+                        <m:mo stretchy="false">&#177;</m:mo>
+                        <m:msqrt>
+                          <m:mrow>
+                            <m:mrow>
+                              <m:msup>
+                                <m:mi>b</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msup>
+                              <m:mo stretchy="false">&#8722;</m:mo>
+                              <m:mn>4</m:mn>
+                            </m:mrow>
+                            <m:mstyle fontstyle="italic">
+                              <m:mrow>
+                                <m:mtext>ac</m:mtext>
+                              </m:mrow>
+                            </m:mstyle>
+                          </m:mrow>
+                        </m:msqrt>
+                      </m:mrow>
+                      <m:mrow><m:mtext>2</m:mtext><m:mtext fontstyle="italic">a</m:mtext></m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{t= {  { - b +-  sqrt {b rSup { size 8{2} }  - 4 ital "ac"} }  over  {"2a"} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions: 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and 
+
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{-1 "." "03""s"} {}</m:annotation></m:semantics></m:math>. The negative value of time implies an event before the start of motion, and so we discard it. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-267"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>96 s</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"" s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-46"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1368589">The time for projectile motion is completely determined by the vertical motion. So any projectile that has an initial vertical velocity of 14.3 m/s and lands 20.0 m below its starting altitude will spend 3.96 s in the air.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-653"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1599448">From the information now in hand, we can find the final horizontal and vertical velocities <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> and combine them to find the total velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and the angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> it makes with the horizontal. Of course, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is constant so we can solve for it at any horizontal location. In this case, we chose the starting point since we know both the initial velocity and initial angle. Therefore:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-873"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 35&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} } = \( "25" "." 0" m/s" \)  \( "cos""35" rSup { size 8{ circ } }  \) ="20" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2252925">The final vertical velocity is given by the following equation:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-168"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">&#8722;</m:mo><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gt,</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt,"} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2173689">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0y</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> was found in part (a) to be <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Thus,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-113"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mtext>14</m:mtext>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                  <m:mn>3 m/s</m:mn>
+                  <m:mrow>
+                    <m:mtext/>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mo stretchy="false">(</m:mo>
+                  </m:mrow>
+                  <m:mn>9</m:mn>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>80 m/s</m:mtext>
+                  <m:msup>
+                    <m:mtext/>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mn>3</m:mn>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>96 s</m:mtext>
+                  <m:mtext/>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } ="14" "." 3" m/s" -  \( 9 "." "80"" m/s" rSup { size 8{2} }  \)  \( 3 "." "96"" s" \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1792451">so that</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-571"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } = - "24" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2239982">To find the magnitude of the final velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> we combine its perpendicular components, using the following equation:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-394"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">+</m:mo><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup></m:mrow></m:msqrt></m:mrow><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:mo stretchy="false">(</m:mo><m:mtext>20</m:mtext><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:mrow><m:mrow><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">+</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:msqrt><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } = sqrt { \( "20" "." 5" m/s" \)  rSup { size 8{2} } + \(  - "24" "." 5" m/s" \)  rSup { size 8{2} } } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1677955">which gives</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-60"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>31</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>9 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v="31" "." 9" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1645980">The direction <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is found from the equation:</para>
+    
+    <equation id="eip-353"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>&#952;</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>v</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1972156">so that</para>
+    
+    <equation id="eip-589"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mrow><m:mn>5</m:mn><m:mo stretchy="false">/</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5</m:mn><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>19</m:mtext><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \(  - "24" "." 5/"20" "." 5 \) ="tan" rSup { size 8{ - 1} }  \(  - 1 "." "19" \) "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1613163">Thus,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-379"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>50</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>1</m:mn><m:mrow><m:mo stretchy="false">&#186;</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } = - "50" "." 1 rSup { size 12{ circ } "."} } {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-299"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1459619">The negative angle means that the velocity is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>50</m:mtext><m:mtext>.</m:mtext><m:mn>1&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50" "." 1&#176;} {}</m:annotation></m:semantics></m:math> below the horizontal. This result is consistent with the fact that the final vertical velocity is negative and hence downward&#8212;as you would expect because the final altitude is 20.0 m lower than the initial altitude. (See <link target-id="import-auto-id1817519"/>.)</para></example>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1532818">One of the most important things illustrated by projectile motion is that vertical and horizontal motions are independent of each other. Galileo was the first person to fully comprehend this characteristic. He used it to predict the range of a projectile. On level ground, we define <term id="import-auto-id1751163">range</term> to be the horizontal distance <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> traveled by a projectile. Galileo and many others were interested in the range of projectiles primarily for military purposes&#8212;such as aiming cannons. However, investigating the range of projectiles can shed light on other interesting phenomena, such as the orbits of satellites around the Earth. Let us consider projectile range further.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1904800"><media id="import-auto-id1904802" alt="Part a of the figure shows three different trajectories of projectiles on level ground. In each case the projectiles makes an angle of forty five degrees with the horizontal axis. The first projectile of initial velocity thirty meters per second travels a horizontal distance of R equal to ninety one point eight meters. The second projectile of initial velocity forty meters per second travels a horizontal distance of R equal to one hundred sixty three meters. The third projectile of initial velocity fifty meters per second travels a horizontal distance of R equal to two hundred fifty five meters.">
+          <image mime-type="image/jpg" src="Figure_03_04_05a.jpg" height="300"/>
+        </media>
+        
+<caption>Trajectories of projectiles on level ground. (a) The greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range for a given initial angle. (b) The effect of initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> on the range of a projectile with a given initial speed. Note that the range is the same for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>15&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"15"&#176;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mtext>75&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"75&#176;"} {}</m:annotation></m:semantics></m:math>, although the maximum heights of those paths are different.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1750749">How does the initial velocity of a projectile affect its range? Obviously, the greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range, as shown in <link target-id="import-auto-id1904800"/>(a). The initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> also has a dramatic effect on the range, as illustrated in <link target-id="import-auto-id1904800"/>(b). For a fixed initial speed, such as might be produced by a cannon, the maximum range is obtained with <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } &#160;=&#160;"45&#186;"} {}</m:annotation></m:semantics></m:math>. This is true only for conditions neglecting air resistance. If air resistance is considered, the maximum angle is approximately <m:math><m:semantics><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38&#186;"} {}</m:annotation></m:semantics></m:math>. Interestingly, for every initial angle except <m:math><m:semantics><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45&#186;"} {}</m:annotation></m:semantics></m:math>, there are two angles that give the same range&#8212;the sum of those angles is <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#186;"} {}</m:annotation></m:semantics></m:math>. The range also depends on the value of the acceleration of gravity <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. The lunar astronaut Alan Shepherd was able to drive a golf ball a great distance on the Moon because gravity is weaker there. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on <emphasis effect="italics"><emphasis effect="italics">level ground</emphasis></emphasis> for which air resistance is negligible is given by </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-240"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mtext>,</m:mtext><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1674836">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial speed and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle relative to the horizontal. The proof of this equation is left as an end-of-chapter problem (hints are given), but it does fit the major features of projectile range as described.</para>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1686986">When we speak of the range of a projectile on level ground, we assume that <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> is very small compared with the circumference of the Earth. If, however, the range is large, the Earth curves away below the projectile and acceleration of gravity changes direction along the path. The range is larger than predicted by the range equation given above because the projectile has farther to fall than it would on level ground. (See <link target-id="import-auto-id1645881"/>.) If the initial speed is great enough, the projectile goes into orbit.  This possibility was recognized centuries before it could be accomplished. When an object is in orbit, the Earth curves away from underneath the object at the same rate as it falls. The object thus falls continuously but never hits the surface. These and other aspects of orbital motion, such as the rotation of the Earth, will be covered analytically and in greater depth later in this text.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645878">Once again we see that thinking about one topic, such as the range of a projectile, can lead us to others, such as the Earth orbits. In  <link document="m42045">Addition of Velocities</link>, we will examine the addition of velocities, which is another important aspect of two-dimensional kinematics and will also yield insights beyond the immediate topic.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645881"><media id="import-auto-id1825851" alt="A figure of the Earth is shown and on top of it a very high tower is placed. A projectile satellite is launched from this very high tower with initial velocity of v zero in the horizontal direction. Several trajectories are shown with increasing range. A circular trajectory is shown indicating the satellite achieved its orbit and it is revolving around the Earth.">
+        <image mime-type="image/jpg" src="Figure_03_04_06a.jpg" width="200"/>
+      </media>
+      
+    <caption>Projectile to satellite. In each case shown here, a projectile is launched from a very high tower to avoid air resistance. With increasing initial speed, the range increases and becomes longer than it would be on level ground because the Earth curves away underneath its path. With a large enough initial speed, orbit is achieved.</caption></figure>
+<note xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-89"><label/><title>PhET Explorations: Projectile Motion</title>
+
+<para id="eip-id1169738107387">Blast a Buick out of a cannon! Learn about projectile motion by firing various objects. Set the angle, initial speed, and mass. Add air resistance. Make a game out of this simulation by trying to hit a target.</para>
+
+ <figure id="eip-id1462984"><media id="Phet_module_3.4" alt="">
+
+  <image mime-type="image/png" for="online" src="projectile-motion_en.jar" thumbnail="PhET_Icon.png" width="450"/>
+  <image mime-type="image/png" for="pdf" src="PhET_Icon.png" width="450"/>
+   
+</media>
+
+      <caption><link url="projectile-motion_en.jar">Projectile Motion</link></caption></figure></note><section id="fs-id1843457" class="section-summary">
+<title>Summary</title><list xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2130996"><item id="import-auto-id1677012">Projectile motion is the motion of an object through the air that is subject only to the acceleration of gravity.</item>
+    <item id="import-auto-id1786765">To solve projectile motion problems, perform the following steps:
+      <list id="fs-id1842700" list-type="enumerated" number-style="arabic" class="stepwise"><item id="import-auto-id1830314">Determine a coordinate system. Then, resolve the position and/or velocity of the object in the horizontal and vertical components. The components of position <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> are given by the quantities <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>, and the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction.</item>
+      <item id="import-auto-id1830316">Analyze the motion of the projectile in the horizontal direction using the following equations:
+    <equation id="eip-898"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Horizontal motion </m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>a</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mn>0</m:mn>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation>
+    <equation id="eip-236"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>x</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
+        </m:semantics>
+      </m:math> </equation>
+    <equation id="eip-612"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo>
+
+<m:msub>
+<m:mtext mathvariant="bold">v</m:mtext>
+<m:mrow>
+<m:mtext>x</m:mtext>
+</m:mrow>
+</m:msub>
+
+
+</m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math></equation></item>
+        <item id="import-auto-id1939082">Analyze the motion of the projectile in the vertical direction using the following equations:
+    <equation id="import-auto-id1939084"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Vertical motion </m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mtext>Assuming positive direction is up; </m:mtext><m:mspace width="0.25em"/>
+                  <m:mrow>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>a</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">=</m:mo>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mi>g</m:mi>
+                      </m:mrow>
+                    </m:mrow>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:mo stretchy="false">&#8722;</m:mo>
+                      <m:mn>9</m:mn>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>80 m</m:mtext>
+                  <m:msup>
+                    <m:mtext>/s</m:mtext>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Vertical motion " \( "Assuming positive direction is up; "a rSub { size 8{y} } = - g= - 9 "." "80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><equation id="import-auto-id1492830"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:mfrac>
+                        <m:mn>1</m:mn>
+                        <m:mn>2</m:mn>
+                      </m:mfrac>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><equation id="import-auto-id2022844"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:msub>
+                    <m:mi>v</m:mi>
+                    
+                      <m:mrow>
+                        <m:mi>y</m:mi>
+                      </m:mrow>
+                    
+                  </m:msub>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mstyle fontstyle="italic">
+                      <m:mrow>
+                        <m:mtext>gt</m:mtext>
+                      </m:mrow>
+                    </m:mstyle>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id1677876"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                  
+                    <m:mrow>
+                      <m:msup>
+                        <m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+<equation id="import-auto-id1653540"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mo>.</m:mo><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) } {}</m:annotation></m:semantics></m:math></equation>
+        </item>
+        <item id="import-auto-id1552181">Recombine the horizontal and vertical components of location and/or velocity using the following equations:
+    <equation id="import-auto-id2092332">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>s</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msup>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id2282348">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>&#952;</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:mi>x</m:mi>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id2274748">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>v</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id1979208"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mtext>v</m:mtext></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math></equation></item></list></item>
+  <item id="import-auto-id1888635">The maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mi>h</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h} {}</m:annotation></m:semantics></m:math> of a projectile launched with initial vertical velocity <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> is given by
+  <equation id="import-auto-id1534227"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>h</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mrow><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} } } {}</m:annotation></m:semantics></m:math></equation></item>
+    <item id="import-auto-id1823593">The maximum horizontal distance traveled by a projectile is called the <emphasis>range</emphasis>. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on level ground launched at an angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> above the horizontal with initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is given by
+  <equation id="import-auto-id1951750"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } } {}</m:annotation></m:semantics></m:math></equation></item>
+</list></section>
+    <section id="fs-id2865659" type="conceptual-questions" class="conceptual-questions"><title>Conceptual Questions</title><exercise id="fs-id2183300" type="conceptual-questions">
+        <problem id="fs-id2183302"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2298558">Answer the following questions for projectile motion on level ground assuming negligible air resistance (the initial angle being neither <m:math><m:semantics><m:mrow><m:mrow><m:mtext>0&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"0&#176;"} {}</m:annotation></m:semantics></m:math> nor <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#176;"} {}</m:annotation></m:semantics></m:math>): (a) Is the velocity ever zero? (b) When is the velocity a minimum? A maximum? (c) Can the velocity ever be the same as the initial velocity at a time other than at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=0} {}</m:annotation></m:semantics></m:math>? (d) Can the speed ever be the same as the initial speed at a time other than at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=0} {}</m:annotation></m:semantics></m:math>?
+        </para></problem>
+      </exercise>
+      <exercise id="fs-id1638420" type="conceptual-questions">
+        <problem id="fs-id1638423"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1638424">Answer the following questions for projectile motion on level ground assuming negligible air resistance (the initial angle being neither <m:math><m:semantics><m:mrow><m:mrow><m:mtext>0&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"0&#176;"} {}</m:annotation></m:semantics></m:math> nor <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#176;"} {}</m:annotation></m:semantics></m:math>): (a) Is the acceleration ever zero? (b) Is the acceleration ever in the same direction as a component of velocity? (c) Is the acceleration ever opposite in direction to a component of velocity?
+        </para></problem>
+      </exercise>
+      <exercise id="fs-id2062475" type="conceptual-questions">
+        <problem id="fs-id2062477"><para id="fs-id2062478">For a fixed initial speed, the range of a projectile is determined by the angle at which it is fired. For all but the maximum, there are two angles that give the same range. Considering factors that might affect the ability of an archer to hit a target, such as wind, explain why the smaller angle (closer to the horizontal) is preferable. When would it be necessary for the archer to use the larger angle? Why does the punter in a football game use the higher trajectory?</para></problem></exercise>
+      <exercise id="fs-id1875651" type="conceptual-questions"><problem id="fs-id1875652"><para id="fs-id1875653">During a lecture demonstration, a professor places two coins on the edge of a table. She then flicks one of the coins horizontally off the table, simultaneously nudging the other over the edge. Describe the subsequent motion of the two coins, in particular discussing whether they hit the floor at the same time.
+        </para></problem>
+        </exercise>
+    </section>
+   <section id="fs-id1875655" type="problems-exercises" class="problems-exercises"><title>Problems &amp; Exercises</title><exercise id="fs-id1923898" type="problems-exercises">      <problem id="fs-id1105650"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1105652">A projectile is launched at ground level with an initial speed of 50.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>30.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal. It strikes a target above the ground 3.00 seconds later. What are the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> distances from where the projectile was launched to where it lands?</para></problem>
+  <solution id="fs-id1543587">
+ <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1915206"><m:math><m:semantics>
+
+<m:mtable columnalign="left">
+ <m:mtr>
+  <m:mtd><m:mi>x</m:mi></m:mtd>
+  <m:mtd><m:mo stretchy="false">=</m:mo></m:mtd>
+  <m:mtd><m:mtext>1.30 m</m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mn>10</m:mn><m:mn>2</m:mn></m:msup>
+  </m:mtd>
+ </m:mtr>
+
+ <m:mtr>
+  <m:mtd><m:mi>y</m:mi></m:mtd>
+  <m:mtd><m:mo stretchy="false">=</m:mo></m:mtd>
+  <m:mtd><m:mtext>30</m:mtext><m:mtext>.9 m.</m:mtext>
+  </m:mtd>
+ </m:mtr>
+
+</m:mtable>
+</m:semantics></m:math></para></solution>
+</exercise>
+      <exercise id="fs-id1275043" type="problems-exercises"><problem id="fs-id1019417"><para id="fs-id1980036">A ball is kicked with an initial velocity of 16 m/s in the horizontal direction and 12 m/s in the vertical direction. (a) At what speed does the ball hit the ground? (b) For how long does the ball remain in the air? (c)What maximum height is attained by the ball?
+      </para></problem></exercise>
+          <exercise id="fs-id2889503" type="problems-exercises">  <problem id="fs-id1790979"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1790980">A ball is thrown horizontally from the top of a 60.0-m building and lands 100.0 m from the base of the building. Ignore air resistance. (a) How long is the ball in the air? (b) What must have been the initial horizontal component of the velocity? (c) What is the vertical component of the velocity just before the ball hits the ground? (d) What is the velocity (including both the horizontal and vertical components) of the ball just before it hits the ground?</para></problem>
+            <solution id="fs-id1945253">
+              <para id="fs-id2167208">(a) 3.50 s</para>
+              <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1612943">(b) 28.6  m/s (c) 34.3 m/s</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id916496">(d) 44.7 m/s,  <m:math><m:semantics><m:mrow><m:mn>50.2&#186;</m:mn></m:mrow></m:semantics></m:math> below horizontal</para></solution>
+          </exercise>
+      <exercise id="fs-id2197387" type="problems-exercises"><problem id="fs-id2261404"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2261405">(a) A daredevil is attempting to jump his motorcycle over a line of buses parked end to end by driving up a <m:math><m:semantics><m:mrow><m:mrow><m:mtext>32&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"32&#176;"} {}</m:annotation></m:semantics></m:math> ramp at a speed of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>40</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s&#160;</m:mtext><m:mo stretchy="false">(</m:mo><m:mtext>144&#160;km/h</m:mtext><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40" "." "0&#160;m/s&#160;" \( "144&#160;km/h" \) } {}</m:annotation></m:semantics></m:math>. How many buses can he clear if the top of the takeoff ramp is at the same height as the bus tops and the buses are 20.0 m long? (b) Discuss what your answer implies about the margin of error in this act&#8212;that is, consider how much greater the range is than the horizontal distance he must travel to miss the end of the last bus. (Neglect air resistance.)
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1420192" type="problems-exercises"><problem id="fs-id1078714"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1078715">An archer shoots an arrow at a 75.0 m distant target; the bull&#8217;s-eye of the target is at same height as the release height of the arrow. (a) At what angle must the arrow be released to hit the bull&#8217;s-eye if its initial speed is 35.0 m/s? In this part of the problem, explicitly show how you follow the steps involved in solving projectile motion problems. (b) There is a large tree halfway between the archer and the target with an overhanging horizontal branch 3.50 m above the release height of the arrow. Will the arrow go over or under the branch?</para></problem>
+        <solution id="fs-id1970452">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1970455">(a) <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mtext>4&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"18" "." "4&#176;"} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1678230">(b) The arrow will go over the branch.</para></solution>
+      </exercise>
+     <exercise id="fs-id1934878" type="problems-exercises"><problem id="fs-id2226553"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2226554">A rugby player passes the ball 7.00 m across the field, where it is caught at the same height as it left his hand. (a) At what angle was the ball thrown if its initial speed was 12.0 m/s, assuming that the smaller of the two possible angles was used? (b) What other angle gives the same range, and why would it not be used? (c) How long did this pass take?</para></problem>
+     </exercise>
+      <exercise id="fs-id2126267" type="problems-exercises"><problem id="fs-id2889922"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2889923">Verify the ranges for the projectiles in <link target-id="import-auto-id1904800"/>(a) for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="45"&#176;} {}</m:annotation></m:semantics></m:math> and the given initial velocities.</para></problem><solution id="fs-id1903883">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1912801"><m:math><m:semantics><m:mrow><m:mrow><m:mtable><m:mtr><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup>
+<m:mrow>
+<m:mtext>sin</m:mtext><m:msub><m:mn>2&#952;</m:mn><m:mn>0</m:mn></m:msub><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow></m:mtr><m:mtr><m:mrow><m:mtext>For </m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow><m:mo>,</m:mo><m:mrow/></m:mrow><m:mrow><m:mrow>
+
+<m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup><m:mi>g</m:mi></m:mfrac></m:mrow><m:mrow/></m:mrow></m:mtr></m:mtable><m:mrow/></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0">alignl { stack {
+ size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} # 
+"For "&#952;="45"&#176;: {} # 
+R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {} 
+} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>; 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>163</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math>
+
+ for 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>; 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>50</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50 m/s"} {}</m:annotation></m:semantics></m:math>.</para></solution>
+      </exercise>
+      <exercise id="fs-id2214647" type="problems-exercises"><problem id="fs-id2214182"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2214183">Verify the ranges shown for the projectiles in <link target-id="import-auto-id1904800"/>(b) for an initial velocity of 50 m/s at the given initial angles.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id2905201" type="problems-exercises"><problem id="fs-id1851487"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1851488">The cannon on a battleship can fire a shell a maximum distance of 32.0 km. (a) Calculate the initial velocity of the shell. (b) What maximum height does it reach? (At its highest, the shell is above 60% of the atmosphere&#8212;but air resistance is not really negligible as assumed to make this problem easier.) (c) The ocean is not flat, because the Earth is curved. Assume that the radius of the Earth is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mrow><m:mtext>37</m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mtext>10</m:mtext><m:mrow><m:mn>3</m:mn></m:mrow></m:msup></m:mrow><m:mspace width="0.25em"/><m:mtext> km</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{6 "." "37" times "10" rSup { size 8{3} } " km"} {}</m:annotation></m:semantics></m:math>. How many meters lower will its surface be 32.0 km from the ship along a horizontal line parallel to the surface at the ship? Does your answer imply that error introduced by the assumption of a flat Earth in projectile motion is significant here?</para></problem>
+        <solution id="fs-id2075683">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1862278">(a) 560 m/s</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2252609">(b) <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>8</m:mn><m:mtext>.</m:mtext><m:mrow><m:mtext>00 </m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mtext> 10</m:mtext><m:mrow><m:mn>3</m:mn></m:mrow></m:msup></m:mrow><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{8 "." "00 " times " 10" rSup { size 8{3} } " m"} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2262837">(c) 80.0 m. This error is not significant because it is only 1% of the answer in part (b).</para></solution>
+      </exercise>
+      <exercise id="fs-id1925728" type="problems-exercises"><problem id="fs-id2282381"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2282382">An arrow is shot from a height of 1.5 m toward a cliff of height <m:math><m:semantics><m:mrow><m:mrow><m:mi>H</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{H} {}</m:annotation></m:semantics></m:math>. It is shot with a velocity of 30 m/s at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mtext>60&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"60&#176;"} {}</m:annotation></m:semantics></m:math> above the horizontal. It lands on the top edge of the cliff 4.0 s later. (a) What is the height of the cliff? (b) What is the maximum height reached by the arrow along its trajectory? (c) What is the arrow&#8217;s impact speed just before hitting the cliff?
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1745072" type="problems-exercises"><problem id="fs-id2275266"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2275267">In the standing broad jump, one squats and then pushes off with the legs to see how far one can jump. Suppose the extension of the legs from the crouch position is 0.600 m and the acceleration achieved from this position is 1.25 times the acceleration due to gravity, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. How far can they jump? State your assumptions. (Increased range can be achieved by swinging the arms in the direction of the jump.)</para></problem>
+      <solution id="fs-id2864553">
+        <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2864555">1.50 m, assuming launch angle of  <m:math><m:semantics><m:mrow><m:mn>45&#186;</m:mn></m:mrow></m:semantics></m:math></para></solution>
+      </exercise>
+      <exercise id="fs-id1875777" type="problems-exercises"><problem id="fs-id2864558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2864559">The world long jump record is 8.95 m (Mike Powell, USA, 1991). Treated as a projectile, what is the maximum range obtainable by a person if he has a take-off speed of 9.5 m/s? State your assumptions.
+      </para></problem>
+      </exercise>
+     <exercise id="fs-id2254986" type="problems-exercises"><problem id="fs-id1543443"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1543444">Serving at a speed of 170 km/h, a tennis player hits the ball at a height of 2.5 m and an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> below the horizontal. The service line is 11.9 m from the net, which is 0.91 m high. What is the angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> such that the ball just crosses the net? Will the ball land in the service box, whose out line is 6.40 m from the net?</para></problem>
+      <solution id="fs-id722706">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2260869"><m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo>=</m:mo><m:mn>6.1&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2088346">yes, the ball lands at 5.3 m from the net</para></solution>
+      </exercise>
+      <exercise id="fs-id2173828" type="problems-exercises"><problem id="fs-id2088349"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2088350">A football quarterback is moving straight backward at a speed of 2.00 m/s when he throws a pass to a player 18.0 m straight downfield. (a) If the ball is thrown at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mtext>25&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25&#176;"} {}</m:annotation></m:semantics></m:math> relative to the ground and is caught at the same height as it is released, what is its initial speed relative to the ground? (b) How long does it take to get to the receiver? (c) What is its maximum height above its point of release?
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1796436" type="problems-exercises"><problem id="fs-id1979282"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1979284">Gun sights are adjusted to aim high to compensate for the effect of gravity, effectively making the gun accurate only for a specific range. (a) If a gun is sighted to hit targets that are at the same height as the gun and 100.0 m away, how low will the bullet hit if aimed directly at a target 150.0 m away? The muzzle velocity of the bullet is 275 m/s. (b) Discuss qualitatively how a larger muzzle velocity would affect this problem and what would be the effect of air resistance.</para></problem>
+        <solution id="fs-id2175653">
+      <para id="fs-id2175655">(a) &#8722;0.486 m</para>
+      <para id="fs-id1461088">(b) The larger the muzzle velocity, the smaller the deviation in the vertical direction, because the time of flight would be smaller. Air resistance would have the effect of decreasing the time of flight, therefore increasing the vertical deviation.</para>
+      </solution>
+      </exercise>
+      <exercise id="fs-id2177814" type="problems-exercises"><problem id="fs-id1781566"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1781567">An eagle is flying horizontally at a speed of 3.00 m/s when the fish in her talons wiggles loose and falls into the lake 5.00 m below. Calculate the velocity of the fish relative to the water when it hits the water.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1914025" type="problems-exercises"><problem id="fs-id2057849"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2057850">An owl is carrying a mouse to the chicks in its nest. Its position at that time is 4.00 m west and 12.0 m above the center of the 30.0 cm diameter nest. The owl is flying east at 3.50 m/s at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mn>30.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30&#186;}</m:annotation></m:semantics></m:math> below the horizontal when it accidentally drops the mouse. Is the owl lucky enough to have the mouse hit the nest? To answer this question, calculate the horizontal position of the mouse when it has fallen 12.0 m.</para></problem>
+        <solution id="fs-id2042074">
+        <para id="fs-id2042076">4.23 m. No, the owl is not lucky; he misses the nest.</para></solution>
+      </exercise>
+      <exercise id="fs-id1403577" type="problems-exercises"><problem id="fs-id2865734"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2865735">Suppose a soccer player kicks the ball from a distance 30 m toward the goal. Find the initial speed of the ball if it just passes over the goal, 2.4 m above the ground, given the initial direction to be <m:math><m:semantics><m:mrow><m:mrow><m:mtext>40&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40" rSup { size 8{o} } } {}</m:annotation></m:semantics></m:math> above the horizontal.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id2260735" type="problems-exercises"><problem id="fs-id1789803"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1789804">Can a goalkeeper at her/ his goal kick a soccer ball into the opponent&#8217;s goal without the ball touching the ground? The distance will be about 95 m. A goalkeeper can give the ball a speed of 30 m/s.</para></problem>
+      <solution id="fs-id1985242">
+        <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1985244">No, the maximum range (neglecting air resistance) is about 92 m. </para></solution>
+      </exercise>      
+     <exercise id="fs-id1437858" type="problems-exercises"><problem id="fs-id1891285"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1891286">The free throw line in basketball is 4.57 m (15 ft) from the basket, which is 3.05 m (10 ft) above the floor. A player standing on the free throw line throws the ball with an initial speed of 7.15 m/s, releasing it at a height of 2.44 m (8 ft) above the floor. At what angle above the horizontal must the ball be thrown to exactly hit the basket? Note that most players will use a large initial angle rather than a flat shot because it allows for a larger margin of error. Explicitly show how you follow the steps involved in solving projectile motion problems.</para></problem>
+     </exercise>
+      <exercise id="fs-id1827481" type="problems-exercises"><problem id="fs-id1750926"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1750928">In 2007, Michael Carter (U.S.) set a world record in the shot put with a throw of 24.77 m. What was the initial speed of the shot if he released it at a height of 2.10 m and threw it at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>38.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> above the horizontal? (Although the maximum distance for a projectile on level ground is achieved at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> when air resistance is neglected, the actual angle to achieve maximum range is smaller; thus, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> will give a longer range than <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> in the shot put.)</para></problem>
+        <solution id="fs-id1630701">
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2261978">15.0 m/s</para></solution>
+      </exercise>
+          <exercise id="fs-id1670278" type="problems-exercises"><problem id="fs-id1945400"><para id="fs-id1945401">A basketball player is running at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>5</m:mn><m:mtext>.</m:mtext><m:mtext>00&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{5 "." "00&#160;m/s"} {}</m:annotation></m:semantics></m:math> directly toward the basket when he jumps into the air to dunk the ball. He maintains his horizontal velocity. (a) What vertical velocity does he need to rise 0.750 m above the floor? (b) How far from the basket (measured in the horizontal direction) must he start his jump to reach his maximum height at the same time as he reaches the basket?
+          </para></problem>
+          </exercise>
+      <exercise id="fs-id1779635" type="problems-exercises">
+        <problem id="fs-id1637691"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1637692">A football player punts the ball at a <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>45.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#176;} {}</m:annotation></m:semantics></m:math> angle. Without an effect from the wind, the ball would travel 60.0 m horizontally. (a) What is the initial speed of the ball? (b) When the ball is near its maximum height it experiences a brief gust of wind that reduces its horizontal velocity by 1.50 m/s. What distance does the ball travel horizontally?</para></problem>
+      <solution id="fs-id1545352">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1545354">(a) 24.2 m/s
+</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1796132">(b) The ball travels a total of 57.4 m with the brief gust of wind.</para></solution>
+      </exercise>
+<exercise id="fs-id2046931" type="problems-exercises">
+  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mo>&#8211;</m:mo><m:mo stretchy="false">(</m:mo><m:mrow><m:mn>1</m:mn><m:mo stretchy="false">/</m:mo><m:mn>2</m:mn></m:mrow><m:mo stretchy="false">)</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=&#965; rSub { size 8{0y} } t \( 1/2 \)  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> (These equations describe the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions of a projectile that starts at the origin.) You should obtain an equation of the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> where <m:math><m:semantics><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{b} {}</m:annotation></m:semantics></m:math> are constants.
+</para></problem>
+</exercise>
+<exercise id="fs-id2133758" type="problems-exercises"><problem id="fs-id2890360"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2890361">Derive <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mn>2&#952;</m:mn><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } } {}</m:annotation></m:semantics></m:math> for the range of a projectile on level ground by finding the time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> at which <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> becomes zero and substituting this value of <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> into the expression for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x - x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, noting that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=x - x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math></para></problem>
+<solution id="eip-id2932521">
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id2932523"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mi>gt</m:mi></m:mstyle><m:mn>2</m:mn></m:msup><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo>
+
+</m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mi>gt</m:mi></m:mstyle><m:mn>2</m:mn></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y - y rSub { size 8{0} } =0=v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } = \( v rSub { size 8{0} } "sin"&#952; \) t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>,</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1990384">so that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:mn>2</m:mn><m:mo stretchy="false">(</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/>
+<m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+<m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t= {  {2 \( v rSub { size 8{0} } "sin"&#952; \) }  over  {g} } } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1355828"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/>
+<m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+<m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mi>R</m:mi></m:mrow><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x - x rSub { size 8{0} } =v rSub { size 8{0x} } t= \( v rSub { size 8{0} } "cos"&#952; \) t=R,} {}</m:annotation></m:semantics></m:math> and substituting for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> gives:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3306953"><m:math>
+        <m:semantics>
+          <m:mrow>
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>R</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msub>
+<m:mstyle fontstyle="italic">
+                      <m:mi>v</m:mi> </m:mstyle>
+                          <m:mn>0</m:mn>
+                    </m:msub>
+                  </m:mrow><m:mspace width="0.25em"/>
+                  <m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+                  <m:mi>&#952;</m:mi>
+                  <m:mrow>
+                    <m:mfenced open="(" close=")">
+                      <m:mfrac>
+
+                        <m:mrow>
+                          <m:msub>
+<m:mrow>
+                            <m:mn>2</m:mn>
+<m:mi>v</m:mi>
+</m:mrow>
+                                <m:mn>0</m:mn>
+                          </m:msub><m:mspace width="0.25em"/>
+                          <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+                          <m:mi>&#952;</m:mi>
+                        </m:mrow>
+                        <m:mi>g</m:mi>
+                      </m:mfrac>
+                    </m:mfenced>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mrow>
+                        <m:msubsup>
+<m:mrow>
+                          <m:mn>2</m:mn> <m:mi>v</m:mi>
+</m:mrow>
+                          <m:mn>0</m:mn>
+                          <m:mn>2</m:mn>
+                 
+                        </m:msubsup><m:mspace width="0.25em"/>
+                        <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+                        <m:mi>&#952;</m:mi><m:mspace width="0.25em"/>
+                        <m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+                        <m:mi>&#952;</m:mi>
+                      </m:mrow>
+                      <m:mi>g</m:mi>
+                    </m:mfrac>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{R=v rSub { size 8{0} } "cos"&#952; left ( {  {2v rSub { size 8{0} } "sin"&#952;}  over  {g} }  right )= {  {2v rSub { size 8{0}   rSup { size 8{2} } } "sin"&#952;"cos"&#952;}  over  {g} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1599732">since <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>2</m:mn><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>sin</m:mtext><m:mspace width="0.25em"/></m:mrow><m:mn>2&#952;</m:mn><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{2"sin"&#952;"cos"&#952;="sin"2&#952;,} {}</m:annotation></m:semantics></m:math> the range is:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3385487"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow>
+<m:msup>
+<m:msub>
+<m:mi>v</m:mi>
+
+
+<m:mn>0</m:mn></m:msub>
+<m:mrow>
+<m:mn>2</m:mn>
+</m:mrow>
+</m:msup><m:mspace width="0.25em"/>
+<m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mn>2&#952;</m:mn></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ {underline  {R= {  {v rSub { size 8{0}   rSup { size 8{2} } } "sin"2&#952;}  over  {g} } }} } {}</m:annotation></m:semantics></m:math>.</para></solution></exercise>
+
+    
+    
+    
+    
+ 
+<exercise id="fs-id1794949" type="problems-exercises"><problem id="fs-id1626931"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1626932"><emphasis>Unreasonable Results</emphasis> (a) Find the maximum range of a super cannon that has a muzzle velocity of 4.0 km/s. (b) What is unreasonable about the range you found? (c) Is the premise unreasonable or is the available equation inapplicable? Explain your answer. (d) If such a muzzle velocity could be obtained, discuss the effects of air resistance, thinning air with altitude, and the curvature of the Earth on the range of the super cannon.
+</para></problem>
+</exercise>
+ <exercise xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1815382" type="problems-exercises"><problem id="fs-id2255165"><para id="fs-id2255166"><emphasis>Construct Your Own Problem</emphasis> Consider a ball tossed over a fence. Construct a problem in which you calculate the ball&#8217;s needed initial velocity to just clear the fence. Among the things to determine are; the height of the fence, the distance to the fence from the point of release of the ball, and the height at which the ball is released. You should also consider whether it is possible to choose the initial speed for the ball and just calculate the angle at which it is thrown. Also examine the possibility of multiple solutions given the distances and heights you have chosen.
+ </para></problem>
+</exercise></section>
+</content>
+    <glossary>
+      <definition id="import-auto-id2275857"><term>air resistance</term> <meaning id="fs-id1668212">a frictional force that slows the motion of objects as they travel through the air; when solving basic physics problems, air resistance is assumed to be zero</meaning></definition>
+      
+<definition id="fs-id1405173"><term>kinematics</term><meaning id="fs-id1949378">the study of motion without regard to mass or force</meaning></definition>
+
+<definition id="fs-id1949381"><term>motion</term><meaning id="fs-id2324535">displacement of an object as a function of time</meaning></definition>
+
+<definition id="import-auto-id1459204"><term>projectile</term> <meaning id="fs-id1798529">an object that travels through the air and experiences only acceleration due to gravity</meaning></definition>
+
+      <definition id="import-auto-id1981500"><term>projectile motion</term> <meaning id="fs-id2253704">the motion of an object that is subject only to the acceleration of gravity</meaning></definition>
+      <definition id="import-auto-id2257218"><term>range</term> <meaning id="fs-id1883200">the maximum horizontal distance that a projectile travels</meaning></definition>
+      <definition id="import-auto-id2852095"><term>trajectory</term> <meaning id="fs-id2222621">the path of a projectile through the air</meaning></definition>
+    </glossary>
+</document>

--- a/cnxml/tests/data/invalid-derived-from.cnxml
+++ b/cnxml/tests/data/invalid-derived-from.cnxml
@@ -42,44 +42,44 @@
        where CONTENT_URL is the value provided above in the <md:content-url> element.
   -->
   <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
-  <md:repository>http://legacy-staging.cnx.org/content</md:repository>
-  <md:content-url>http://legacy-staging.cnx.org/content/m48590/1.11</md:content-url>
-  <md:content-id>m48590</md:content-id>
-  <md:title>Introduction</md:title>
-  <md:version>1.11</md:version>
-  <md:created>2014/01/01 13:57:36 -0600</md:created>
-  <md:revised>2015/06/24 10:59:20 -0500</md:revised>
-  <md:actors>
-    <md:person userid="cnxecon">
-      <md:firstname>OpenStax</md:firstname>
-      <md:surname>College</md:surname>
-      <md:fullname>OpenStax Economics</md:fullname>
-      <md:email>info@openstaxcollege.org</md:email>
-    </md:person>
-    <md:organization userid="OpenStaxCollege">
-      <md:shortname>OpenStax</md:shortname>
-      <md:fullname>OpenStax</md:fullname>
-      <md:email>info@openstax.org</md:email>
-    </md:organization>
-    <md:person userid="OSCRiceUniversity">
-      <md:firstname>Rice</md:firstname>
-      <md:surname>University</md:surname>
-      <md:fullname>Rice University</md:fullname>
-      <md:email>info@openstaxcollege.org</md:email>
-    </md:person>
-  </md:actors>
-  <md:roles>
-    <md:role type="author">OpenStaxCollege</md:role>
-    <md:role type="maintainer">OpenStaxCollege cnxecon</md:role>
-    <md:role type="licensor">OSCRiceUniversity</md:role>
-  </md:roles>
-  <md:license url="http://creativecommons.org/licenses/by/4.0/" />
-  <!-- For information on license requirements for use or modification, see license url in the
-       above <md:license> element.
-       For information on formatting required attribution, see the URL:
-         CONTENT_URL/content_info#cnx_cite_header
-       where CONTENT_URL is the value provided above in the <md:content-url> element.
-  -->
+    <md:repository>http://legacy-staging.cnx.org/content</md:repository>
+    <md:content-url>http://legacy-staging.cnx.org/content/m48590/1.11</md:content-url>
+    <md:content-id>m48590</md:content-id>
+    <md:title>Introduction</md:title>
+    <md:version>1.11</md:version>
+    <md:created>2014/01/01 13:57:36 -0600</md:created>
+    <md:revised>2015/06/24 10:59:20 -0500</md:revised>
+    <md:actors>
+      <md:person userid="cnxecon">
+        <md:firstname>OpenStax</md:firstname>
+        <md:surname>College</md:surname>
+        <md:fullname>OpenStax Economics</md:fullname>
+        <md:email>info@openstaxcollege.org</md:email>
+      </md:person>
+      <md:organization userid="OpenStaxCollege">
+        <md:shortname>OpenStax</md:shortname>
+        <md:fullname>OpenStax</md:fullname>
+        <md:email>info@openstax.org</md:email>
+      </md:organization>
+      <md:person userid="OSCRiceUniversity">
+        <md:firstname>Rice</md:firstname>
+        <md:surname>University</md:surname>
+        <md:fullname>Rice University</md:fullname>
+        <md:email>info@openstaxcollege.org</md:email>
+      </md:person>
+    </md:actors>
+    <md:roles>
+      <md:role type="author">OpenStaxCollege</md:role>
+      <md:role type="maintainer">OpenStaxCollege cnxecon</md:role>
+      <md:role type="licensor">OSCRiceUniversity</md:role>
+    </md:roles>
+    <md:license url="http://creativecommons.org/licenses/by/4.0/" />
+    <!-- For information on license requirements for use or modification, see license url in the
+         above <md:license> element.
+         For information on formatting required attribution, see the URL:
+           CONTENT_URL/content_info#cnx_cite_header
+         where CONTENT_URL is the value provided above in the <md:content-url> element.
+    -->
   </md:derived-from>
   <md:keywordlist>
     <md:keyword>Air resistance</md:keyword>
@@ -104,16 +104,16 @@
 </metadata>
 
 <content>
-    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple: 
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple:
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical, 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical,
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math>. Both accelerations are constant, so the kinematic equations can be used.</para><note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1767845"><label/><title>Review of Kinematic Equations (constant <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow></m:mrow></m:mrow></m:semantics></m:math>)</title>
-    
+
     <equation id="eip-891"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -123,11 +123,11 @@
                           </m:mrow>
                           <m:msub>
                             <m:mi>x</m:mi>
-                            
+
                               <m:mrow>
                                 <m:mn>0</m:mn>
                               </m:mrow>
-                            
+
                           </m:msub>
                           <m:mrow>
                             <m:mi/>
@@ -141,7 +141,7 @@
                           <m:mi>t</m:mi>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{x=`x rSub { size 8{0} } `+` { bar  {v}}t} {}</m:annotation>
@@ -149,7 +149,7 @@
               </m:math> </equation><equation id="eip-557"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -164,11 +164,11 @@
                             <m:mrow>
                               <m:msub>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                               <m:mo stretchy="false">+</m:mo>
                               <m:mi>v</m:mi>
@@ -177,16 +177,16 @@
                           </m:mfrac>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{ { bar  {v}}=` {  {v rSub { size 8{0} } +v}  over  {2} } } {}</m:annotation>
                 </m:semantics>
-              </m:math> 
+              </m:math>
 </equation><equation id="eip-405"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mi>v</m:mi>
@@ -194,11 +194,11 @@
                           <m:mrow>
                             <m:msub>
                               <m:mi>v</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>0</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msub>
                             <m:mo stretchy="false">+</m:mo>
                             <m:mstyle fontstyle="italic">
@@ -209,7 +209,7 @@
                           </m:mrow>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{v=v rSub { size 8{0} } + ital "at"} {}</m:annotation>
@@ -218,7 +218,7 @@
 </equation><equation id="eip-556"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -227,20 +227,20 @@
                             <m:mrow>
                               <m:msub>
                                 <m:mi>x</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                               <m:mo stretchy="false">+</m:mo>
                               <m:msub>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                             </m:mrow>
                           </m:mrow>
@@ -255,16 +255,16 @@
                             <m:mrow>
                               <m:msup>
                                 <m:mtext fontstyle="italic">at</m:mtext>
-                                
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
 </m:msup>
                             </m:mrow>
-                        
+
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{0} } t+ {  {1}  over  {2} }  ital "at" rSup { size 8{2} } } {}</m:annotation>
@@ -272,32 +272,32 @@
               </m:math> </equation><equation id="eip-389"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
                             <m:msup>
                               <m:mi>v</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>2</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msup>
                             <m:mo stretchy="false">=</m:mo>
                             <m:mrow>
                               <m:msubsup>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
-                                
+
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msubsup>
                               <m:mo stretchy="false">+</m:mo>
                               <m:mn>2</m:mn><m:mi>a</m:mi>
@@ -309,11 +309,11 @@
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:msub>
                               <m:mi>x</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>0</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msub>
                           </m:mrow>
                           <m:mo stretchy="false">)</m:mo>
@@ -324,32 +324,32 @@
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{v rSup { size 8{2} } =v rSub { size 8{0} }  rSup { size 8{2} } +2a \( x - x rSub { size 8{0} }  \) } {}</m:annotation>
                 </m:semantics>
-              </m:math> 
+              </m:math>
 </equation></note><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2242290"><media id="import-auto-id1402609" alt="A soccer player is kicking a soccer ball. The ball travels in a projectile motion and reaches a point whose vertical distance is y and horizontal distance is x. The displacement between the kicking point and the final point is s. The angle made by this displacement vector with x axis is theta.">
         <image mime-type="image/jpg" src="Figure_03_04_01.jpg" width="350"/>
       </media>
-      
+
     <caption>The total displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> of a soccer ball at a point along its path. The vector <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> has components <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> along the horizontal and vertical axes. Its magnitude is <m:math><m:semantics><m:mrow><m:mrow><m:mi>s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math>, and it makes an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> with the horizontal.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-36">Given these assumptions, the following steps are then used to analyze projectile motion:</para>
 
-<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so 
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction, as shown in <link target-id="import-auto-id1815222"/>. Initial values are denoted with a subscript 0, as usual.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-205"><emphasis effect="italics"><emphasis>Step 2.</emphasis></emphasis>  <emphasis effect="italics">Treat the motion as two independent one-dimensional motions, one horizontal and the other vertical.</emphasis> The kinematic equations for horizontal and vertical motion take the following forms:
 </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-338"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Horizontal Motion</m:mtext>
@@ -357,11 +357,11 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>a</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mn>0</m:mn>
@@ -369,16 +369,16 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal Motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-362"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -387,37 +387,37 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-627"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-293"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Vertical Motion</m:mtext>
@@ -430,11 +430,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>a</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">=</m:mo>
                       <m:mrow>
@@ -448,23 +448,23 @@
                         <m:mo stretchy="false">&#8722;</m:mo>
                         <m:mn>9.</m:mn>
                       </m:mrow>
-                     
+
                       <m:mtext>80</m:mtext>
                     </m:mrow>
                   </m:mrow>
                   <m:mo stretchy="false"> </m:mo>
                   <m:msup>
                     <m:mtext>m/s</m:mtext>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Vertical Motion " \( "assuming positive is up "a rSub { size 8{y} } = - g= - 9/"80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
@@ -472,7 +472,7 @@
       </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-131"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -481,11 +481,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:mfrac>
@@ -498,55 +498,55 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-305"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:msub>
                     <m:mi>v</m:mi>
-                    
+
                       <m:mrow>
                         <m:mi>y</m:mi>
                       </m:mrow>
-                    
+
                   </m:msub>
                   <m:mo stretchy="false">=</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">&#8722;</m:mo>
                     <m:mstyle fontstyle="italic">
@@ -557,16 +557,16 @@
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-542"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -575,21 +575,21 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
-                          
+
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
@@ -601,33 +601,33 @@
                       <m:mn>2</m:mn>
                     </m:mfrac>
                   </m:mrow>
-                
+
                     <m:mrow>
                       <m:msup>
                         <m:mi fontstyle="italic">gt</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
-         
+
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-243"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-708"><emphasis effect="italics"><emphasis>Step 3.</emphasis></emphasis>  <emphasis effect="italics"> Solve for the unknowns in the two separate motions&#8212;one horizontal and one vertical.</emphasis> Note that the only common variable between the motions is time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>. The problem solving procedures here are the same as for one-dimensional <term>kinematics</term> and are illustrated in the solved examples below.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-979"><emphasis effect="italics"><emphasis>Step 4.</emphasis></emphasis>  <emphasis effect="italics">Recombine the two motions to find the total displacement</emphasis> <m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">s</m:mtext></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math><emphasis effect="italics"> and velocity </emphasis><m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">v</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>. Because the <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are perpendicular, we determine these vectors by using the techniques outlined in the <link document="m42128">Vector Addition and Subtraction: Analytical Methods</link> and employing <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>A</m:mi>
@@ -636,46 +636,46 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>A</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>A</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
         and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( A rSub { size 8{y} } /A rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math> in the following form, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is the direction of the displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is the direction of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>:
 </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-245"><emphasis>Total displacement and velocity</emphasis></para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-743"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>s</m:mi>
@@ -684,26 +684,26 @@
                     <m:mrow>
                       <m:msup>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msup>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
@@ -711,7 +711,7 @@
       </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-373"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -719,14 +719,14 @@
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
@@ -738,16 +738,16 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-679"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>v</m:mi>
@@ -756,59 +756,59 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-264"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1815222"><media id="import-auto-id2275311" alt="In part a the figure shows projectile motion of a ball with initial velocity of v zero at an angle of theta zero with the horizontal x axis. The horizontal component v x and the vertical component v y at various positions of ball in the projectile path is shown. In part b only the horizontal velocity component v sub x is shown whose magnitude is constant at various positions in the path. In part c only vertical velocity component v sub y is shown. The vertical velocity component v sub y is upwards till it reaches the maximum point and then its direction changes to downwards. In part d resultant v of horizontal velocity component v sub x and downward vertical velocity component v sub y is found which makes an angle theta with the horizontal x axis. The direction of resultant velocity v is towards south east.">
           <image mime-type="image/jpg" src="Figure_03_04_02.jpg" height="600"/>
         </media>
-        
+
   <caption>(a) We analyze two-dimensional projectile motion by breaking it into two independent one-dimensional motions along the vertical and horizontal axes. (b) The horizontal motion is simple, because <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is thus constant. (c) The velocity in the vertical direction begins to decrease as the object rises; at its highest point, the vertical velocity is zero. As the object falls towards the Earth again, the vertical velocity increases again in magnitude but points in the opposite direction to the initial vertical velocity. (d) The <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are recombined to give the total velocity at any given point on the trajectory.</caption></figure><example id="fs-id2175010">
     <title>A Fireworks Projectile Explodes High and Away</title>
-    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and  
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero and solve for the desired quantities.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-774"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1669571">By &#8220;height&#8221; we mean the altitude or vertical position <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> above the starting point. The highest point in any trajectory, called the apex, is reached when <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ v rSub { size 8{y} } =0} {}</m:annotation></m:semantics></m:math>. Since we know the initial and final velocities as well as the initial position, we use the following equation to find <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>:
 
 </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-734"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id934168"><media id="import-auto-id1576299" alt="The x y graph shows the trajectory of fireworks shell. The initial velocity of the shell v zero is at angle theta zero equal to seventy five degrees with the horizontal x axis. The fuse is set to explode the shell at the highest point of the trajectory which is at a height h equal to two hundred thirty three meters and at a horizontal distance x equal to one hundred twenty five meters from the origin.">
         <image mime-type="image/jpg" src="Figure_03_04_03a.jpg" height="250"/>
       </media>
-      
+
     <caption>The trajectory of a fireworks shell. The fuse is set to explode the shell at the highest point in its trajectory, which is found to be at a height of 233 m and 125 m away horizontally.</caption></figure><para id="import-auto-id1163607">Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> are both zero, the equation simplifies to</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-42"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mn>0</m:mn><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
@@ -816,7 +816,7 @@
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-256"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -825,16 +825,16 @@
                     <m:mfrac>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
-                         
+
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                      <m:mrow> <m:mn>2</m:mn><m:mi>g</m:mi></m:mrow>
                     </m:mfrac>
@@ -842,24 +842,24 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
-    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find 
+      </m:math>
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>75.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-677"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70.0 m/s</m:mtext><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>sin 75&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>67.6 m/s.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } = \( "70" "." 0" m/s" \)  \( "sin""75" { size 12{ circ } }  \) ="67" "." 6" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2271493">and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-512"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>y</m:mi>
@@ -871,11 +871,11 @@
                       <m:mtext>.6 m/s</m:mtext>
                       <m:msup>
                         <m:mo stretchy="false">)</m:mo>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                     <m:mrow>
@@ -886,11 +886,11 @@
                       <m:mtext>80 m</m:mtext>
                       <m:msup>
                         <m:mtext>/s</m:mtext>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">)</m:mo>
                     </m:mrow>
@@ -903,13 +903,13 @@
 
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  { \( "67" "." 6" m/s" \)  rSup { size 8{2} } }  over  {2 \( 9 "." "80"" m/s" rSup { size 8{2} }  \) } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1919502">so that</para>
-    
+
     <equation id="eip-310"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>233</m:mtext></m:mrow><m:mo stretchy="false"> </m:mo><m:mtext> m.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y="233"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-429"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2165781">Note that because up is positive, the initial velocity is positive, as is the maximum height, but the acceleration due to gravity is negative. Note also that the maximum height depends only on the vertical component of the initial velocity, so that any projectile with a 67.6 m/s initial vertical component of velocity will reach a maximum height of 233 m (neglecting air resistance). The numbers in this example are reasonable for large fireworks displays, the shells of which do reach such heights before exploding. In practice, air resistance is not completely negligible, and so the initial velocity would have to be somewhat larger than that given to reach the same height.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-449"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1632028">As in many physics problems, there is more than one way to solve for the time to the highest point. In this case, the easiest method is to use <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation></m:semantics></m:math>. Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is zero, this equation reduces to simply</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-383"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -924,20 +924,20 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
@@ -949,7 +949,7 @@
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1383088">Note that the final vertical velocity, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>, at the highest point is zero. Thus,</para>
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-50"><m:math>
         <m:semantics>
@@ -960,7 +960,7 @@
 <m:mtd>                            <m:mo stretchy="false">=</m:mo></m:mtd>
 <m:mtd>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -971,26 +971,26 @@
                               <m:mn>2</m:mn>
 <m:mi>y</m:mi>
 
-</m:mrow>                                 
+</m:mrow>
                               <m:mrow>
                                 <m:mo stretchy="false">(</m:mo>
                                 <m:mrow>
                                   <m:msub>
                                     <m:mi>v</m:mi>
-                                    
+
                                       <m:mrow>
                                         <m:mn>0y</m:mn>
                                       </m:mrow>
-                                    
+
                                   </m:msub>
                                   <m:mo stretchy="false">+</m:mo>
                                   <m:msub>
                                     <m:mi>v</m:mi>
-                                    
+
                                       <m:mrow>
                                         <m:mi>y</m:mi>
                                       </m:mrow>
-                                    
+
                                   </m:msub>
                                 </m:mrow>
                                 <m:mo stretchy="false">)</m:mo>
@@ -1010,13 +1010,13 @@
                             <m:mrow>
                               <m:mo stretchy="false">(</m:mo>
                               <m:mtext>67.6 m/s</m:mtext>
-                             
+
                               <m:mo stretchy="false">)</m:mo>
                             </m:mrow>
                           </m:mfrac>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow></m:mtd>
                 </m:mtr>
@@ -1024,9 +1024,9 @@
 <m:mtd><m:mo>=</m:mo></m:mtd>
 <m:mtd>
                   <m:mrow>
-                   
+
                     <m:mtext>6.90 s</m:mtext><m:mtext>.</m:mtext>
-                 
+
                   </m:mrow></m:mtd>
                 </m:mtr>
               </m:mtable>
@@ -1034,18 +1034,18 @@
             </m:mrow>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0">alignl { stack {
- size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} # 
-=6 "." "90"" s" {} 
+ size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} #
+=6 "." "90"" s" {}
 } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-31"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1848626">This time is also reasonable for large fireworks. When you are able to see the launch of fireworks, you will notice several seconds pass before the shell explodes. (Another way of finding the time is by using <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>, and solving the quadratic equation for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-939"><emphasis>Solution for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2262600">Because air resistance is negligible, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and the horizontal velocity is constant, as discussed above. The horizontal displacement is horizontal velocity multiplied by time as given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is equal to zero:</para><equation id="eip-675"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{x} } t ","} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1871833">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-component of the velocity, which is given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} }  "." } {}</m:annotation></m:semantics></m:math> Now,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-884"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 75.0&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>18</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>1 m/s.</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 12{0} } = \( "70" "." 0" m/s" \)  \( "cos""75.0&#186;"  \) ="18" "." 1" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2046887">The time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> for both motions is the same, and so <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-685"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mn>1 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mtext>90 s</m:mtext><m:mtext/><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>125 m.</m:mtext></m:mrow><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x= \( "18" "." 1" m/s" \)  \( 6 "." "90"" s" \) ="125"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-247"><emphasis>Discussion for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1857186">The horizontal motion is a constant velocity in the absence of air resistance. The horizontal displacement found here could be useful in keeping the fireworks fragments from falling on spectators. Once the shell explodes, air resistance has a major effect, and many fragments will land directly below.</para></example>
     <para id="import-auto-id1986266">In solving part (a) of the preceding example, the expression we found for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is valid for any projectile motion where air resistance is negligible. Call the maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mi>h</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=h} {}</m:annotation></m:semantics></m:math>; then,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-803"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1054,17 +1054,17 @@
                     <m:mfrac>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
 <m:mrow>
                       <m:mn>2</m:mn>
@@ -1075,27 +1075,27 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1973673">This equation defines the <emphasis effect="italics"><emphasis effect="italics">maximum height of a projectile</emphasis></emphasis> and depends only on the vertical component of the initial velocity.</para>
     <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1479427"><label/><title>Defining a Coordinate System</title>
-    
+
     <para id="import-auto-id2275341">It is important to set up a coordinate system when analyzing projectile motion. One part of defining the coordinate system is to define an origin for the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions. Often, it is convenient to choose the initial position of the object as the origin such that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math>. It is also important to define the positive and negative directions in the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> directions. Typically, we define the positive vertical direction as upwards, and the positive horizontal direction is usually the direction of the object&#8217;s motion. When this is the case, the vertical acceleration, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>, takes a negative value (since it is directed downwards towards the Earth). However, it is occasionally useful to define the coordinates differently. For example, if you are analyzing the motion of a ball thrown downwards from the top of a cliff, it may make sense to define the positive direction downwards since the motion of the ball is solely in the downwards direction. If this is the case, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math> takes a positive value.</para>
     </note><example id="fs-id708626">
     <title>Calculating Projectile Motion: Hot Rock Projectile</title>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1916950">Kilauea in Hawaii is the world&#8217;s most continuously active volcano. Very active volcanoes characteristically eject red-hot rocks and lava rather than smoke and ash. Suppose a large rock is ejected from the volcano with a speed of 25.0 m/s and at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"35"&#176;} {}</m:annotation></m:semantics></m:math> above the horizontal, as shown in <link target-id="import-auto-id1817519"/>. The rock strikes the side of the volcano at an altitude 20.0 m lower than its starting point. (a) Calculate the time it takes the rock to follow this path. (b) What are the magnitude and direction of the rock&#8217;s velocity at impact?</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1817519"><media id="import-auto-id1817520" alt="The trajectory of a rock ejected from a volcano is shown. The initial velocity of rock v zero is equal to twenty five meters per second and it makes an angle of thirty five degrees with the horizontal x axis. The figure shows rock falling down a height of twenty meters below the volcano level. The velocity at this point is v which makes an angle of theta with horizontal x axis. The direction of v is south east.">
         <image mime-type="image/jpg" src="Figure_03_04_04a.jpg" width="400"/>
       </media>
-      
+
     <caption>The trajectory of a rock ejected from the Kilauea volcano.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-770"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1823692">Again, resolving this two-dimensional motion into two independent one-dimensional motions will allow us to solve for the desired quantities. The time a projectile is in the air is governed by its vertical motion alone. We will solve for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> first. While the rock is rising and falling vertically, the horizontal motion continues at a constant velocity. This example asks for the final velocity. Thus, the vertical and horizontal results will be recombined to obtain <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> at the final time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> determined in the first part of the example.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-408"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1608071">While the rock is in the air, it rises and then falls to a final position 20.0 m lower than its starting altitude. We can find the time for this by using</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-895"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
 <m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1843834">If we take the initial position <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero, then the final position is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow></m:mrow><m:mtext>.0  m</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= - "20" "." 0" m" "." } {}</m:annotation></m:semantics></m:math> Now the initial vertical velocity is the vertical component of the initial velocity, found from  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> = (<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25" "." "0&#160;m/s"} {}</m:annotation></m:semantics></m:math>)(<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>sin 35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"sin 35"&#176;} {}</m:annotation></m:semantics></m:math>) = <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Substituting known values yields</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-722"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>0 m</m:mn><m:mrow><m:mtext/><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mn>3 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced></m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
 <m:mtext>.</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ - "20" "." 0" m"= \( "14" "." 3" m/s" \) t -  left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1561988">Rearranging terms gives a quadratic equation in <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>:</para>
-    
-    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form 
+
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form
 <m:math>
 <m:semantics>
 <m:mrow><m:mrow><m:mrow><m:mrow><m:mrow>
@@ -1113,17 +1113,17 @@
 </m:mrow></m:mrow></m:mrow></m:mrow></m:mrow>
 <m:annotation encoding="StarMath 5.0"> size 12{ ital "at" rSup { size 8{2} } + ital "bt"+c=0} {}</m:annotation>
 </m:semantics>
-</m:math>, where the constants are 
+</m:math>, where the constants are
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
 <m:mi>a</m:mi><m:mo>=</m:mo><m:mn>4.90</m:mn>
-</m:mrow></m:mrow></m:semantics></m:math>, 
+</m:mrow></m:mrow></m:semantics></m:math>,
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
 <m:mi>b</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>14.3</m:mn>
-</m:mrow></m:mrow></m:semantics></m:math>, and 
+</m:mrow></m:mrow></m:semantics></m:math>, and
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
@@ -1131,7 +1131,7 @@
 </m:mrow></m:mrow></m:semantics></m:math> Its solutions are given by the quadratic formula:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-880"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1149,11 +1149,11 @@
                             <m:mrow>
                               <m:msup>
                                 <m:mi>b</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msup>
                               <m:mo stretchy="false">&#8722;</m:mo>
                               <m:mn>4</m:mn>
@@ -1172,39 +1172,39 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{t= {  { - b +-  sqrt {b rSup { size 8{2} }  - 4 ital "ac"} }  over  {"2a"} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
-    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions: 
+      </m:math>
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions:
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and
 
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{-1 "." "03""s"} {}</m:annotation></m:semantics></m:math>. The negative value of time implies an event before the start of motion, and so we discard it. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-267"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>96 s</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"" s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-46"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1368589">The time for projectile motion is completely determined by the vertical motion. So any projectile that has an initial vertical velocity of 14.3 m/s and lands 20.0 m below its starting altitude will spend 3.96 s in the air.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-653"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1599448">From the information now in hand, we can find the final horizontal and vertical velocities <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> and combine them to find the total velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and the angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> it makes with the horizontal. Of course, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is constant so we can solve for it at any horizontal location. In this case, we chose the starting point since we know both the initial velocity and initial angle. Therefore:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-873"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 35&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} } = \( "25" "." 0" m/s" \)  \( "cos""35" rSup { size 8{ circ } }  \) ="20" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2252925">The final vertical velocity is given by the following equation:</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-168"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">&#8722;</m:mo><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gt,</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt,"} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2173689">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0y</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> was found in part (a) to be <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Thus,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-113"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mtext>14</m:mtext>
@@ -1221,11 +1221,11 @@
                   <m:mtext>80 m/s</m:mtext>
                   <m:msup>
                     <m:mtext/>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mo stretchy="false">(</m:mo>
@@ -1236,91 +1236,91 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } ="14" "." 3" m/s" -  \( 9 "." "80"" m/s" rSup { size 8{2} }  \)  \( 3 "." "96"" s" \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1792451">so that</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-571"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } = - "24" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2239982">To find the magnitude of the final velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> we combine its perpendicular components, using the following equation:</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-394"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">+</m:mo><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup></m:mrow></m:msqrt></m:mrow><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:mo stretchy="false">(</m:mo><m:mtext>20</m:mtext><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:mrow><m:mrow><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">+</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:msqrt><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } = sqrt { \( "20" "." 5" m/s" \)  rSup { size 8{2} } + \(  - "24" "." 5" m/s" \)  rSup { size 8{2} } } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1677955">which gives</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-60"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>31</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>9 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v="31" "." 9" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1645980">The direction <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is found from the equation:</para>
-    
+
     <equation id="eip-353"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
                     <m:msub>
                       <m:mi>&#952;</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>v</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">/</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1972156">so that</para>
-    
+
     <equation id="eip-589"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mrow><m:mn>5</m:mn><m:mo stretchy="false">/</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5</m:mn><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>19</m:mtext><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \(  - "24" "." 5/"20" "." 5 \) ="tan" rSup { size 8{ - 1} }  \(  - 1 "." "19" \) "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1613163">Thus,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-379"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>50</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>1</m:mn><m:mrow><m:mo stretchy="false">&#186;</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } = - "50" "." 1 rSup { size 12{ circ } "."} } {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-299"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1459619">The negative angle means that the velocity is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>50</m:mtext><m:mtext>.</m:mtext><m:mn>1&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50" "." 1&#176;} {}</m:annotation></m:semantics></m:math> below the horizontal. This result is consistent with the fact that the final vertical velocity is negative and hence downward&#8212;as you would expect because the final altitude is 20.0 m lower than the initial altitude. (See <link target-id="import-auto-id1817519"/>.)</para></example>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1532818">One of the most important things illustrated by projectile motion is that vertical and horizontal motions are independent of each other. Galileo was the first person to fully comprehend this characteristic. He used it to predict the range of a projectile. On level ground, we define <term id="import-auto-id1751163">range</term> to be the horizontal distance <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> traveled by a projectile. Galileo and many others were interested in the range of projectiles primarily for military purposes&#8212;such as aiming cannons. However, investigating the range of projectiles can shed light on other interesting phenomena, such as the orbits of satellites around the Earth. Let us consider projectile range further.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1904800"><media id="import-auto-id1904802" alt="Part a of the figure shows three different trajectories of projectiles on level ground. In each case the projectiles makes an angle of forty five degrees with the horizontal axis. The first projectile of initial velocity thirty meters per second travels a horizontal distance of R equal to ninety one point eight meters. The second projectile of initial velocity forty meters per second travels a horizontal distance of R equal to one hundred sixty three meters. The third projectile of initial velocity fifty meters per second travels a horizontal distance of R equal to two hundred fifty five meters.">
           <image mime-type="image/jpg" src="Figure_03_04_05a.jpg" height="300"/>
         </media>
-        
+
 <caption>Trajectories of projectiles on level ground. (a) The greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range for a given initial angle. (b) The effect of initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> on the range of a projectile with a given initial speed. Note that the range is the same for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>15&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"15"&#176;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mtext>75&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"75&#176;"} {}</m:annotation></m:semantics></m:math>, although the maximum heights of those paths are different.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1750749">How does the initial velocity of a projectile affect its range? Obviously, the greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range, as shown in <link target-id="import-auto-id1904800"/>(a). The initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> also has a dramatic effect on the range, as illustrated in <link target-id="import-auto-id1904800"/>(b). For a fixed initial speed, such as might be produced by a cannon, the maximum range is obtained with <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } &#160;=&#160;"45&#186;"} {}</m:annotation></m:semantics></m:math>. This is true only for conditions neglecting air resistance. If air resistance is considered, the maximum angle is approximately <m:math><m:semantics><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38&#186;"} {}</m:annotation></m:semantics></m:math>. Interestingly, for every initial angle except <m:math><m:semantics><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45&#186;"} {}</m:annotation></m:semantics></m:math>, there are two angles that give the same range&#8212;the sum of those angles is <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#186;"} {}</m:annotation></m:semantics></m:math>. The range also depends on the value of the acceleration of gravity <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. The lunar astronaut Alan Shepherd was able to drive a golf ball a great distance on the Moon because gravity is weaker there. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on <emphasis effect="italics"><emphasis effect="italics">level ground</emphasis></emphasis> for which air resistance is negligible is given by </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-240"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mtext>,</m:mtext><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1674836">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial speed and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle relative to the horizontal. The proof of this equation is left as an end-of-chapter problem (hints are given), but it does fit the major features of projectile range as described.</para>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1686986">When we speak of the range of a projectile on level ground, we assume that <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> is very small compared with the circumference of the Earth. If, however, the range is large, the Earth curves away below the projectile and acceleration of gravity changes direction along the path. The range is larger than predicted by the range equation given above because the projectile has farther to fall than it would on level ground. (See <link target-id="import-auto-id1645881"/>.) If the initial speed is great enough, the projectile goes into orbit.  This possibility was recognized centuries before it could be accomplished. When an object is in orbit, the Earth curves away from underneath the object at the same rate as it falls. The object thus falls continuously but never hits the surface. These and other aspects of orbital motion, such as the rotation of the Earth, will be covered analytically and in greater depth later in this text.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645878">Once again we see that thinking about one topic, such as the range of a projectile, can lead us to others, such as the Earth orbits. In  <link document="m42045">Addition of Velocities</link>, we will examine the addition of velocities, which is another important aspect of two-dimensional kinematics and will also yield insights beyond the immediate topic.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645881"><media id="import-auto-id1825851" alt="A figure of the Earth is shown and on top of it a very high tower is placed. A projectile satellite is launched from this very high tower with initial velocity of v zero in the horizontal direction. Several trajectories are shown with increasing range. A circular trajectory is shown indicating the satellite achieved its orbit and it is revolving around the Earth.">
         <image mime-type="image/jpg" src="Figure_03_04_06a.jpg" width="200"/>
       </media>
-      
+
     <caption>Projectile to satellite. In each case shown here, a projectile is launched from a very high tower to avoid air resistance. With increasing initial speed, the range increases and becomes longer than it would be on level ground because the Earth curves away underneath its path. With a large enough initial speed, orbit is achieved.</caption></figure>
 <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-89"><label/><title>PhET Explorations: Projectile Motion</title>
 
@@ -1330,7 +1330,7 @@
 
   <image mime-type="image/png" for="online" src="projectile-motion_en.jar" thumbnail="PhET_Icon.png" width="450"/>
   <image mime-type="image/png" for="pdf" src="PhET_Icon.png" width="450"/>
-   
+
 </media>
 
       <caption><link url="projectile-motion_en.jar">Projectile Motion</link></caption></figure></note><section id="fs-id1843457" class="section-summary">
@@ -1341,7 +1341,7 @@
     <equation id="eip-898"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Horizontal motion </m:mtext>
@@ -1349,11 +1349,11 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>a</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mn>0</m:mn>
@@ -1361,7 +1361,7 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
@@ -1370,7 +1370,7 @@
     <equation id="eip-236"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1379,27 +1379,27 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
@@ -1420,7 +1420,7 @@
     <equation id="import-auto-id1939084"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Vertical motion </m:mtext>
@@ -1430,11 +1430,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>a</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">=</m:mo>
                       <m:mrow>
@@ -1452,25 +1452,25 @@
                   <m:mtext>80 m</m:mtext>
                   <m:msup>
                     <m:mtext>/s</m:mtext>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Vertical motion " \( "Assuming positive direction is up; "a rSub { size 8{y} } = - g= - 9 "." "80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><equation id="import-auto-id1492830"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1479,11 +1479,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:mfrac>
@@ -1496,56 +1496,56 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><equation id="import-auto-id2022844"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:msub>
                     <m:mi>v</m:mi>
-                    
+
                       <m:mrow>
                         <m:mi>y</m:mi>
                       </m:mrow>
-                    
+
                   </m:msub>
                   <m:mo stretchy="false">=</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">&#8722;</m:mo>
                     <m:mstyle fontstyle="italic">
@@ -1556,17 +1556,17 @@
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id1677876"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1575,21 +1575,21 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
@@ -1601,26 +1601,26 @@
                       <m:mn>2</m:mn>
                     </m:mfrac>
                   </m:mrow>
-                  
+
                     <m:mrow>
                       <m:msup>
                         <m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
-                  
+
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
 <equation id="import-auto-id1653540"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mo>.</m:mo><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) } {}</m:annotation></m:semantics></m:math></equation>
         </item>
@@ -1629,7 +1629,7 @@
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>s</m:mi>
@@ -1638,37 +1638,37 @@
                     <m:mrow>
                       <m:msup>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msup>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id2282348">
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1676,14 +1676,14 @@
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
@@ -1695,18 +1695,18 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id2274748">
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>v</m:mi>
@@ -1715,41 +1715,41 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id1979208"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mtext>v</m:mtext></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math></equation></item></list></item>
   <item id="import-auto-id1888635">The maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mi>h</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h} {}</m:annotation></m:semantics></m:math> of a projectile launched with initial vertical velocity <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> is given by
@@ -1815,19 +1815,19 @@
 <m:mtext>sin</m:mtext><m:msub><m:mn>2&#952;</m:mn><m:mn>0</m:mn></m:msub><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow></m:mtr><m:mtr><m:mrow><m:mtext>For </m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow><m:mo>,</m:mo><m:mrow/></m:mrow><m:mrow><m:mrow>
 
 <m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup><m:mi>g</m:mi></m:mfrac></m:mrow><m:mrow/></m:mrow></m:mtr></m:mtable><m:mrow/></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0">alignl { stack {
- size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} # 
-"For "&#952;="45"&#176;: {} # 
-R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {} 
-} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for 
+ size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} #
+"For "&#952;="45"&#176;: {} #
+R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
+} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>; 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>;
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>163</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math>
 
- for 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>; 
+ for
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>;
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>50</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50 m/s"} {}</m:annotation></m:semantics></m:math>.</para></solution>
       </exercise>
@@ -1874,7 +1874,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
       <exercise id="fs-id2260735" type="problems-exercises"><problem id="fs-id1789803"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1789804">Can a goalkeeper at her/ his goal kick a soccer ball into the opponent&#8217;s goal without the ball touching the ground? The distance will be about 95 m. A goalkeeper can give the ball a speed of 30 m/s.</para></problem>
       <solution id="fs-id1985242">
         <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1985244">No, the maximum range (neglecting air resistance) is about 92 m. </para></solution>
-      </exercise>      
+      </exercise>
      <exercise id="fs-id1437858" type="problems-exercises"><problem id="fs-id1891285"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1891286">The free throw line in basketball is 4.57 m (15 ft) from the basket, which is 3.05 m (10 ft) above the floor. A player standing on the free throw line throws the ball with an initial speed of 7.15 m/s, releasing it at a height of 2.44 m (8 ft) above the floor. At what angle above the horizontal must the ball be thrown to exactly hit the basket? Note that most players will use a large initial angle rather than a flat shot because it allows for a larger margin of error. Explicitly show how you follow the steps involved in solving projectile motion problems.</para></problem>
      </exercise>
       <exercise id="fs-id1827481" type="problems-exercises"><problem id="fs-id1750926"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1750928">In 2007, Michael Carter (U.S.) set a world record in the shot put with a throw of 24.77 m. What was the initial speed of the shot if he released it at a height of 2.10 m and threw it at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>38.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> above the horizontal? (Although the maximum distance for a projectile on level ground is achieved at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> when air resistance is neglected, the actual angle to achieve maximum range is smaller; thus, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> will give a longer range than <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> in the shot put.)</para></problem>
@@ -1891,11 +1891,11 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1796132">(b) The ball travels a total of 57.4 m with the brief gust of wind.</para></solution>
       </exercise>
 <exercise id="fs-id2046931" type="problems-exercises">
-  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation 
+  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mo>&#8211;</m:mo><m:mo stretchy="false">(</m:mo><m:mrow><m:mn>1</m:mn><m:mo stretchy="false">/</m:mo><m:mn>2</m:mn></m:mrow><m:mo stretchy="false">)</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=&#965; rSub { size 8{0y} } t \( 1/2 \)  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> (These equations describe the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions of a projectile that starts at the origin.) You should obtain an equation of the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> where <m:math><m:semantics><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{b} {}</m:annotation></m:semantics></m:math> are constants.
 </para></problem>
@@ -1951,7 +1951,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </m:mrow>
                           <m:mn>0</m:mn>
                           <m:mn>2</m:mn>
-                 
+
                         </m:msubsup><m:mspace width="0.25em"/>
                         <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
                         <m:mi>&#952;</m:mi><m:mspace width="0.25em"/>
@@ -1963,12 +1963,12 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{R=v rSub { size 8{0} } "cos"&#952; left ( {  {2v rSub { size 8{0} } "sin"&#952;}  over  {g} }  right )= {  {2v rSub { size 8{0}   rSup { size 8{2} } } "sin"&#952;"cos"&#952;}  over  {g} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1599732">since <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>2</m:mn><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>sin</m:mtext><m:mspace width="0.25em"/></m:mrow><m:mn>2&#952;</m:mn><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{2"sin"&#952;"cos"&#952;="sin"2&#952;,} {}</m:annotation></m:semantics></m:math> the range is:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3385487"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow>
 <m:msup>
 <m:msub>
@@ -1982,11 +1982,11 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </m:msup><m:mspace width="0.25em"/>
 <m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mn>2&#952;</m:mn></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ {underline  {R= {  {v rSub { size 8{0}   rSup { size 8{2} } } "sin"2&#952;}  over  {g} } }} } {}</m:annotation></m:semantics></m:math>.</para></solution></exercise>
 
-    
-    
-    
-    
- 
+
+
+
+
+
 <exercise id="fs-id1794949" type="problems-exercises"><problem id="fs-id1626931"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1626932"><emphasis>Unreasonable Results</emphasis> (a) Find the maximum range of a super cannon that has a muzzle velocity of 4.0 km/s. (b) What is unreasonable about the range you found? (c) Is the premise unreasonable or is the available equation inapplicable? Explain your answer. (d) If such a muzzle velocity could be obtained, discuss the effects of air resistance, thinning air with altitude, and the curvature of the Earth on the range of the super cannon.
 </para></problem>
 </exercise>
@@ -1996,7 +1996,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </content>
     <glossary>
       <definition id="import-auto-id2275857"><term>air resistance</term> <meaning id="fs-id1668212">a frictional force that slows the motion of objects as they travel through the air; when solving basic physics problems, air resistance is assumed to be zero</meaning></definition>
-      
+
 <definition id="fs-id1405173"><term>kinematics</term><meaning id="fs-id1949378">the study of motion without regard to mass or force</meaning></definition>
 
 <definition id="fs-id1949381"><term>motion</term><meaning id="fs-id2324535">displacement of an object as a function of time</meaning></definition>

--- a/cnxml/tests/data/valid-derived-from-2.cnxml
+++ b/cnxml/tests/data/valid-derived-from-2.cnxml
@@ -41,8 +41,7 @@
          CONTENT_URL/content_info#cnx_cite_header
        where CONTENT_URL is the value provided above in the <md:content-url> element.
   -->
-  <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
-  </md:derived-from>
+  <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11"/>
   <md:keywordlist>
     <md:keyword>Air resistance</md:keyword>
     <md:keyword>Kinematics</md:keyword>

--- a/cnxml/tests/data/valid-derived-from-2.cnxml
+++ b/cnxml/tests/data/valid-derived-from-2.cnxml
@@ -42,7 +42,6 @@
        where CONTENT_URL is the value provided above in the <md:content-url> element.
   -->
   <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
-  <md:language>en</md:language>
   </md:derived-from>
   <md:keywordlist>
     <md:keyword>Air resistance</md:keyword>
@@ -67,16 +66,16 @@
 </metadata>
 
 <content>
-    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple: 
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple:
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical, 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical,
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math>. Both accelerations are constant, so the kinematic equations can be used.</para><note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1767845"><label/><title>Review of Kinematic Equations (constant <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow></m:mrow></m:mrow></m:semantics></m:math>)</title>
-    
+
     <equation id="eip-891"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -86,11 +85,11 @@
                           </m:mrow>
                           <m:msub>
                             <m:mi>x</m:mi>
-                            
+
                               <m:mrow>
                                 <m:mn>0</m:mn>
                               </m:mrow>
-                            
+
                           </m:msub>
                           <m:mrow>
                             <m:mi/>
@@ -104,7 +103,7 @@
                           <m:mi>t</m:mi>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{x=`x rSub { size 8{0} } `+` { bar  {v}}t} {}</m:annotation>
@@ -112,7 +111,7 @@
               </m:math> </equation><equation id="eip-557"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -127,11 +126,11 @@
                             <m:mrow>
                               <m:msub>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                               <m:mo stretchy="false">+</m:mo>
                               <m:mi>v</m:mi>
@@ -140,16 +139,16 @@
                           </m:mfrac>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{ { bar  {v}}=` {  {v rSub { size 8{0} } +v}  over  {2} } } {}</m:annotation>
                 </m:semantics>
-              </m:math> 
+              </m:math>
 </equation><equation id="eip-405"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mi>v</m:mi>
@@ -157,11 +156,11 @@
                           <m:mrow>
                             <m:msub>
                               <m:mi>v</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>0</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msub>
                             <m:mo stretchy="false">+</m:mo>
                             <m:mstyle fontstyle="italic">
@@ -172,7 +171,7 @@
                           </m:mrow>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{v=v rSub { size 8{0} } + ital "at"} {}</m:annotation>
@@ -181,7 +180,7 @@
 </equation><equation id="eip-556"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -190,20 +189,20 @@
                             <m:mrow>
                               <m:msub>
                                 <m:mi>x</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                               <m:mo stretchy="false">+</m:mo>
                               <m:msub>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                             </m:mrow>
                           </m:mrow>
@@ -218,16 +217,16 @@
                             <m:mrow>
                               <m:msup>
                                 <m:mtext fontstyle="italic">at</m:mtext>
-                                
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
 </m:msup>
                             </m:mrow>
-                        
+
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{0} } t+ {  {1}  over  {2} }  ital "at" rSup { size 8{2} } } {}</m:annotation>
@@ -235,32 +234,32 @@
               </m:math> </equation><equation id="eip-389"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
                             <m:msup>
                               <m:mi>v</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>2</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msup>
                             <m:mo stretchy="false">=</m:mo>
                             <m:mrow>
                               <m:msubsup>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
-                                
+
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msubsup>
                               <m:mo stretchy="false">+</m:mo>
                               <m:mn>2</m:mn><m:mi>a</m:mi>
@@ -272,11 +271,11 @@
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:msub>
                               <m:mi>x</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>0</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msub>
                           </m:mrow>
                           <m:mo stretchy="false">)</m:mo>
@@ -287,32 +286,32 @@
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{v rSup { size 8{2} } =v rSub { size 8{0} }  rSup { size 8{2} } +2a \( x - x rSub { size 8{0} }  \) } {}</m:annotation>
                 </m:semantics>
-              </m:math> 
+              </m:math>
 </equation></note><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2242290"><media id="import-auto-id1402609" alt="A soccer player is kicking a soccer ball. The ball travels in a projectile motion and reaches a point whose vertical distance is y and horizontal distance is x. The displacement between the kicking point and the final point is s. The angle made by this displacement vector with x axis is theta.">
         <image mime-type="image/jpg" src="Figure_03_04_01.jpg" width="350"/>
       </media>
-      
+
     <caption>The total displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> of a soccer ball at a point along its path. The vector <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> has components <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> along the horizontal and vertical axes. Its magnitude is <m:math><m:semantics><m:mrow><m:mrow><m:mi>s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math>, and it makes an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> with the horizontal.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-36">Given these assumptions, the following steps are then used to analyze projectile motion:</para>
 
-<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so 
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction, as shown in <link target-id="import-auto-id1815222"/>. Initial values are denoted with a subscript 0, as usual.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-205"><emphasis effect="italics"><emphasis>Step 2.</emphasis></emphasis>  <emphasis effect="italics">Treat the motion as two independent one-dimensional motions, one horizontal and the other vertical.</emphasis> The kinematic equations for horizontal and vertical motion take the following forms:
 </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-338"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Horizontal Motion</m:mtext>
@@ -320,11 +319,11 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>a</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mn>0</m:mn>
@@ -332,16 +331,16 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal Motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-362"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -350,37 +349,37 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-627"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-293"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Vertical Motion</m:mtext>
@@ -393,11 +392,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>a</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">=</m:mo>
                       <m:mrow>
@@ -411,23 +410,23 @@
                         <m:mo stretchy="false">&#8722;</m:mo>
                         <m:mn>9.</m:mn>
                       </m:mrow>
-                     
+
                       <m:mtext>80</m:mtext>
                     </m:mrow>
                   </m:mrow>
                   <m:mo stretchy="false"> </m:mo>
                   <m:msup>
                     <m:mtext>m/s</m:mtext>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Vertical Motion " \( "assuming positive is up "a rSub { size 8{y} } = - g= - 9/"80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
@@ -435,7 +434,7 @@
       </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-131"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -444,11 +443,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:mfrac>
@@ -461,55 +460,55 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-305"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:msub>
                     <m:mi>v</m:mi>
-                    
+
                       <m:mrow>
                         <m:mi>y</m:mi>
                       </m:mrow>
-                    
+
                   </m:msub>
                   <m:mo stretchy="false">=</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">&#8722;</m:mo>
                     <m:mstyle fontstyle="italic">
@@ -520,16 +519,16 @@
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-542"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -538,21 +537,21 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
-                          
+
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
@@ -564,33 +563,33 @@
                       <m:mn>2</m:mn>
                     </m:mfrac>
                   </m:mrow>
-                
+
                     <m:mrow>
                       <m:msup>
                         <m:mi fontstyle="italic">gt</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
-         
+
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-243"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-708"><emphasis effect="italics"><emphasis>Step 3.</emphasis></emphasis>  <emphasis effect="italics"> Solve for the unknowns in the two separate motions&#8212;one horizontal and one vertical.</emphasis> Note that the only common variable between the motions is time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>. The problem solving procedures here are the same as for one-dimensional <term>kinematics</term> and are illustrated in the solved examples below.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-979"><emphasis effect="italics"><emphasis>Step 4.</emphasis></emphasis>  <emphasis effect="italics">Recombine the two motions to find the total displacement</emphasis> <m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">s</m:mtext></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math><emphasis effect="italics"> and velocity </emphasis><m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">v</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>. Because the <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are perpendicular, we determine these vectors by using the techniques outlined in the <link document="m42128">Vector Addition and Subtraction: Analytical Methods</link> and employing <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>A</m:mi>
@@ -599,46 +598,46 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>A</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>A</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
         and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( A rSub { size 8{y} } /A rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math> in the following form, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is the direction of the displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is the direction of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>:
 </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-245"><emphasis>Total displacement and velocity</emphasis></para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-743"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>s</m:mi>
@@ -647,26 +646,26 @@
                     <m:mrow>
                       <m:msup>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msup>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
@@ -674,7 +673,7 @@
       </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-373"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -682,14 +681,14 @@
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
@@ -701,16 +700,16 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-679"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>v</m:mi>
@@ -719,59 +718,59 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-264"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1815222"><media id="import-auto-id2275311" alt="In part a the figure shows projectile motion of a ball with initial velocity of v zero at an angle of theta zero with the horizontal x axis. The horizontal component v x and the vertical component v y at various positions of ball in the projectile path is shown. In part b only the horizontal velocity component v sub x is shown whose magnitude is constant at various positions in the path. In part c only vertical velocity component v sub y is shown. The vertical velocity component v sub y is upwards till it reaches the maximum point and then its direction changes to downwards. In part d resultant v of horizontal velocity component v sub x and downward vertical velocity component v sub y is found which makes an angle theta with the horizontal x axis. The direction of resultant velocity v is towards south east.">
           <image mime-type="image/jpg" src="Figure_03_04_02.jpg" height="600"/>
         </media>
-        
+
   <caption>(a) We analyze two-dimensional projectile motion by breaking it into two independent one-dimensional motions along the vertical and horizontal axes. (b) The horizontal motion is simple, because <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is thus constant. (c) The velocity in the vertical direction begins to decrease as the object rises; at its highest point, the vertical velocity is zero. As the object falls towards the Earth again, the vertical velocity increases again in magnitude but points in the opposite direction to the initial vertical velocity. (d) The <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are recombined to give the total velocity at any given point on the trajectory.</caption></figure><example id="fs-id2175010">
     <title>A Fireworks Projectile Explodes High and Away</title>
-    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and  
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero and solve for the desired quantities.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-774"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1669571">By &#8220;height&#8221; we mean the altitude or vertical position <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> above the starting point. The highest point in any trajectory, called the apex, is reached when <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ v rSub { size 8{y} } =0} {}</m:annotation></m:semantics></m:math>. Since we know the initial and final velocities as well as the initial position, we use the following equation to find <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>:
 
 </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-734"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id934168"><media id="import-auto-id1576299" alt="The x y graph shows the trajectory of fireworks shell. The initial velocity of the shell v zero is at angle theta zero equal to seventy five degrees with the horizontal x axis. The fuse is set to explode the shell at the highest point of the trajectory which is at a height h equal to two hundred thirty three meters and at a horizontal distance x equal to one hundred twenty five meters from the origin.">
         <image mime-type="image/jpg" src="Figure_03_04_03a.jpg" height="250"/>
       </media>
-      
+
     <caption>The trajectory of a fireworks shell. The fuse is set to explode the shell at the highest point in its trajectory, which is found to be at a height of 233 m and 125 m away horizontally.</caption></figure><para id="import-auto-id1163607">Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> are both zero, the equation simplifies to</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-42"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mn>0</m:mn><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
@@ -779,7 +778,7 @@
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-256"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -788,16 +787,16 @@
                     <m:mfrac>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
-                         
+
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                      <m:mrow> <m:mn>2</m:mn><m:mi>g</m:mi></m:mrow>
                     </m:mfrac>
@@ -805,24 +804,24 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
-    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find 
+      </m:math>
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>75.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-677"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70.0 m/s</m:mtext><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>sin 75&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>67.6 m/s.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } = \( "70" "." 0" m/s" \)  \( "sin""75" { size 12{ circ } }  \) ="67" "." 6" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2271493">and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-512"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>y</m:mi>
@@ -834,11 +833,11 @@
                       <m:mtext>.6 m/s</m:mtext>
                       <m:msup>
                         <m:mo stretchy="false">)</m:mo>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                     <m:mrow>
@@ -849,11 +848,11 @@
                       <m:mtext>80 m</m:mtext>
                       <m:msup>
                         <m:mtext>/s</m:mtext>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">)</m:mo>
                     </m:mrow>
@@ -866,13 +865,13 @@
 
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  { \( "67" "." 6" m/s" \)  rSup { size 8{2} } }  over  {2 \( 9 "." "80"" m/s" rSup { size 8{2} }  \) } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1919502">so that</para>
-    
+
     <equation id="eip-310"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>233</m:mtext></m:mrow><m:mo stretchy="false"> </m:mo><m:mtext> m.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y="233"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-429"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2165781">Note that because up is positive, the initial velocity is positive, as is the maximum height, but the acceleration due to gravity is negative. Note also that the maximum height depends only on the vertical component of the initial velocity, so that any projectile with a 67.6 m/s initial vertical component of velocity will reach a maximum height of 233 m (neglecting air resistance). The numbers in this example are reasonable for large fireworks displays, the shells of which do reach such heights before exploding. In practice, air resistance is not completely negligible, and so the initial velocity would have to be somewhat larger than that given to reach the same height.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-449"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1632028">As in many physics problems, there is more than one way to solve for the time to the highest point. In this case, the easiest method is to use <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation></m:semantics></m:math>. Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is zero, this equation reduces to simply</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-383"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -887,20 +886,20 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
@@ -912,7 +911,7 @@
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1383088">Note that the final vertical velocity, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>, at the highest point is zero. Thus,</para>
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-50"><m:math>
         <m:semantics>
@@ -923,7 +922,7 @@
 <m:mtd>                            <m:mo stretchy="false">=</m:mo></m:mtd>
 <m:mtd>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -934,26 +933,26 @@
                               <m:mn>2</m:mn>
 <m:mi>y</m:mi>
 
-</m:mrow>                                 
+</m:mrow>
                               <m:mrow>
                                 <m:mo stretchy="false">(</m:mo>
                                 <m:mrow>
                                   <m:msub>
                                     <m:mi>v</m:mi>
-                                    
+
                                       <m:mrow>
                                         <m:mn>0y</m:mn>
                                       </m:mrow>
-                                    
+
                                   </m:msub>
                                   <m:mo stretchy="false">+</m:mo>
                                   <m:msub>
                                     <m:mi>v</m:mi>
-                                    
+
                                       <m:mrow>
                                         <m:mi>y</m:mi>
                                       </m:mrow>
-                                    
+
                                   </m:msub>
                                 </m:mrow>
                                 <m:mo stretchy="false">)</m:mo>
@@ -973,13 +972,13 @@
                             <m:mrow>
                               <m:mo stretchy="false">(</m:mo>
                               <m:mtext>67.6 m/s</m:mtext>
-                             
+
                               <m:mo stretchy="false">)</m:mo>
                             </m:mrow>
                           </m:mfrac>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow></m:mtd>
                 </m:mtr>
@@ -987,9 +986,9 @@
 <m:mtd><m:mo>=</m:mo></m:mtd>
 <m:mtd>
                   <m:mrow>
-                   
+
                     <m:mtext>6.90 s</m:mtext><m:mtext>.</m:mtext>
-                 
+
                   </m:mrow></m:mtd>
                 </m:mtr>
               </m:mtable>
@@ -997,18 +996,18 @@
             </m:mrow>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0">alignl { stack {
- size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} # 
-=6 "." "90"" s" {} 
+ size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} #
+=6 "." "90"" s" {}
 } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-31"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1848626">This time is also reasonable for large fireworks. When you are able to see the launch of fireworks, you will notice several seconds pass before the shell explodes. (Another way of finding the time is by using <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>, and solving the quadratic equation for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-939"><emphasis>Solution for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2262600">Because air resistance is negligible, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and the horizontal velocity is constant, as discussed above. The horizontal displacement is horizontal velocity multiplied by time as given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is equal to zero:</para><equation id="eip-675"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{x} } t ","} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1871833">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-component of the velocity, which is given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} }  "." } {}</m:annotation></m:semantics></m:math> Now,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-884"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 75.0&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>18</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>1 m/s.</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 12{0} } = \( "70" "." 0" m/s" \)  \( "cos""75.0&#186;"  \) ="18" "." 1" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2046887">The time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> for both motions is the same, and so <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-685"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mn>1 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mtext>90 s</m:mtext><m:mtext/><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>125 m.</m:mtext></m:mrow><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x= \( "18" "." 1" m/s" \)  \( 6 "." "90"" s" \) ="125"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-247"><emphasis>Discussion for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1857186">The horizontal motion is a constant velocity in the absence of air resistance. The horizontal displacement found here could be useful in keeping the fireworks fragments from falling on spectators. Once the shell explodes, air resistance has a major effect, and many fragments will land directly below.</para></example>
     <para id="import-auto-id1986266">In solving part (a) of the preceding example, the expression we found for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is valid for any projectile motion where air resistance is negligible. Call the maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mi>h</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=h} {}</m:annotation></m:semantics></m:math>; then,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-803"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1017,17 +1016,17 @@
                     <m:mfrac>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
 <m:mrow>
                       <m:mn>2</m:mn>
@@ -1038,27 +1037,27 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1973673">This equation defines the <emphasis effect="italics"><emphasis effect="italics">maximum height of a projectile</emphasis></emphasis> and depends only on the vertical component of the initial velocity.</para>
     <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1479427"><label/><title>Defining a Coordinate System</title>
-    
+
     <para id="import-auto-id2275341">It is important to set up a coordinate system when analyzing projectile motion. One part of defining the coordinate system is to define an origin for the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions. Often, it is convenient to choose the initial position of the object as the origin such that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math>. It is also important to define the positive and negative directions in the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> directions. Typically, we define the positive vertical direction as upwards, and the positive horizontal direction is usually the direction of the object&#8217;s motion. When this is the case, the vertical acceleration, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>, takes a negative value (since it is directed downwards towards the Earth). However, it is occasionally useful to define the coordinates differently. For example, if you are analyzing the motion of a ball thrown downwards from the top of a cliff, it may make sense to define the positive direction downwards since the motion of the ball is solely in the downwards direction. If this is the case, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math> takes a positive value.</para>
     </note><example id="fs-id708626">
     <title>Calculating Projectile Motion: Hot Rock Projectile</title>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1916950">Kilauea in Hawaii is the world&#8217;s most continuously active volcano. Very active volcanoes characteristically eject red-hot rocks and lava rather than smoke and ash. Suppose a large rock is ejected from the volcano with a speed of 25.0 m/s and at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"35"&#176;} {}</m:annotation></m:semantics></m:math> above the horizontal, as shown in <link target-id="import-auto-id1817519"/>. The rock strikes the side of the volcano at an altitude 20.0 m lower than its starting point. (a) Calculate the time it takes the rock to follow this path. (b) What are the magnitude and direction of the rock&#8217;s velocity at impact?</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1817519"><media id="import-auto-id1817520" alt="The trajectory of a rock ejected from a volcano is shown. The initial velocity of rock v zero is equal to twenty five meters per second and it makes an angle of thirty five degrees with the horizontal x axis. The figure shows rock falling down a height of twenty meters below the volcano level. The velocity at this point is v which makes an angle of theta with horizontal x axis. The direction of v is south east.">
         <image mime-type="image/jpg" src="Figure_03_04_04a.jpg" width="400"/>
       </media>
-      
+
     <caption>The trajectory of a rock ejected from the Kilauea volcano.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-770"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1823692">Again, resolving this two-dimensional motion into two independent one-dimensional motions will allow us to solve for the desired quantities. The time a projectile is in the air is governed by its vertical motion alone. We will solve for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> first. While the rock is rising and falling vertically, the horizontal motion continues at a constant velocity. This example asks for the final velocity. Thus, the vertical and horizontal results will be recombined to obtain <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> at the final time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> determined in the first part of the example.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-408"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1608071">While the rock is in the air, it rises and then falls to a final position 20.0 m lower than its starting altitude. We can find the time for this by using</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-895"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
 <m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1843834">If we take the initial position <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero, then the final position is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow></m:mrow><m:mtext>.0  m</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= - "20" "." 0" m" "." } {}</m:annotation></m:semantics></m:math> Now the initial vertical velocity is the vertical component of the initial velocity, found from  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> = (<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25" "." "0&#160;m/s"} {}</m:annotation></m:semantics></m:math>)(<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>sin 35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"sin 35"&#176;} {}</m:annotation></m:semantics></m:math>) = <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Substituting known values yields</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-722"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>0 m</m:mn><m:mrow><m:mtext/><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mn>3 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced></m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
 <m:mtext>.</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ - "20" "." 0" m"= \( "14" "." 3" m/s" \) t -  left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1561988">Rearranging terms gives a quadratic equation in <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>:</para>
-    
-    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form 
+
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form
 <m:math>
 <m:semantics>
 <m:mrow><m:mrow><m:mrow><m:mrow><m:mrow>
@@ -1076,17 +1075,17 @@
 </m:mrow></m:mrow></m:mrow></m:mrow></m:mrow>
 <m:annotation encoding="StarMath 5.0"> size 12{ ital "at" rSup { size 8{2} } + ital "bt"+c=0} {}</m:annotation>
 </m:semantics>
-</m:math>, where the constants are 
+</m:math>, where the constants are
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
 <m:mi>a</m:mi><m:mo>=</m:mo><m:mn>4.90</m:mn>
-</m:mrow></m:mrow></m:semantics></m:math>, 
+</m:mrow></m:mrow></m:semantics></m:math>,
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
 <m:mi>b</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>14.3</m:mn>
-</m:mrow></m:mrow></m:semantics></m:math>, and 
+</m:mrow></m:mrow></m:semantics></m:math>, and
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
@@ -1094,7 +1093,7 @@
 </m:mrow></m:mrow></m:semantics></m:math> Its solutions are given by the quadratic formula:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-880"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1112,11 +1111,11 @@
                             <m:mrow>
                               <m:msup>
                                 <m:mi>b</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msup>
                               <m:mo stretchy="false">&#8722;</m:mo>
                               <m:mn>4</m:mn>
@@ -1135,39 +1134,39 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{t= {  { - b +-  sqrt {b rSup { size 8{2} }  - 4 ital "ac"} }  over  {"2a"} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
-    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions: 
+      </m:math>
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions:
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and
 
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{-1 "." "03""s"} {}</m:annotation></m:semantics></m:math>. The negative value of time implies an event before the start of motion, and so we discard it. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-267"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>96 s</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"" s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-46"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1368589">The time for projectile motion is completely determined by the vertical motion. So any projectile that has an initial vertical velocity of 14.3 m/s and lands 20.0 m below its starting altitude will spend 3.96 s in the air.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-653"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1599448">From the information now in hand, we can find the final horizontal and vertical velocities <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> and combine them to find the total velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and the angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> it makes with the horizontal. Of course, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is constant so we can solve for it at any horizontal location. In this case, we chose the starting point since we know both the initial velocity and initial angle. Therefore:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-873"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 35&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} } = \( "25" "." 0" m/s" \)  \( "cos""35" rSup { size 8{ circ } }  \) ="20" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2252925">The final vertical velocity is given by the following equation:</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-168"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">&#8722;</m:mo><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gt,</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt,"} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2173689">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0y</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> was found in part (a) to be <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Thus,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-113"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mtext>14</m:mtext>
@@ -1184,11 +1183,11 @@
                   <m:mtext>80 m/s</m:mtext>
                   <m:msup>
                     <m:mtext/>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mo stretchy="false">(</m:mo>
@@ -1199,91 +1198,91 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } ="14" "." 3" m/s" -  \( 9 "." "80"" m/s" rSup { size 8{2} }  \)  \( 3 "." "96"" s" \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1792451">so that</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-571"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } = - "24" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2239982">To find the magnitude of the final velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> we combine its perpendicular components, using the following equation:</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-394"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">+</m:mo><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup></m:mrow></m:msqrt></m:mrow><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:mo stretchy="false">(</m:mo><m:mtext>20</m:mtext><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:mrow><m:mrow><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">+</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:msqrt><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } = sqrt { \( "20" "." 5" m/s" \)  rSup { size 8{2} } + \(  - "24" "." 5" m/s" \)  rSup { size 8{2} } } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1677955">which gives</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-60"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>31</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>9 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v="31" "." 9" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1645980">The direction <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is found from the equation:</para>
-    
+
     <equation id="eip-353"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
                     <m:msub>
                       <m:mi>&#952;</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>v</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">/</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1972156">so that</para>
-    
+
     <equation id="eip-589"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mrow><m:mn>5</m:mn><m:mo stretchy="false">/</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5</m:mn><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>19</m:mtext><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \(  - "24" "." 5/"20" "." 5 \) ="tan" rSup { size 8{ - 1} }  \(  - 1 "." "19" \) "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1613163">Thus,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-379"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>50</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>1</m:mn><m:mrow><m:mo stretchy="false">&#186;</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } = - "50" "." 1 rSup { size 12{ circ } "."} } {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-299"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1459619">The negative angle means that the velocity is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>50</m:mtext><m:mtext>.</m:mtext><m:mn>1&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50" "." 1&#176;} {}</m:annotation></m:semantics></m:math> below the horizontal. This result is consistent with the fact that the final vertical velocity is negative and hence downward&#8212;as you would expect because the final altitude is 20.0 m lower than the initial altitude. (See <link target-id="import-auto-id1817519"/>.)</para></example>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1532818">One of the most important things illustrated by projectile motion is that vertical and horizontal motions are independent of each other. Galileo was the first person to fully comprehend this characteristic. He used it to predict the range of a projectile. On level ground, we define <term id="import-auto-id1751163">range</term> to be the horizontal distance <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> traveled by a projectile. Galileo and many others were interested in the range of projectiles primarily for military purposes&#8212;such as aiming cannons. However, investigating the range of projectiles can shed light on other interesting phenomena, such as the orbits of satellites around the Earth. Let us consider projectile range further.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1904800"><media id="import-auto-id1904802" alt="Part a of the figure shows three different trajectories of projectiles on level ground. In each case the projectiles makes an angle of forty five degrees with the horizontal axis. The first projectile of initial velocity thirty meters per second travels a horizontal distance of R equal to ninety one point eight meters. The second projectile of initial velocity forty meters per second travels a horizontal distance of R equal to one hundred sixty three meters. The third projectile of initial velocity fifty meters per second travels a horizontal distance of R equal to two hundred fifty five meters.">
           <image mime-type="image/jpg" src="Figure_03_04_05a.jpg" height="300"/>
         </media>
-        
+
 <caption>Trajectories of projectiles on level ground. (a) The greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range for a given initial angle. (b) The effect of initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> on the range of a projectile with a given initial speed. Note that the range is the same for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>15&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"15"&#176;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mtext>75&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"75&#176;"} {}</m:annotation></m:semantics></m:math>, although the maximum heights of those paths are different.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1750749">How does the initial velocity of a projectile affect its range? Obviously, the greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range, as shown in <link target-id="import-auto-id1904800"/>(a). The initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> also has a dramatic effect on the range, as illustrated in <link target-id="import-auto-id1904800"/>(b). For a fixed initial speed, such as might be produced by a cannon, the maximum range is obtained with <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } &#160;=&#160;"45&#186;"} {}</m:annotation></m:semantics></m:math>. This is true only for conditions neglecting air resistance. If air resistance is considered, the maximum angle is approximately <m:math><m:semantics><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38&#186;"} {}</m:annotation></m:semantics></m:math>. Interestingly, for every initial angle except <m:math><m:semantics><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45&#186;"} {}</m:annotation></m:semantics></m:math>, there are two angles that give the same range&#8212;the sum of those angles is <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#186;"} {}</m:annotation></m:semantics></m:math>. The range also depends on the value of the acceleration of gravity <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. The lunar astronaut Alan Shepherd was able to drive a golf ball a great distance on the Moon because gravity is weaker there. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on <emphasis effect="italics"><emphasis effect="italics">level ground</emphasis></emphasis> for which air resistance is negligible is given by </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-240"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mtext>,</m:mtext><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1674836">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial speed and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle relative to the horizontal. The proof of this equation is left as an end-of-chapter problem (hints are given), but it does fit the major features of projectile range as described.</para>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1686986">When we speak of the range of a projectile on level ground, we assume that <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> is very small compared with the circumference of the Earth. If, however, the range is large, the Earth curves away below the projectile and acceleration of gravity changes direction along the path. The range is larger than predicted by the range equation given above because the projectile has farther to fall than it would on level ground. (See <link target-id="import-auto-id1645881"/>.) If the initial speed is great enough, the projectile goes into orbit.  This possibility was recognized centuries before it could be accomplished. When an object is in orbit, the Earth curves away from underneath the object at the same rate as it falls. The object thus falls continuously but never hits the surface. These and other aspects of orbital motion, such as the rotation of the Earth, will be covered analytically and in greater depth later in this text.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645878">Once again we see that thinking about one topic, such as the range of a projectile, can lead us to others, such as the Earth orbits. In  <link document="m42045">Addition of Velocities</link>, we will examine the addition of velocities, which is another important aspect of two-dimensional kinematics and will also yield insights beyond the immediate topic.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645881"><media id="import-auto-id1825851" alt="A figure of the Earth is shown and on top of it a very high tower is placed. A projectile satellite is launched from this very high tower with initial velocity of v zero in the horizontal direction. Several trajectories are shown with increasing range. A circular trajectory is shown indicating the satellite achieved its orbit and it is revolving around the Earth.">
         <image mime-type="image/jpg" src="Figure_03_04_06a.jpg" width="200"/>
       </media>
-      
+
     <caption>Projectile to satellite. In each case shown here, a projectile is launched from a very high tower to avoid air resistance. With increasing initial speed, the range increases and becomes longer than it would be on level ground because the Earth curves away underneath its path. With a large enough initial speed, orbit is achieved.</caption></figure>
 <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-89"><label/><title>PhET Explorations: Projectile Motion</title>
 
@@ -1293,7 +1292,7 @@
 
   <image mime-type="image/png" for="online" src="projectile-motion_en.jar" thumbnail="PhET_Icon.png" width="450"/>
   <image mime-type="image/png" for="pdf" src="PhET_Icon.png" width="450"/>
-   
+
 </media>
 
       <caption><link url="projectile-motion_en.jar">Projectile Motion</link></caption></figure></note><section id="fs-id1843457" class="section-summary">
@@ -1304,7 +1303,7 @@
     <equation id="eip-898"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Horizontal motion </m:mtext>
@@ -1312,11 +1311,11 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>a</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mn>0</m:mn>
@@ -1324,7 +1323,7 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
@@ -1333,7 +1332,7 @@
     <equation id="eip-236"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1342,27 +1341,27 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
@@ -1383,7 +1382,7 @@
     <equation id="import-auto-id1939084"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Vertical motion </m:mtext>
@@ -1393,11 +1392,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>a</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">=</m:mo>
                       <m:mrow>
@@ -1415,25 +1414,25 @@
                   <m:mtext>80 m</m:mtext>
                   <m:msup>
                     <m:mtext>/s</m:mtext>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Vertical motion " \( "Assuming positive direction is up; "a rSub { size 8{y} } = - g= - 9 "." "80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><equation id="import-auto-id1492830"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1442,11 +1441,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:mfrac>
@@ -1459,56 +1458,56 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><equation id="import-auto-id2022844"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:msub>
                     <m:mi>v</m:mi>
-                    
+
                       <m:mrow>
                         <m:mi>y</m:mi>
                       </m:mrow>
-                    
+
                   </m:msub>
                   <m:mo stretchy="false">=</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">&#8722;</m:mo>
                     <m:mstyle fontstyle="italic">
@@ -1519,17 +1518,17 @@
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id1677876"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1538,21 +1537,21 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
@@ -1564,26 +1563,26 @@
                       <m:mn>2</m:mn>
                     </m:mfrac>
                   </m:mrow>
-                  
+
                     <m:mrow>
                       <m:msup>
                         <m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
-                  
+
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
 <equation id="import-auto-id1653540"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mo>.</m:mo><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) } {}</m:annotation></m:semantics></m:math></equation>
         </item>
@@ -1592,7 +1591,7 @@
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>s</m:mi>
@@ -1601,37 +1600,37 @@
                     <m:mrow>
                       <m:msup>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msup>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id2282348">
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1639,14 +1638,14 @@
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
@@ -1658,18 +1657,18 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id2274748">
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>v</m:mi>
@@ -1678,41 +1677,41 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id1979208"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mtext>v</m:mtext></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math></equation></item></list></item>
   <item id="import-auto-id1888635">The maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mi>h</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h} {}</m:annotation></m:semantics></m:math> of a projectile launched with initial vertical velocity <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> is given by
@@ -1778,19 +1777,19 @@
 <m:mtext>sin</m:mtext><m:msub><m:mn>2&#952;</m:mn><m:mn>0</m:mn></m:msub><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow></m:mtr><m:mtr><m:mrow><m:mtext>For </m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow><m:mo>,</m:mo><m:mrow/></m:mrow><m:mrow><m:mrow>
 
 <m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup><m:mi>g</m:mi></m:mfrac></m:mrow><m:mrow/></m:mrow></m:mtr></m:mtable><m:mrow/></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0">alignl { stack {
- size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} # 
-"For "&#952;="45"&#176;: {} # 
-R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {} 
-} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for 
+ size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} #
+"For "&#952;="45"&#176;: {} #
+R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
+} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>; 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>;
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>163</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math>
 
- for 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>; 
+ for
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>;
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>50</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50 m/s"} {}</m:annotation></m:semantics></m:math>.</para></solution>
       </exercise>
@@ -1837,7 +1836,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
       <exercise id="fs-id2260735" type="problems-exercises"><problem id="fs-id1789803"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1789804">Can a goalkeeper at her/ his goal kick a soccer ball into the opponent&#8217;s goal without the ball touching the ground? The distance will be about 95 m. A goalkeeper can give the ball a speed of 30 m/s.</para></problem>
       <solution id="fs-id1985242">
         <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1985244">No, the maximum range (neglecting air resistance) is about 92 m. </para></solution>
-      </exercise>      
+      </exercise>
      <exercise id="fs-id1437858" type="problems-exercises"><problem id="fs-id1891285"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1891286">The free throw line in basketball is 4.57 m (15 ft) from the basket, which is 3.05 m (10 ft) above the floor. A player standing on the free throw line throws the ball with an initial speed of 7.15 m/s, releasing it at a height of 2.44 m (8 ft) above the floor. At what angle above the horizontal must the ball be thrown to exactly hit the basket? Note that most players will use a large initial angle rather than a flat shot because it allows for a larger margin of error. Explicitly show how you follow the steps involved in solving projectile motion problems.</para></problem>
      </exercise>
       <exercise id="fs-id1827481" type="problems-exercises"><problem id="fs-id1750926"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1750928">In 2007, Michael Carter (U.S.) set a world record in the shot put with a throw of 24.77 m. What was the initial speed of the shot if he released it at a height of 2.10 m and threw it at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>38.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> above the horizontal? (Although the maximum distance for a projectile on level ground is achieved at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> when air resistance is neglected, the actual angle to achieve maximum range is smaller; thus, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> will give a longer range than <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> in the shot put.)</para></problem>
@@ -1854,11 +1853,11 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1796132">(b) The ball travels a total of 57.4 m with the brief gust of wind.</para></solution>
       </exercise>
 <exercise id="fs-id2046931" type="problems-exercises">
-  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation 
+  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mo>&#8211;</m:mo><m:mo stretchy="false">(</m:mo><m:mrow><m:mn>1</m:mn><m:mo stretchy="false">/</m:mo><m:mn>2</m:mn></m:mrow><m:mo stretchy="false">)</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=&#965; rSub { size 8{0y} } t \( 1/2 \)  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> (These equations describe the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions of a projectile that starts at the origin.) You should obtain an equation of the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> where <m:math><m:semantics><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{b} {}</m:annotation></m:semantics></m:math> are constants.
 </para></problem>
@@ -1914,7 +1913,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </m:mrow>
                           <m:mn>0</m:mn>
                           <m:mn>2</m:mn>
-                 
+
                         </m:msubsup><m:mspace width="0.25em"/>
                         <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
                         <m:mi>&#952;</m:mi><m:mspace width="0.25em"/>
@@ -1926,12 +1925,12 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{R=v rSub { size 8{0} } "cos"&#952; left ( {  {2v rSub { size 8{0} } "sin"&#952;}  over  {g} }  right )= {  {2v rSub { size 8{0}   rSup { size 8{2} } } "sin"&#952;"cos"&#952;}  over  {g} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1599732">since <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>2</m:mn><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>sin</m:mtext><m:mspace width="0.25em"/></m:mrow><m:mn>2&#952;</m:mn><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{2"sin"&#952;"cos"&#952;="sin"2&#952;,} {}</m:annotation></m:semantics></m:math> the range is:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3385487"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow>
 <m:msup>
 <m:msub>
@@ -1945,11 +1944,11 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </m:msup><m:mspace width="0.25em"/>
 <m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mn>2&#952;</m:mn></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ {underline  {R= {  {v rSub { size 8{0}   rSup { size 8{2} } } "sin"2&#952;}  over  {g} } }} } {}</m:annotation></m:semantics></m:math>.</para></solution></exercise>
 
-    
-    
-    
-    
- 
+
+
+
+
+
 <exercise id="fs-id1794949" type="problems-exercises"><problem id="fs-id1626931"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1626932"><emphasis>Unreasonable Results</emphasis> (a) Find the maximum range of a super cannon that has a muzzle velocity of 4.0 km/s. (b) What is unreasonable about the range you found? (c) Is the premise unreasonable or is the available equation inapplicable? Explain your answer. (d) If such a muzzle velocity could be obtained, discuss the effects of air resistance, thinning air with altitude, and the curvature of the Earth on the range of the super cannon.
 </para></problem>
 </exercise>
@@ -1959,7 +1958,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </content>
     <glossary>
       <definition id="import-auto-id2275857"><term>air resistance</term> <meaning id="fs-id1668212">a frictional force that slows the motion of objects as they travel through the air; when solving basic physics problems, air resistance is assumed to be zero</meaning></definition>
-      
+
 <definition id="fs-id1405173"><term>kinematics</term><meaning id="fs-id1949378">the study of motion without regard to mass or force</meaning></definition>
 
 <definition id="fs-id1949381"><term>motion</term><meaning id="fs-id2324535">displacement of an object as a function of time</meaning></definition>

--- a/cnxml/tests/data/valid-derived-from-2.cnxml
+++ b/cnxml/tests/data/valid-derived-from-2.cnxml
@@ -1,0 +1,1973 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" id="imported-from-openoffice" module-id="imported-from-openoffice" cnxml-version="0.7">
+  <title>Projectile Motion</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <!-- WARNING! The 'metadata' section is read only. Do not edit below.
+       Changes to the metadata section in the source will not be saved. -->
+  <md:repository>http://legacy.cnx.org/content</md:repository>
+  <md:content-url>http://legacy.cnx.org/content/m42042/latest/</md:content-url>
+  <md:content-id>m42042</md:content-id>
+  <md:title>Projectile Motion</md:title>
+  <md:version>1.12</md:version>
+  <md:created>2011/12/21 11:28:12 -0600</md:created>
+  <md:revised>2014/10/28 11:35:40.941 GMT-5</md:revised>
+  <md:actors>
+    <md:person userid="cnxcap">
+      <md:firstname>College</md:firstname>
+      <md:surname>Physics</md:surname>
+      <md:fullname>OSC Physics Maintainer</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+    <md:organization userid="OpenStaxCollege">
+      <md:shortname>OpenStax College</md:shortname>
+      <md:fullname>OpenStax College</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:organization>
+    <md:person userid="OSCRiceUniversity">
+      <md:firstname>Rice</md:firstname>
+      <md:surname>University</md:surname>
+      <md:fullname>Rice University</md:fullname>
+      <md:email>daniel@openstaxcollege.org</md:email>
+    </md:person>
+  </md:actors>
+  <md:roles>
+    <md:role type="author">OpenStaxCollege</md:role>
+    <md:role type="maintainer">OpenStaxCollege cnxcap</md:role>
+    <md:role type="licensor">OSCRiceUniversity</md:role>
+  </md:roles>
+  <md:license url="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License 4.0</md:license>
+  <!-- For information on license requirements for use or modification, see license url in the
+       above <md:license> element.
+       For information on formatting required attribution, see the URL:
+         CONTENT_URL/content_info#cnx_cite_header
+       where CONTENT_URL is the value provided above in the <md:content-url> element.
+  -->
+  <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
+  <md:language>en</md:language>
+  </md:derived-from>
+  <md:keywordlist>
+    <md:keyword>Air resistance</md:keyword>
+    <md:keyword>Kinematics</md:keyword>
+    <md:keyword>Motion</md:keyword>
+    <md:keyword>Projectile</md:keyword>
+    <md:keyword>Projectile motion</md:keyword>
+    <md:keyword>Range</md:keyword>
+    <md:keyword>Trajectory</md:keyword>
+  </md:keywordlist>
+  <md:subjectlist>
+    <md:subject>Science and Technology</md:subject>
+  </md:subjectlist>
+  <md:abstract><list>
+<item>Identify and explain the properties of a projectile, such as acceleration due to gravity, range, maximum height, and trajectory.</item>
+<item>Determine the location and velocity of a projectile at different points in its trajectory.</item>
+<item>Apply the principle of independence of motion to solve projectile motion problems.</item>
+</list></md:abstract>
+  <md:language>en</md:language>
+  <!-- WARNING! The 'metadata' section is read only. Do not edit above.
+       Changes to the metadata section in the source will not be saved. -->
+</metadata>
+
+<content>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple: 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical, 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math>. Both accelerations are constant, so the kinematic equations can be used.</para><note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1767845"><label/><title>Review of Kinematic Equations (constant <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow></m:mrow></m:mrow></m:semantics></m:math>)</title>
+    
+    <equation id="eip-891"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:msub>
+                            <m:mi>x</m:mi>
+                            
+                              <m:mrow>
+                                <m:mn>0</m:mn>
+                              </m:mrow>
+                            
+                          </m:msub>
+                          <m:mrow>
+                            <m:mi/>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:mover accent="true">
+                            <m:mi>v</m:mi>
+                            <m:mo stretchy="true">-</m:mo>
+                          </m:mover>
+                          <m:mi>t</m:mi>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{x=`x rSub { size 8{0} } `+` { bar  {v}}t} {}</m:annotation>
+                </m:semantics>
+              </m:math> </equation><equation id="eip-557"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mover accent="true">
+                              <m:mi>v</m:mi>
+                              <m:mo stretchy="true">-</m:mo>
+                            </m:mover>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:mfrac>
+                            <m:mrow>
+                              <m:msub>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:mi>v</m:mi>
+                            </m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mfrac>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{ { bar  {v}}=` {  {v rSub { size 8{0} } +v}  over  {2} } } {}</m:annotation>
+                </m:semantics>
+              </m:math> 
+</equation><equation id="eip-405"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mi>v</m:mi>
+                          <m:mo stretchy="false">=</m:mo>
+                          <m:mrow>
+                            <m:msub>
+                              <m:mi>v</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>0</m:mn>
+                                </m:mrow>
+                              
+                            </m:msub>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mstyle fontstyle="italic">
+                              <m:mrow>
+                                <m:mtext>at</m:mtext>
+                              </m:mrow>
+                            </m:mstyle>
+                          </m:mrow>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{v=v rSub { size 8{0} } + ital "at"} {}</m:annotation>
+                </m:semantics>
+              </m:math>
+</equation><equation id="eip-556"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mrow>
+                              <m:msub>
+                                <m:mi>x</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:msub>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                            </m:mrow>
+                          </m:mrow>
+                          <m:mrow>
+                            <m:mi>t</m:mi>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mfrac>
+                              <m:mn>1</m:mn>
+                              <m:mn>2</m:mn>
+                            </m:mfrac>
+                          </m:mrow>
+                            <m:mrow>
+                              <m:msup>
+                                <m:mtext fontstyle="italic">at</m:mtext>
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+</m:msup>
+                            </m:mrow>
+                        
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{0} } t+ {  {1}  over  {2} }  ital "at" rSup { size 8{2} } } {}</m:annotation>
+                </m:semantics>
+              </m:math> </equation><equation id="eip-389"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:msup>
+                              <m:mi>v</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>2</m:mn>
+                                </m:mrow>
+                              
+                            </m:msup>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mrow>
+                              <m:msubsup>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msubsup>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:mn>2</m:mn><m:mi>a</m:mi>
+                            </m:mrow>
+                          </m:mrow>
+                          <m:mo stretchy="false">(</m:mo>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:msub>
+                              <m:mi>x</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>0</m:mn>
+                                </m:mrow>
+                              
+                            </m:msub>
+                          </m:mrow>
+                          <m:mo stretchy="false">)</m:mo>
+                        </m:mrow>
+                      </m:mrow>
+                    <m:mtext>.</m:mtext>
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{v rSup { size 8{2} } =v rSub { size 8{0} }  rSup { size 8{2} } +2a \( x - x rSub { size 8{0} }  \) } {}</m:annotation>
+                </m:semantics>
+              </m:math> 
+</equation></note><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2242290"><media id="import-auto-id1402609" alt="A soccer player is kicking a soccer ball. The ball travels in a projectile motion and reaches a point whose vertical distance is y and horizontal distance is x. The displacement between the kicking point and the final point is s. The angle made by this displacement vector with x axis is theta.">
+        <image mime-type="image/jpg" src="Figure_03_04_01.jpg" width="350"/>
+      </media>
+      
+    <caption>The total displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> of a soccer ball at a point along its path. The vector <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> has components <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> along the horizontal and vertical axes. Its magnitude is <m:math><m:semantics><m:mrow><m:mrow><m:mi>s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math>, and it makes an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> with the horizontal.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-36">Given these assumptions, the following steps are then used to analyze projectile motion:</para>
+
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction, as shown in <link target-id="import-auto-id1815222"/>. Initial values are denoted with a subscript 0, as usual.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-205"><emphasis effect="italics"><emphasis>Step 2.</emphasis></emphasis>  <emphasis effect="italics">Treat the motion as two independent one-dimensional motions, one horizontal and the other vertical.</emphasis> The kinematic equations for horizontal and vertical motion take the following forms:
+</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-338"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Horizontal Motion</m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>a</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mn>0</m:mn>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal Motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-362"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>x</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-627"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math>
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-293"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Vertical Motion</m:mtext>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mtext>assuming positive is up</m:mtext>
+<m:mspace width="0.25em"/>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:mrow>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>a</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">=</m:mo>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mi>g</m:mi>
+                      </m:mrow>
+                    </m:mrow>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mn>9.</m:mn>
+                      </m:mrow>
+                     
+                      <m:mtext>80</m:mtext>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:msup>
+                    <m:mtext>m/s</m:mtext>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Vertical Motion " \( "assuming positive is up "a rSub { size 8{y} } = - g= - 9/"80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-131"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:mfrac>
+                        <m:mn>1</m:mn>
+                        <m:mn>2</m:mn>
+                      </m:mfrac>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-305"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:msub>
+                    <m:mi>v</m:mi>
+                    
+                      <m:mrow>
+                        <m:mi>y</m:mi>
+                      </m:mrow>
+                    
+                  </m:msub>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mstyle fontstyle="italic">
+                      <m:mrow>
+                        <m:mtext>gt</m:mtext>
+                      </m:mrow>
+                    </m:mstyle>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-542"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi fontstyle="italic">gt</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+         
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-243"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-708"><emphasis effect="italics"><emphasis>Step 3.</emphasis></emphasis>  <emphasis effect="italics"> Solve for the unknowns in the two separate motions&#8212;one horizontal and one vertical.</emphasis> Note that the only common variable between the motions is time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>. The problem solving procedures here are the same as for one-dimensional <term>kinematics</term> and are illustrated in the solved examples below.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-979"><emphasis effect="italics"><emphasis>Step 4.</emphasis></emphasis>  <emphasis effect="italics">Recombine the two motions to find the total displacement</emphasis> <m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">s</m:mtext></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math><emphasis effect="italics"> and velocity </emphasis><m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">v</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>. Because the <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are perpendicular, we determine these vectors by using the techniques outlined in the <link document="m42128">Vector Addition and Subtraction: Analytical Methods</link> and employing <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>A</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>A</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>A</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+        and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( A rSub { size 8{y} } /A rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math> in the following form, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is the direction of the displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is the direction of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>:
+</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-245"><emphasis>Total displacement and velocity</emphasis></para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-743"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>s</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msup>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-373"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>&#952;</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:mi>x</m:mi>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-679"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>v</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-264"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1815222"><media id="import-auto-id2275311" alt="In part a the figure shows projectile motion of a ball with initial velocity of v zero at an angle of theta zero with the horizontal x axis. The horizontal component v x and the vertical component v y at various positions of ball in the projectile path is shown. In part b only the horizontal velocity component v sub x is shown whose magnitude is constant at various positions in the path. In part c only vertical velocity component v sub y is shown. The vertical velocity component v sub y is upwards till it reaches the maximum point and then its direction changes to downwards. In part d resultant v of horizontal velocity component v sub x and downward vertical velocity component v sub y is found which makes an angle theta with the horizontal x axis. The direction of resultant velocity v is towards south east.">
+          <image mime-type="image/jpg" src="Figure_03_04_02.jpg" height="600"/>
+        </media>
+        
+  <caption>(a) We analyze two-dimensional projectile motion by breaking it into two independent one-dimensional motions along the vertical and horizontal axes. (b) The horizontal motion is simple, because <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is thus constant. (c) The velocity in the vertical direction begins to decrease as the object rises; at its highest point, the vertical velocity is zero. As the object falls towards the Earth again, the vertical velocity increases again in magnitude but points in the opposite direction to the initial vertical velocity. (d) The <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are recombined to give the total velocity at any given point on the trajectory.</caption></figure><example id="fs-id2175010">
+    <title>A Fireworks Projectile Explodes High and Away</title>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and  
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero and solve for the desired quantities.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-774"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1669571">By &#8220;height&#8221; we mean the altitude or vertical position <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> above the starting point. The highest point in any trajectory, called the apex, is reached when <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ v rSub { size 8{y} } =0} {}</m:annotation></m:semantics></m:math>. Since we know the initial and final velocities as well as the initial position, we use the following equation to find <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>:
+
+</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-734"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id934168"><media id="import-auto-id1576299" alt="The x y graph shows the trajectory of fireworks shell. The initial velocity of the shell v zero is at angle theta zero equal to seventy five degrees with the horizontal x axis. The fuse is set to explode the shell at the highest point of the trajectory which is at a height h equal to two hundred thirty three meters and at a horizontal distance x equal to one hundred twenty five meters from the origin.">
+        <image mime-type="image/jpg" src="Figure_03_04_03a.jpg" height="250"/>
+      </media>
+      
+    <caption>The trajectory of a fireworks shell. The fuse is set to explode the shell at the highest point in its trajectory, which is found to be at a height of 233 m and 125 m away horizontally.</caption></figure><para id="import-auto-id1163607">Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> are both zero, the equation simplifies to</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-42"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mn>0</m:mn><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn></m:mrow></m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gy.</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{0=v rSub { size 8{0y} }  rSup { size 8{2} }  - 2 ital "gy."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2114969">Solving for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> gives</para>
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-256"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                         
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                     <m:mrow> <m:mn>2</m:mn><m:mi>g</m:mi></m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>75.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-677"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70.0 m/s</m:mtext><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>sin 75&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>67.6 m/s.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } = \( "70" "." 0" m/s" \)  \( "sin""75" { size 12{ circ } }  \) ="67" "." 6" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2271493">and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-512"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>y</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mfrac>
+                    <m:mrow>
+                      <m:mo stretchy="false">(</m:mo>
+                      <m:mtext>67</m:mtext>
+                      <m:mtext>.6 m/s</m:mtext>
+                      <m:msup>
+                        <m:mo stretchy="false">)</m:mo>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                    <m:mrow>
+                      <m:mn>2</m:mn>
+                      <m:mo stretchy="false">(</m:mo>
+                      <m:mn>9</m:mn>
+                      <m:mtext>.</m:mtext>
+                      <m:mtext>80 m</m:mtext>
+                      <m:msup>
+                        <m:mtext>/s</m:mtext>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">)</m:mo>
+                    </m:mrow>
+                  </m:mfrac>
+                </m:mrow>
+
+              </m:mrow>
+            <m:mo>,</m:mo>
+                   </m:mrow>
+
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  { \( "67" "." 6" m/s" \)  rSup { size 8{2} } }  over  {2 \( 9 "." "80"" m/s" rSup { size 8{2} }  \) } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1919502">so that</para>
+    
+    <equation id="eip-310"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>233</m:mtext></m:mrow><m:mo stretchy="false"> </m:mo><m:mtext> m.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y="233"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-429"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2165781">Note that because up is positive, the initial velocity is positive, as is the maximum height, but the acceleration due to gravity is negative. Note also that the maximum height depends only on the vertical component of the initial velocity, so that any projectile with a 67.6 m/s initial vertical component of velocity will reach a maximum height of 233 m (neglecting air resistance). The numbers in this example are reasonable for large fireworks displays, the shells of which do reach such heights before exploding. In practice, air resistance is not completely negligible, and so the initial velocity would have to be somewhat larger than that given to reach the same height.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-449"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1632028">As in many physics problems, there is more than one way to solve for the time to the highest point. In this case, the easiest method is to use <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation></m:semantics></m:math>. Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is zero, this equation reduces to simply</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-383"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            <m:mtext>.</m:mtext>
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1383088">Note that the final vertical velocity, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>, at the highest point is zero. Thus,</para>
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-50"><m:math>
+        <m:semantics>
+          <m:mrow>
+            <m:mrow>
+              <m:mtable columnalign="left">
+                <m:mtr><m:mtd>                            <m:mi>t</m:mi></m:mtd>
+<m:mtd>                            <m:mo stretchy="false">=</m:mo></m:mtd>
+<m:mtd>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+
+
+                            <m:mfrac>
+<m:mrow>
+                              <m:mn>2</m:mn>
+<m:mi>y</m:mi>
+
+</m:mrow>                                 
+                              <m:mrow>
+                                <m:mo stretchy="false">(</m:mo>
+                                <m:mrow>
+                                  <m:msub>
+                                    <m:mi>v</m:mi>
+                                    
+                                      <m:mrow>
+                                        <m:mn>0y</m:mn>
+                                      </m:mrow>
+                                    
+                                  </m:msub>
+                                  <m:mo stretchy="false">+</m:mo>
+                                  <m:msub>
+                                    <m:mi>v</m:mi>
+                                    
+                                      <m:mrow>
+                                        <m:mi>y</m:mi>
+                                      </m:mrow>
+                                    
+                                  </m:msub>
+                                </m:mrow>
+                                <m:mo stretchy="false">)</m:mo>
+                              </m:mrow>
+                            </m:mfrac>
+                          </m:mrow>
+                          <m:mo stretchy="false">=</m:mo>
+                          <m:mfrac>
+                            <m:mrow>
+                              <m:mrow>
+                                <m:mn>2</m:mn>
+                                <m:mo stretchy="false">(</m:mo>
+                                <m:mtext>233 m</m:mtext>
+                              </m:mrow>
+                               <m:mo stretchy="false">)</m:mo>
+                            </m:mrow>
+                            <m:mrow>
+                              <m:mo stretchy="false">(</m:mo>
+                              <m:mtext>67.6 m/s</m:mtext>
+                             
+                              <m:mo stretchy="false">)</m:mo>
+                            </m:mrow>
+                          </m:mfrac>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow></m:mtd>
+                </m:mtr>
+                <m:mtr><m:mtd/>
+<m:mtd><m:mo>=</m:mo></m:mtd>
+<m:mtd>
+                  <m:mrow>
+                   
+                    <m:mtext>6.90 s</m:mtext><m:mtext>.</m:mtext>
+                 
+                  </m:mrow></m:mtd>
+                </m:mtr>
+              </m:mtable>
+              <m:mrow/>
+            </m:mrow>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0">alignl { stack {
+ size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} # 
+=6 "." "90"" s" {} 
+} } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-31"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1848626">This time is also reasonable for large fireworks. When you are able to see the launch of fireworks, you will notice several seconds pass before the shell explodes. (Another way of finding the time is by using <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>, and solving the quadratic equation for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-939"><emphasis>Solution for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2262600">Because air resistance is negligible, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and the horizontal velocity is constant, as discussed above. The horizontal displacement is horizontal velocity multiplied by time as given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is equal to zero:</para><equation id="eip-675"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{x} } t ","} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1871833">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-component of the velocity, which is given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} }  "." } {}</m:annotation></m:semantics></m:math> Now,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-884"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 75.0&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>18</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>1 m/s.</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 12{0} } = \( "70" "." 0" m/s" \)  \( "cos""75.0&#186;"  \) ="18" "." 1" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2046887">The time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> for both motions is the same, and so <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-685"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mn>1 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mtext>90 s</m:mtext><m:mtext/><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>125 m.</m:mtext></m:mrow><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x= \( "18" "." 1" m/s" \)  \( 6 "." "90"" s" \) ="125"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-247"><emphasis>Discussion for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1857186">The horizontal motion is a constant velocity in the absence of air resistance. The horizontal displacement found here could be useful in keeping the fireworks fragments from falling on spectators. Once the shell explodes, air resistance has a major effect, and many fragments will land directly below.</para></example>
+    <para id="import-auto-id1986266">In solving part (a) of the preceding example, the expression we found for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is valid for any projectile motion where air resistance is negligible. Call the maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mi>h</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=h} {}</m:annotation></m:semantics></m:math>; then,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-803"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>h</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+<m:mrow>
+                      <m:mn>2</m:mn>
+<m:mi>g</m:mi>
+</m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1973673">This equation defines the <emphasis effect="italics"><emphasis effect="italics">maximum height of a projectile</emphasis></emphasis> and depends only on the vertical component of the initial velocity.</para>
+    <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1479427"><label/><title>Defining a Coordinate System</title>
+    
+    <para id="import-auto-id2275341">It is important to set up a coordinate system when analyzing projectile motion. One part of defining the coordinate system is to define an origin for the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions. Often, it is convenient to choose the initial position of the object as the origin such that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math>. It is also important to define the positive and negative directions in the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> directions. Typically, we define the positive vertical direction as upwards, and the positive horizontal direction is usually the direction of the object&#8217;s motion. When this is the case, the vertical acceleration, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>, takes a negative value (since it is directed downwards towards the Earth). However, it is occasionally useful to define the coordinates differently. For example, if you are analyzing the motion of a ball thrown downwards from the top of a cliff, it may make sense to define the positive direction downwards since the motion of the ball is solely in the downwards direction. If this is the case, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math> takes a positive value.</para>
+    </note><example id="fs-id708626">
+    <title>Calculating Projectile Motion: Hot Rock Projectile</title>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1916950">Kilauea in Hawaii is the world&#8217;s most continuously active volcano. Very active volcanoes characteristically eject red-hot rocks and lava rather than smoke and ash. Suppose a large rock is ejected from the volcano with a speed of 25.0 m/s and at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"35"&#176;} {}</m:annotation></m:semantics></m:math> above the horizontal, as shown in <link target-id="import-auto-id1817519"/>. The rock strikes the side of the volcano at an altitude 20.0 m lower than its starting point. (a) Calculate the time it takes the rock to follow this path. (b) What are the magnitude and direction of the rock&#8217;s velocity at impact?</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1817519"><media id="import-auto-id1817520" alt="The trajectory of a rock ejected from a volcano is shown. The initial velocity of rock v zero is equal to twenty five meters per second and it makes an angle of thirty five degrees with the horizontal x axis. The figure shows rock falling down a height of twenty meters below the volcano level. The velocity at this point is v which makes an angle of theta with horizontal x axis. The direction of v is south east.">
+        <image mime-type="image/jpg" src="Figure_03_04_04a.jpg" width="400"/>
+      </media>
+      
+    <caption>The trajectory of a rock ejected from the Kilauea volcano.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-770"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1823692">Again, resolving this two-dimensional motion into two independent one-dimensional motions will allow us to solve for the desired quantities. The time a projectile is in the air is governed by its vertical motion alone. We will solve for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> first. While the rock is rising and falling vertically, the horizontal motion continues at a constant velocity. This example asks for the final velocity. Thus, the vertical and horizontal results will be recombined to obtain <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> at the final time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> determined in the first part of the example.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-408"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1608071">While the rock is in the air, it rises and then falls to a final position 20.0 m lower than its starting altitude. We can find the time for this by using</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-895"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
+<m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1843834">If we take the initial position <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero, then the final position is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow></m:mrow><m:mtext>.0  m</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= - "20" "." 0" m" "." } {}</m:annotation></m:semantics></m:math> Now the initial vertical velocity is the vertical component of the initial velocity, found from  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> = (<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25" "." "0&#160;m/s"} {}</m:annotation></m:semantics></m:math>)(<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>sin 35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"sin 35"&#176;} {}</m:annotation></m:semantics></m:math>) = <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Substituting known values yields</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-722"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>0 m</m:mn><m:mrow><m:mtext/><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mn>3 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced></m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
+<m:mtext>.</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ - "20" "." 0" m"= \( "14" "." 3" m/s" \) t -  left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1561988">Rearranging terms gives a quadratic equation in <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form 
+<m:math>
+<m:semantics>
+<m:mrow><m:mrow><m:mrow><m:mrow><m:mrow>
+<m:msup>
+<m:mstyle fontstyle="italic">
+<m:mi>at</m:mi></m:mstyle><m:mn>2</m:mn>
+</m:msup>
+<m:mo stretchy="false">+</m:mo>
+
+<m:mstyle fontstyle="italic"><m:mi>bt</m:mi></m:mstyle>
+<m:mo stretchy="false">+</m:mo>
+<m:mi>c</m:mi>
+<m:mo stretchy="false">=</m:mo>
+<m:mn>0</m:mn>
+</m:mrow></m:mrow></m:mrow></m:mrow></m:mrow>
+<m:annotation encoding="StarMath 5.0"> size 12{ ital "at" rSup { size 8{2} } + ital "bt"+c=0} {}</m:annotation>
+</m:semantics>
+</m:math>, where the constants are 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>a</m:mi><m:mo>=</m:mo><m:mn>4.90</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math>, 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>b</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>14.3</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math>, and 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>c</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>20.0.</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math> Its solutions are given by the quadratic formula:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-880"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mo stretchy="false">&#8722;</m:mo>
+                          <m:mi>b</m:mi>
+                        </m:mrow>
+                        <m:mo stretchy="false">&#177;</m:mo>
+                        <m:msqrt>
+                          <m:mrow>
+                            <m:mrow>
+                              <m:msup>
+                                <m:mi>b</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msup>
+                              <m:mo stretchy="false">&#8722;</m:mo>
+                              <m:mn>4</m:mn>
+                            </m:mrow>
+                            <m:mstyle fontstyle="italic">
+                              <m:mrow>
+                                <m:mtext>ac</m:mtext>
+                              </m:mrow>
+                            </m:mstyle>
+                          </m:mrow>
+                        </m:msqrt>
+                      </m:mrow>
+                      <m:mrow><m:mtext>2</m:mtext><m:mtext fontstyle="italic">a</m:mtext></m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{t= {  { - b +-  sqrt {b rSup { size 8{2} }  - 4 ital "ac"} }  over  {"2a"} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions: 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and 
+
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{-1 "." "03""s"} {}</m:annotation></m:semantics></m:math>. The negative value of time implies an event before the start of motion, and so we discard it. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-267"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>96 s</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"" s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-46"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1368589">The time for projectile motion is completely determined by the vertical motion. So any projectile that has an initial vertical velocity of 14.3 m/s and lands 20.0 m below its starting altitude will spend 3.96 s in the air.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-653"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1599448">From the information now in hand, we can find the final horizontal and vertical velocities <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> and combine them to find the total velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and the angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> it makes with the horizontal. Of course, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is constant so we can solve for it at any horizontal location. In this case, we chose the starting point since we know both the initial velocity and initial angle. Therefore:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-873"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 35&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} } = \( "25" "." 0" m/s" \)  \( "cos""35" rSup { size 8{ circ } }  \) ="20" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2252925">The final vertical velocity is given by the following equation:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-168"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">&#8722;</m:mo><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gt,</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt,"} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2173689">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0y</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> was found in part (a) to be <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Thus,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-113"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mtext>14</m:mtext>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                  <m:mn>3 m/s</m:mn>
+                  <m:mrow>
+                    <m:mtext/>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mo stretchy="false">(</m:mo>
+                  </m:mrow>
+                  <m:mn>9</m:mn>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>80 m/s</m:mtext>
+                  <m:msup>
+                    <m:mtext/>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mn>3</m:mn>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>96 s</m:mtext>
+                  <m:mtext/>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } ="14" "." 3" m/s" -  \( 9 "." "80"" m/s" rSup { size 8{2} }  \)  \( 3 "." "96"" s" \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1792451">so that</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-571"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } = - "24" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2239982">To find the magnitude of the final velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> we combine its perpendicular components, using the following equation:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-394"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">+</m:mo><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup></m:mrow></m:msqrt></m:mrow><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:mo stretchy="false">(</m:mo><m:mtext>20</m:mtext><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:mrow><m:mrow><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">+</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:msqrt><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } = sqrt { \( "20" "." 5" m/s" \)  rSup { size 8{2} } + \(  - "24" "." 5" m/s" \)  rSup { size 8{2} } } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1677955">which gives</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-60"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>31</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>9 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v="31" "." 9" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1645980">The direction <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is found from the equation:</para>
+    
+    <equation id="eip-353"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>&#952;</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>v</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1972156">so that</para>
+    
+    <equation id="eip-589"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mrow><m:mn>5</m:mn><m:mo stretchy="false">/</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5</m:mn><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>19</m:mtext><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \(  - "24" "." 5/"20" "." 5 \) ="tan" rSup { size 8{ - 1} }  \(  - 1 "." "19" \) "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1613163">Thus,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-379"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>50</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>1</m:mn><m:mrow><m:mo stretchy="false">&#186;</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } = - "50" "." 1 rSup { size 12{ circ } "."} } {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-299"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1459619">The negative angle means that the velocity is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>50</m:mtext><m:mtext>.</m:mtext><m:mn>1&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50" "." 1&#176;} {}</m:annotation></m:semantics></m:math> below the horizontal. This result is consistent with the fact that the final vertical velocity is negative and hence downward&#8212;as you would expect because the final altitude is 20.0 m lower than the initial altitude. (See <link target-id="import-auto-id1817519"/>.)</para></example>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1532818">One of the most important things illustrated by projectile motion is that vertical and horizontal motions are independent of each other. Galileo was the first person to fully comprehend this characteristic. He used it to predict the range of a projectile. On level ground, we define <term id="import-auto-id1751163">range</term> to be the horizontal distance <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> traveled by a projectile. Galileo and many others were interested in the range of projectiles primarily for military purposes&#8212;such as aiming cannons. However, investigating the range of projectiles can shed light on other interesting phenomena, such as the orbits of satellites around the Earth. Let us consider projectile range further.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1904800"><media id="import-auto-id1904802" alt="Part a of the figure shows three different trajectories of projectiles on level ground. In each case the projectiles makes an angle of forty five degrees with the horizontal axis. The first projectile of initial velocity thirty meters per second travels a horizontal distance of R equal to ninety one point eight meters. The second projectile of initial velocity forty meters per second travels a horizontal distance of R equal to one hundred sixty three meters. The third projectile of initial velocity fifty meters per second travels a horizontal distance of R equal to two hundred fifty five meters.">
+          <image mime-type="image/jpg" src="Figure_03_04_05a.jpg" height="300"/>
+        </media>
+        
+<caption>Trajectories of projectiles on level ground. (a) The greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range for a given initial angle. (b) The effect of initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> on the range of a projectile with a given initial speed. Note that the range is the same for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>15&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"15"&#176;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mtext>75&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"75&#176;"} {}</m:annotation></m:semantics></m:math>, although the maximum heights of those paths are different.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1750749">How does the initial velocity of a projectile affect its range? Obviously, the greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range, as shown in <link target-id="import-auto-id1904800"/>(a). The initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> also has a dramatic effect on the range, as illustrated in <link target-id="import-auto-id1904800"/>(b). For a fixed initial speed, such as might be produced by a cannon, the maximum range is obtained with <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } &#160;=&#160;"45&#186;"} {}</m:annotation></m:semantics></m:math>. This is true only for conditions neglecting air resistance. If air resistance is considered, the maximum angle is approximately <m:math><m:semantics><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38&#186;"} {}</m:annotation></m:semantics></m:math>. Interestingly, for every initial angle except <m:math><m:semantics><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45&#186;"} {}</m:annotation></m:semantics></m:math>, there are two angles that give the same range&#8212;the sum of those angles is <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#186;"} {}</m:annotation></m:semantics></m:math>. The range also depends on the value of the acceleration of gravity <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. The lunar astronaut Alan Shepherd was able to drive a golf ball a great distance on the Moon because gravity is weaker there. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on <emphasis effect="italics"><emphasis effect="italics">level ground</emphasis></emphasis> for which air resistance is negligible is given by </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-240"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mtext>,</m:mtext><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1674836">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial speed and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle relative to the horizontal. The proof of this equation is left as an end-of-chapter problem (hints are given), but it does fit the major features of projectile range as described.</para>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1686986">When we speak of the range of a projectile on level ground, we assume that <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> is very small compared with the circumference of the Earth. If, however, the range is large, the Earth curves away below the projectile and acceleration of gravity changes direction along the path. The range is larger than predicted by the range equation given above because the projectile has farther to fall than it would on level ground. (See <link target-id="import-auto-id1645881"/>.) If the initial speed is great enough, the projectile goes into orbit.  This possibility was recognized centuries before it could be accomplished. When an object is in orbit, the Earth curves away from underneath the object at the same rate as it falls. The object thus falls continuously but never hits the surface. These and other aspects of orbital motion, such as the rotation of the Earth, will be covered analytically and in greater depth later in this text.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645878">Once again we see that thinking about one topic, such as the range of a projectile, can lead us to others, such as the Earth orbits. In  <link document="m42045">Addition of Velocities</link>, we will examine the addition of velocities, which is another important aspect of two-dimensional kinematics and will also yield insights beyond the immediate topic.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645881"><media id="import-auto-id1825851" alt="A figure of the Earth is shown and on top of it a very high tower is placed. A projectile satellite is launched from this very high tower with initial velocity of v zero in the horizontal direction. Several trajectories are shown with increasing range. A circular trajectory is shown indicating the satellite achieved its orbit and it is revolving around the Earth.">
+        <image mime-type="image/jpg" src="Figure_03_04_06a.jpg" width="200"/>
+      </media>
+      
+    <caption>Projectile to satellite. In each case shown here, a projectile is launched from a very high tower to avoid air resistance. With increasing initial speed, the range increases and becomes longer than it would be on level ground because the Earth curves away underneath its path. With a large enough initial speed, orbit is achieved.</caption></figure>
+<note xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-89"><label/><title>PhET Explorations: Projectile Motion</title>
+
+<para id="eip-id1169738107387">Blast a Buick out of a cannon! Learn about projectile motion by firing various objects. Set the angle, initial speed, and mass. Add air resistance. Make a game out of this simulation by trying to hit a target.</para>
+
+ <figure id="eip-id1462984"><media id="Phet_module_3.4" alt="">
+
+  <image mime-type="image/png" for="online" src="projectile-motion_en.jar" thumbnail="PhET_Icon.png" width="450"/>
+  <image mime-type="image/png" for="pdf" src="PhET_Icon.png" width="450"/>
+   
+</media>
+
+      <caption><link url="projectile-motion_en.jar">Projectile Motion</link></caption></figure></note><section id="fs-id1843457" class="section-summary">
+<title>Summary</title><list xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2130996"><item id="import-auto-id1677012">Projectile motion is the motion of an object through the air that is subject only to the acceleration of gravity.</item>
+    <item id="import-auto-id1786765">To solve projectile motion problems, perform the following steps:
+      <list id="fs-id1842700" list-type="enumerated" number-style="arabic" class="stepwise"><item id="import-auto-id1830314">Determine a coordinate system. Then, resolve the position and/or velocity of the object in the horizontal and vertical components. The components of position <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> are given by the quantities <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>, and the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction.</item>
+      <item id="import-auto-id1830316">Analyze the motion of the projectile in the horizontal direction using the following equations:
+    <equation id="eip-898"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Horizontal motion </m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>a</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mn>0</m:mn>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation>
+    <equation id="eip-236"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>x</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
+        </m:semantics>
+      </m:math> </equation>
+    <equation id="eip-612"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo>
+
+<m:msub>
+<m:mtext mathvariant="bold">v</m:mtext>
+<m:mrow>
+<m:mtext>x</m:mtext>
+</m:mrow>
+</m:msub>
+
+
+</m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math></equation></item>
+        <item id="import-auto-id1939082">Analyze the motion of the projectile in the vertical direction using the following equations:
+    <equation id="import-auto-id1939084"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Vertical motion </m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mtext>Assuming positive direction is up; </m:mtext><m:mspace width="0.25em"/>
+                  <m:mrow>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>a</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">=</m:mo>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mi>g</m:mi>
+                      </m:mrow>
+                    </m:mrow>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:mo stretchy="false">&#8722;</m:mo>
+                      <m:mn>9</m:mn>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>80 m</m:mtext>
+                  <m:msup>
+                    <m:mtext>/s</m:mtext>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Vertical motion " \( "Assuming positive direction is up; "a rSub { size 8{y} } = - g= - 9 "." "80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><equation id="import-auto-id1492830"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:mfrac>
+                        <m:mn>1</m:mn>
+                        <m:mn>2</m:mn>
+                      </m:mfrac>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><equation id="import-auto-id2022844"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:msub>
+                    <m:mi>v</m:mi>
+                    
+                      <m:mrow>
+                        <m:mi>y</m:mi>
+                      </m:mrow>
+                    
+                  </m:msub>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mstyle fontstyle="italic">
+                      <m:mrow>
+                        <m:mtext>gt</m:mtext>
+                      </m:mrow>
+                    </m:mstyle>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id1677876"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                  
+                    <m:mrow>
+                      <m:msup>
+                        <m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+<equation id="import-auto-id1653540"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mo>.</m:mo><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) } {}</m:annotation></m:semantics></m:math></equation>
+        </item>
+        <item id="import-auto-id1552181">Recombine the horizontal and vertical components of location and/or velocity using the following equations:
+    <equation id="import-auto-id2092332">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>s</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msup>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id2282348">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>&#952;</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:mi>x</m:mi>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id2274748">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>v</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id1979208"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mtext>v</m:mtext></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math></equation></item></list></item>
+  <item id="import-auto-id1888635">The maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mi>h</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h} {}</m:annotation></m:semantics></m:math> of a projectile launched with initial vertical velocity <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> is given by
+  <equation id="import-auto-id1534227"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>h</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mrow><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} } } {}</m:annotation></m:semantics></m:math></equation></item>
+    <item id="import-auto-id1823593">The maximum horizontal distance traveled by a projectile is called the <emphasis>range</emphasis>. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on level ground launched at an angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> above the horizontal with initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is given by
+  <equation id="import-auto-id1951750"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } } {}</m:annotation></m:semantics></m:math></equation></item>
+</list></section>
+    <section id="fs-id2865659" type="conceptual-questions" class="conceptual-questions"><title>Conceptual Questions</title><exercise id="fs-id2183300" type="conceptual-questions">
+        <problem id="fs-id2183302"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2298558">Answer the following questions for projectile motion on level ground assuming negligible air resistance (the initial angle being neither <m:math><m:semantics><m:mrow><m:mrow><m:mtext>0&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"0&#176;"} {}</m:annotation></m:semantics></m:math> nor <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#176;"} {}</m:annotation></m:semantics></m:math>): (a) Is the velocity ever zero? (b) When is the velocity a minimum? A maximum? (c) Can the velocity ever be the same as the initial velocity at a time other than at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=0} {}</m:annotation></m:semantics></m:math>? (d) Can the speed ever be the same as the initial speed at a time other than at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=0} {}</m:annotation></m:semantics></m:math>?
+        </para></problem>
+      </exercise>
+      <exercise id="fs-id1638420" type="conceptual-questions">
+        <problem id="fs-id1638423"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1638424">Answer the following questions for projectile motion on level ground assuming negligible air resistance (the initial angle being neither <m:math><m:semantics><m:mrow><m:mrow><m:mtext>0&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"0&#176;"} {}</m:annotation></m:semantics></m:math> nor <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#176;"} {}</m:annotation></m:semantics></m:math>): (a) Is the acceleration ever zero? (b) Is the acceleration ever in the same direction as a component of velocity? (c) Is the acceleration ever opposite in direction to a component of velocity?
+        </para></problem>
+      </exercise>
+      <exercise id="fs-id2062475" type="conceptual-questions">
+        <problem id="fs-id2062477"><para id="fs-id2062478">For a fixed initial speed, the range of a projectile is determined by the angle at which it is fired. For all but the maximum, there are two angles that give the same range. Considering factors that might affect the ability of an archer to hit a target, such as wind, explain why the smaller angle (closer to the horizontal) is preferable. When would it be necessary for the archer to use the larger angle? Why does the punter in a football game use the higher trajectory?</para></problem></exercise>
+      <exercise id="fs-id1875651" type="conceptual-questions"><problem id="fs-id1875652"><para id="fs-id1875653">During a lecture demonstration, a professor places two coins on the edge of a table. She then flicks one of the coins horizontally off the table, simultaneously nudging the other over the edge. Describe the subsequent motion of the two coins, in particular discussing whether they hit the floor at the same time.
+        </para></problem>
+        </exercise>
+    </section>
+   <section id="fs-id1875655" type="problems-exercises" class="problems-exercises"><title>Problems &amp; Exercises</title><exercise id="fs-id1923898" type="problems-exercises">      <problem id="fs-id1105650"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1105652">A projectile is launched at ground level with an initial speed of 50.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>30.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal. It strikes a target above the ground 3.00 seconds later. What are the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> distances from where the projectile was launched to where it lands?</para></problem>
+  <solution id="fs-id1543587">
+ <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1915206"><m:math><m:semantics>
+
+<m:mtable columnalign="left">
+ <m:mtr>
+  <m:mtd><m:mi>x</m:mi></m:mtd>
+  <m:mtd><m:mo stretchy="false">=</m:mo></m:mtd>
+  <m:mtd><m:mtext>1.30 m</m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mn>10</m:mn><m:mn>2</m:mn></m:msup>
+  </m:mtd>
+ </m:mtr>
+
+ <m:mtr>
+  <m:mtd><m:mi>y</m:mi></m:mtd>
+  <m:mtd><m:mo stretchy="false">=</m:mo></m:mtd>
+  <m:mtd><m:mtext>30</m:mtext><m:mtext>.9 m.</m:mtext>
+  </m:mtd>
+ </m:mtr>
+
+</m:mtable>
+</m:semantics></m:math></para></solution>
+</exercise>
+      <exercise id="fs-id1275043" type="problems-exercises"><problem id="fs-id1019417"><para id="fs-id1980036">A ball is kicked with an initial velocity of 16 m/s in the horizontal direction and 12 m/s in the vertical direction. (a) At what speed does the ball hit the ground? (b) For how long does the ball remain in the air? (c)What maximum height is attained by the ball?
+      </para></problem></exercise>
+          <exercise id="fs-id2889503" type="problems-exercises">  <problem id="fs-id1790979"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1790980">A ball is thrown horizontally from the top of a 60.0-m building and lands 100.0 m from the base of the building. Ignore air resistance. (a) How long is the ball in the air? (b) What must have been the initial horizontal component of the velocity? (c) What is the vertical component of the velocity just before the ball hits the ground? (d) What is the velocity (including both the horizontal and vertical components) of the ball just before it hits the ground?</para></problem>
+            <solution id="fs-id1945253">
+              <para id="fs-id2167208">(a) 3.50 s</para>
+              <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1612943">(b) 28.6  m/s (c) 34.3 m/s</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id916496">(d) 44.7 m/s,  <m:math><m:semantics><m:mrow><m:mn>50.2&#186;</m:mn></m:mrow></m:semantics></m:math> below horizontal</para></solution>
+          </exercise>
+      <exercise id="fs-id2197387" type="problems-exercises"><problem id="fs-id2261404"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2261405">(a) A daredevil is attempting to jump his motorcycle over a line of buses parked end to end by driving up a <m:math><m:semantics><m:mrow><m:mrow><m:mtext>32&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"32&#176;"} {}</m:annotation></m:semantics></m:math> ramp at a speed of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>40</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s&#160;</m:mtext><m:mo stretchy="false">(</m:mo><m:mtext>144&#160;km/h</m:mtext><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40" "." "0&#160;m/s&#160;" \( "144&#160;km/h" \) } {}</m:annotation></m:semantics></m:math>. How many buses can he clear if the top of the takeoff ramp is at the same height as the bus tops and the buses are 20.0 m long? (b) Discuss what your answer implies about the margin of error in this act&#8212;that is, consider how much greater the range is than the horizontal distance he must travel to miss the end of the last bus. (Neglect air resistance.)
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1420192" type="problems-exercises"><problem id="fs-id1078714"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1078715">An archer shoots an arrow at a 75.0 m distant target; the bull&#8217;s-eye of the target is at same height as the release height of the arrow. (a) At what angle must the arrow be released to hit the bull&#8217;s-eye if its initial speed is 35.0 m/s? In this part of the problem, explicitly show how you follow the steps involved in solving projectile motion problems. (b) There is a large tree halfway between the archer and the target with an overhanging horizontal branch 3.50 m above the release height of the arrow. Will the arrow go over or under the branch?</para></problem>
+        <solution id="fs-id1970452">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1970455">(a) <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mtext>4&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"18" "." "4&#176;"} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1678230">(b) The arrow will go over the branch.</para></solution>
+      </exercise>
+     <exercise id="fs-id1934878" type="problems-exercises"><problem id="fs-id2226553"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2226554">A rugby player passes the ball 7.00 m across the field, where it is caught at the same height as it left his hand. (a) At what angle was the ball thrown if its initial speed was 12.0 m/s, assuming that the smaller of the two possible angles was used? (b) What other angle gives the same range, and why would it not be used? (c) How long did this pass take?</para></problem>
+     </exercise>
+      <exercise id="fs-id2126267" type="problems-exercises"><problem id="fs-id2889922"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2889923">Verify the ranges for the projectiles in <link target-id="import-auto-id1904800"/>(a) for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="45"&#176;} {}</m:annotation></m:semantics></m:math> and the given initial velocities.</para></problem><solution id="fs-id1903883">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1912801"><m:math><m:semantics><m:mrow><m:mrow><m:mtable><m:mtr><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup>
+<m:mrow>
+<m:mtext>sin</m:mtext><m:msub><m:mn>2&#952;</m:mn><m:mn>0</m:mn></m:msub><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow></m:mtr><m:mtr><m:mrow><m:mtext>For </m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow><m:mo>,</m:mo><m:mrow/></m:mrow><m:mrow><m:mrow>
+
+<m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup><m:mi>g</m:mi></m:mfrac></m:mrow><m:mrow/></m:mrow></m:mtr></m:mtable><m:mrow/></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0">alignl { stack {
+ size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} # 
+"For "&#952;="45"&#176;: {} # 
+R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {} 
+} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>; 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>163</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math>
+
+ for 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>; 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>50</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50 m/s"} {}</m:annotation></m:semantics></m:math>.</para></solution>
+      </exercise>
+      <exercise id="fs-id2214647" type="problems-exercises"><problem id="fs-id2214182"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2214183">Verify the ranges shown for the projectiles in <link target-id="import-auto-id1904800"/>(b) for an initial velocity of 50 m/s at the given initial angles.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id2905201" type="problems-exercises"><problem id="fs-id1851487"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1851488">The cannon on a battleship can fire a shell a maximum distance of 32.0 km. (a) Calculate the initial velocity of the shell. (b) What maximum height does it reach? (At its highest, the shell is above 60% of the atmosphere&#8212;but air resistance is not really negligible as assumed to make this problem easier.) (c) The ocean is not flat, because the Earth is curved. Assume that the radius of the Earth is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mrow><m:mtext>37</m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mtext>10</m:mtext><m:mrow><m:mn>3</m:mn></m:mrow></m:msup></m:mrow><m:mspace width="0.25em"/><m:mtext> km</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{6 "." "37" times "10" rSup { size 8{3} } " km"} {}</m:annotation></m:semantics></m:math>. How many meters lower will its surface be 32.0 km from the ship along a horizontal line parallel to the surface at the ship? Does your answer imply that error introduced by the assumption of a flat Earth in projectile motion is significant here?</para></problem>
+        <solution id="fs-id2075683">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1862278">(a) 560 m/s</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2252609">(b) <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>8</m:mn><m:mtext>.</m:mtext><m:mrow><m:mtext>00 </m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mtext> 10</m:mtext><m:mrow><m:mn>3</m:mn></m:mrow></m:msup></m:mrow><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{8 "." "00 " times " 10" rSup { size 8{3} } " m"} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2262837">(c) 80.0 m. This error is not significant because it is only 1% of the answer in part (b).</para></solution>
+      </exercise>
+      <exercise id="fs-id1925728" type="problems-exercises"><problem id="fs-id2282381"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2282382">An arrow is shot from a height of 1.5 m toward a cliff of height <m:math><m:semantics><m:mrow><m:mrow><m:mi>H</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{H} {}</m:annotation></m:semantics></m:math>. It is shot with a velocity of 30 m/s at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mtext>60&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"60&#176;"} {}</m:annotation></m:semantics></m:math> above the horizontal. It lands on the top edge of the cliff 4.0 s later. (a) What is the height of the cliff? (b) What is the maximum height reached by the arrow along its trajectory? (c) What is the arrow&#8217;s impact speed just before hitting the cliff?
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1745072" type="problems-exercises"><problem id="fs-id2275266"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2275267">In the standing broad jump, one squats and then pushes off with the legs to see how far one can jump. Suppose the extension of the legs from the crouch position is 0.600 m and the acceleration achieved from this position is 1.25 times the acceleration due to gravity, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. How far can they jump? State your assumptions. (Increased range can be achieved by swinging the arms in the direction of the jump.)</para></problem>
+      <solution id="fs-id2864553">
+        <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2864555">1.50 m, assuming launch angle of  <m:math><m:semantics><m:mrow><m:mn>45&#186;</m:mn></m:mrow></m:semantics></m:math></para></solution>
+      </exercise>
+      <exercise id="fs-id1875777" type="problems-exercises"><problem id="fs-id2864558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2864559">The world long jump record is 8.95 m (Mike Powell, USA, 1991). Treated as a projectile, what is the maximum range obtainable by a person if he has a take-off speed of 9.5 m/s? State your assumptions.
+      </para></problem>
+      </exercise>
+     <exercise id="fs-id2254986" type="problems-exercises"><problem id="fs-id1543443"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1543444">Serving at a speed of 170 km/h, a tennis player hits the ball at a height of 2.5 m and an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> below the horizontal. The service line is 11.9 m from the net, which is 0.91 m high. What is the angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> such that the ball just crosses the net? Will the ball land in the service box, whose out line is 6.40 m from the net?</para></problem>
+      <solution id="fs-id722706">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2260869"><m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo>=</m:mo><m:mn>6.1&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2088346">yes, the ball lands at 5.3 m from the net</para></solution>
+      </exercise>
+      <exercise id="fs-id2173828" type="problems-exercises"><problem id="fs-id2088349"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2088350">A football quarterback is moving straight backward at a speed of 2.00 m/s when he throws a pass to a player 18.0 m straight downfield. (a) If the ball is thrown at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mtext>25&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25&#176;"} {}</m:annotation></m:semantics></m:math> relative to the ground and is caught at the same height as it is released, what is its initial speed relative to the ground? (b) How long does it take to get to the receiver? (c) What is its maximum height above its point of release?
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1796436" type="problems-exercises"><problem id="fs-id1979282"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1979284">Gun sights are adjusted to aim high to compensate for the effect of gravity, effectively making the gun accurate only for a specific range. (a) If a gun is sighted to hit targets that are at the same height as the gun and 100.0 m away, how low will the bullet hit if aimed directly at a target 150.0 m away? The muzzle velocity of the bullet is 275 m/s. (b) Discuss qualitatively how a larger muzzle velocity would affect this problem and what would be the effect of air resistance.</para></problem>
+        <solution id="fs-id2175653">
+      <para id="fs-id2175655">(a) &#8722;0.486 m</para>
+      <para id="fs-id1461088">(b) The larger the muzzle velocity, the smaller the deviation in the vertical direction, because the time of flight would be smaller. Air resistance would have the effect of decreasing the time of flight, therefore increasing the vertical deviation.</para>
+      </solution>
+      </exercise>
+      <exercise id="fs-id2177814" type="problems-exercises"><problem id="fs-id1781566"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1781567">An eagle is flying horizontally at a speed of 3.00 m/s when the fish in her talons wiggles loose and falls into the lake 5.00 m below. Calculate the velocity of the fish relative to the water when it hits the water.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1914025" type="problems-exercises"><problem id="fs-id2057849"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2057850">An owl is carrying a mouse to the chicks in its nest. Its position at that time is 4.00 m west and 12.0 m above the center of the 30.0 cm diameter nest. The owl is flying east at 3.50 m/s at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mn>30.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30&#186;}</m:annotation></m:semantics></m:math> below the horizontal when it accidentally drops the mouse. Is the owl lucky enough to have the mouse hit the nest? To answer this question, calculate the horizontal position of the mouse when it has fallen 12.0 m.</para></problem>
+        <solution id="fs-id2042074">
+        <para id="fs-id2042076">4.23 m. No, the owl is not lucky; he misses the nest.</para></solution>
+      </exercise>
+      <exercise id="fs-id1403577" type="problems-exercises"><problem id="fs-id2865734"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2865735">Suppose a soccer player kicks the ball from a distance 30 m toward the goal. Find the initial speed of the ball if it just passes over the goal, 2.4 m above the ground, given the initial direction to be <m:math><m:semantics><m:mrow><m:mrow><m:mtext>40&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40" rSup { size 8{o} } } {}</m:annotation></m:semantics></m:math> above the horizontal.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id2260735" type="problems-exercises"><problem id="fs-id1789803"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1789804">Can a goalkeeper at her/ his goal kick a soccer ball into the opponent&#8217;s goal without the ball touching the ground? The distance will be about 95 m. A goalkeeper can give the ball a speed of 30 m/s.</para></problem>
+      <solution id="fs-id1985242">
+        <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1985244">No, the maximum range (neglecting air resistance) is about 92 m. </para></solution>
+      </exercise>      
+     <exercise id="fs-id1437858" type="problems-exercises"><problem id="fs-id1891285"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1891286">The free throw line in basketball is 4.57 m (15 ft) from the basket, which is 3.05 m (10 ft) above the floor. A player standing on the free throw line throws the ball with an initial speed of 7.15 m/s, releasing it at a height of 2.44 m (8 ft) above the floor. At what angle above the horizontal must the ball be thrown to exactly hit the basket? Note that most players will use a large initial angle rather than a flat shot because it allows for a larger margin of error. Explicitly show how you follow the steps involved in solving projectile motion problems.</para></problem>
+     </exercise>
+      <exercise id="fs-id1827481" type="problems-exercises"><problem id="fs-id1750926"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1750928">In 2007, Michael Carter (U.S.) set a world record in the shot put with a throw of 24.77 m. What was the initial speed of the shot if he released it at a height of 2.10 m and threw it at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>38.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> above the horizontal? (Although the maximum distance for a projectile on level ground is achieved at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> when air resistance is neglected, the actual angle to achieve maximum range is smaller; thus, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> will give a longer range than <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> in the shot put.)</para></problem>
+        <solution id="fs-id1630701">
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2261978">15.0 m/s</para></solution>
+      </exercise>
+          <exercise id="fs-id1670278" type="problems-exercises"><problem id="fs-id1945400"><para id="fs-id1945401">A basketball player is running at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>5</m:mn><m:mtext>.</m:mtext><m:mtext>00&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{5 "." "00&#160;m/s"} {}</m:annotation></m:semantics></m:math> directly toward the basket when he jumps into the air to dunk the ball. He maintains his horizontal velocity. (a) What vertical velocity does he need to rise 0.750 m above the floor? (b) How far from the basket (measured in the horizontal direction) must he start his jump to reach his maximum height at the same time as he reaches the basket?
+          </para></problem>
+          </exercise>
+      <exercise id="fs-id1779635" type="problems-exercises">
+        <problem id="fs-id1637691"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1637692">A football player punts the ball at a <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>45.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#176;} {}</m:annotation></m:semantics></m:math> angle. Without an effect from the wind, the ball would travel 60.0 m horizontally. (a) What is the initial speed of the ball? (b) When the ball is near its maximum height it experiences a brief gust of wind that reduces its horizontal velocity by 1.50 m/s. What distance does the ball travel horizontally?</para></problem>
+      <solution id="fs-id1545352">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1545354">(a) 24.2 m/s
+</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1796132">(b) The ball travels a total of 57.4 m with the brief gust of wind.</para></solution>
+      </exercise>
+<exercise id="fs-id2046931" type="problems-exercises">
+  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mo>&#8211;</m:mo><m:mo stretchy="false">(</m:mo><m:mrow><m:mn>1</m:mn><m:mo stretchy="false">/</m:mo><m:mn>2</m:mn></m:mrow><m:mo stretchy="false">)</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=&#965; rSub { size 8{0y} } t \( 1/2 \)  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> (These equations describe the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions of a projectile that starts at the origin.) You should obtain an equation of the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> where <m:math><m:semantics><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{b} {}</m:annotation></m:semantics></m:math> are constants.
+</para></problem>
+</exercise>
+<exercise id="fs-id2133758" type="problems-exercises"><problem id="fs-id2890360"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2890361">Derive <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mn>2&#952;</m:mn><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } } {}</m:annotation></m:semantics></m:math> for the range of a projectile on level ground by finding the time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> at which <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> becomes zero and substituting this value of <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> into the expression for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x - x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, noting that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=x - x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math></para></problem>
+<solution id="eip-id2932521">
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id2932523"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mi>gt</m:mi></m:mstyle><m:mn>2</m:mn></m:msup><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo>
+
+</m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mi>gt</m:mi></m:mstyle><m:mn>2</m:mn></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y - y rSub { size 8{0} } =0=v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } = \( v rSub { size 8{0} } "sin"&#952; \) t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>,</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1990384">so that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:mn>2</m:mn><m:mo stretchy="false">(</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/>
+<m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+<m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t= {  {2 \( v rSub { size 8{0} } "sin"&#952; \) }  over  {g} } } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1355828"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/>
+<m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+<m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mi>R</m:mi></m:mrow><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x - x rSub { size 8{0} } =v rSub { size 8{0x} } t= \( v rSub { size 8{0} } "cos"&#952; \) t=R,} {}</m:annotation></m:semantics></m:math> and substituting for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> gives:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3306953"><m:math>
+        <m:semantics>
+          <m:mrow>
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>R</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msub>
+<m:mstyle fontstyle="italic">
+                      <m:mi>v</m:mi> </m:mstyle>
+                          <m:mn>0</m:mn>
+                    </m:msub>
+                  </m:mrow><m:mspace width="0.25em"/>
+                  <m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+                  <m:mi>&#952;</m:mi>
+                  <m:mrow>
+                    <m:mfenced open="(" close=")">
+                      <m:mfrac>
+
+                        <m:mrow>
+                          <m:msub>
+<m:mrow>
+                            <m:mn>2</m:mn>
+<m:mi>v</m:mi>
+</m:mrow>
+                                <m:mn>0</m:mn>
+                          </m:msub><m:mspace width="0.25em"/>
+                          <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+                          <m:mi>&#952;</m:mi>
+                        </m:mrow>
+                        <m:mi>g</m:mi>
+                      </m:mfrac>
+                    </m:mfenced>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mrow>
+                        <m:msubsup>
+<m:mrow>
+                          <m:mn>2</m:mn> <m:mi>v</m:mi>
+</m:mrow>
+                          <m:mn>0</m:mn>
+                          <m:mn>2</m:mn>
+                 
+                        </m:msubsup><m:mspace width="0.25em"/>
+                        <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+                        <m:mi>&#952;</m:mi><m:mspace width="0.25em"/>
+                        <m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+                        <m:mi>&#952;</m:mi>
+                      </m:mrow>
+                      <m:mi>g</m:mi>
+                    </m:mfrac>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{R=v rSub { size 8{0} } "cos"&#952; left ( {  {2v rSub { size 8{0} } "sin"&#952;}  over  {g} }  right )= {  {2v rSub { size 8{0}   rSup { size 8{2} } } "sin"&#952;"cos"&#952;}  over  {g} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1599732">since <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>2</m:mn><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>sin</m:mtext><m:mspace width="0.25em"/></m:mrow><m:mn>2&#952;</m:mn><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{2"sin"&#952;"cos"&#952;="sin"2&#952;,} {}</m:annotation></m:semantics></m:math> the range is:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3385487"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow>
+<m:msup>
+<m:msub>
+<m:mi>v</m:mi>
+
+
+<m:mn>0</m:mn></m:msub>
+<m:mrow>
+<m:mn>2</m:mn>
+</m:mrow>
+</m:msup><m:mspace width="0.25em"/>
+<m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mn>2&#952;</m:mn></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ {underline  {R= {  {v rSub { size 8{0}   rSup { size 8{2} } } "sin"2&#952;}  over  {g} } }} } {}</m:annotation></m:semantics></m:math>.</para></solution></exercise>
+
+    
+    
+    
+    
+ 
+<exercise id="fs-id1794949" type="problems-exercises"><problem id="fs-id1626931"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1626932"><emphasis>Unreasonable Results</emphasis> (a) Find the maximum range of a super cannon that has a muzzle velocity of 4.0 km/s. (b) What is unreasonable about the range you found? (c) Is the premise unreasonable or is the available equation inapplicable? Explain your answer. (d) If such a muzzle velocity could be obtained, discuss the effects of air resistance, thinning air with altitude, and the curvature of the Earth on the range of the super cannon.
+</para></problem>
+</exercise>
+ <exercise xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1815382" type="problems-exercises"><problem id="fs-id2255165"><para id="fs-id2255166"><emphasis>Construct Your Own Problem</emphasis> Consider a ball tossed over a fence. Construct a problem in which you calculate the ball&#8217;s needed initial velocity to just clear the fence. Among the things to determine are; the height of the fence, the distance to the fence from the point of release of the ball, and the height at which the ball is released. You should also consider whether it is possible to choose the initial speed for the ball and just calculate the angle at which it is thrown. Also examine the possibility of multiple solutions given the distances and heights you have chosen.
+ </para></problem>
+</exercise></section>
+</content>
+    <glossary>
+      <definition id="import-auto-id2275857"><term>air resistance</term> <meaning id="fs-id1668212">a frictional force that slows the motion of objects as they travel through the air; when solving basic physics problems, air resistance is assumed to be zero</meaning></definition>
+      
+<definition id="fs-id1405173"><term>kinematics</term><meaning id="fs-id1949378">the study of motion without regard to mass or force</meaning></definition>
+
+<definition id="fs-id1949381"><term>motion</term><meaning id="fs-id2324535">displacement of an object as a function of time</meaning></definition>
+
+<definition id="import-auto-id1459204"><term>projectile</term> <meaning id="fs-id1798529">an object that travels through the air and experiences only acceleration due to gravity</meaning></definition>
+
+      <definition id="import-auto-id1981500"><term>projectile motion</term> <meaning id="fs-id2253704">the motion of an object that is subject only to the acceleration of gravity</meaning></definition>
+      <definition id="import-auto-id2257218"><term>range</term> <meaning id="fs-id1883200">the maximum horizontal distance that a projectile travels</meaning></definition>
+      <definition id="import-auto-id2852095"><term>trajectory</term> <meaning id="fs-id2222621">the path of a projectile through the air</meaning></definition>
+    </glossary>
+</document>

--- a/cnxml/tests/data/valid-derived-from.cnxml
+++ b/cnxml/tests/data/valid-derived-from.cnxml
@@ -1,0 +1,2011 @@
+<document xmlns="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:m="http://www.w3.org/1998/Math/MathML" id="imported-from-openoffice" module-id="imported-from-openoffice" cnxml-version="0.7">
+  <title>Projectile Motion</title>
+<metadata xmlns:md="http://cnx.rice.edu/mdml" mdml-version="0.5">
+  <!-- WARNING! The 'metadata' section is read only. Do not edit below.
+       Changes to the metadata section in the source will not be saved. -->
+  <md:repository>http://legacy.cnx.org/content</md:repository>
+  <md:content-url>http://legacy.cnx.org/content/m42042/latest/</md:content-url>
+  <md:content-id>m42042</md:content-id>
+  <md:title>Projectile Motion</md:title>
+  <md:version>1.12</md:version>
+  <md:created>2011/12/21 11:28:12 -0600</md:created>
+  <md:revised>2014/10/28 11:35:40.941 GMT-5</md:revised>
+  <md:actors>
+    <md:person userid="cnxcap">
+      <md:firstname>College</md:firstname>
+      <md:surname>Physics</md:surname>
+      <md:fullname>OSC Physics Maintainer</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+    <md:organization userid="OpenStaxCollege">
+      <md:shortname>OpenStax College</md:shortname>
+      <md:fullname>OpenStax College</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:organization>
+    <md:person userid="OSCRiceUniversity">
+      <md:firstname>Rice</md:firstname>
+      <md:surname>University</md:surname>
+      <md:fullname>Rice University</md:fullname>
+      <md:email>daniel@openstaxcollege.org</md:email>
+    </md:person>
+  </md:actors>
+  <md:roles>
+    <md:role type="author">OpenStaxCollege</md:role>
+    <md:role type="maintainer">OpenStaxCollege cnxcap</md:role>
+    <md:role type="licensor">OSCRiceUniversity</md:role>
+  </md:roles>
+  <md:license url="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License 4.0</md:license>
+  <!-- For information on license requirements for use or modification, see license url in the
+       above <md:license> element.
+       For information on formatting required attribution, see the URL:
+         CONTENT_URL/content_info#cnx_cite_header
+       where CONTENT_URL is the value provided above in the <md:content-url> element.
+  -->
+  <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
+  <md:repository>http://legacy-staging.cnx.org/content</md:repository>
+  <md:content-url>http://legacy-staging.cnx.org/content/m48590/1.11</md:content-url>
+  <md:content-id>m48590</md:content-id>
+  <md:title>Introduction</md:title>
+  <md:version>1.11</md:version>
+  <md:created>2014/01/01 13:57:36 -0600</md:created>
+  <md:revised>2015/06/24 10:59:20 -0500</md:revised>
+  <md:actors>
+    <md:person userid="cnxecon">
+      <md:firstname>OpenStax</md:firstname>
+      <md:surname>College</md:surname>
+      <md:fullname>OpenStax Economics</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+    <md:organization userid="OpenStaxCollege">
+      <md:shortname>OpenStax</md:shortname>
+      <md:fullname>OpenStax</md:fullname>
+      <md:email>info@openstax.org</md:email>
+    </md:organization>
+    <md:person userid="OSCRiceUniversity">
+      <md:firstname>Rice</md:firstname>
+      <md:surname>University</md:surname>
+      <md:fullname>Rice University</md:fullname>
+      <md:email>info@openstaxcollege.org</md:email>
+    </md:person>
+  </md:actors>
+  <md:roles>
+    <md:role type="author">OpenStaxCollege</md:role>
+    <md:role type="maintainer">OpenStaxCollege cnxecon</md:role>
+    <md:role type="licensor">OSCRiceUniversity</md:role>
+  </md:roles>
+  <md:license url="http://creativecommons.org/licenses/by/4.0/" />
+  <!-- For information on license requirements for use or modification, see license url in the
+       above <md:license> element.
+       For information on formatting required attribution, see the URL:
+         CONTENT_URL/content_info#cnx_cite_header
+       where CONTENT_URL is the value provided above in the <md:content-url> element.
+  -->
+  <md:language>en</md:language>
+  </md:derived-from>
+  <md:keywordlist>
+    <md:keyword>Air resistance</md:keyword>
+    <md:keyword>Kinematics</md:keyword>
+    <md:keyword>Motion</md:keyword>
+    <md:keyword>Projectile</md:keyword>
+    <md:keyword>Projectile motion</md:keyword>
+    <md:keyword>Range</md:keyword>
+    <md:keyword>Trajectory</md:keyword>
+  </md:keywordlist>
+  <md:subjectlist>
+    <md:subject>Science and Technology</md:subject>
+  </md:subjectlist>
+  <md:abstract><list>
+<item>Identify and explain the properties of a projectile, such as acceleration due to gravity, range, maximum height, and trajectory.</item>
+<item>Determine the location and velocity of a projectile at different points in its trajectory.</item>
+<item>Apply the principle of independence of motion to solve projectile motion problems.</item>
+</list></md:abstract>
+  <md:language>en</md:language>
+  <!-- WARNING! The 'metadata' section is read only. Do not edit above.
+       Changes to the metadata section in the source will not be saved. -->
+</metadata>
+
+<content>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple: 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical, 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math>. Both accelerations are constant, so the kinematic equations can be used.</para><note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1767845"><label/><title>Review of Kinematic Equations (constant <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow></m:mrow></m:mrow></m:semantics></m:math>)</title>
+    
+    <equation id="eip-891"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:msub>
+                            <m:mi>x</m:mi>
+                            
+                              <m:mrow>
+                                <m:mn>0</m:mn>
+                              </m:mrow>
+                            
+                          </m:msub>
+                          <m:mrow>
+                            <m:mi/>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:mover accent="true">
+                            <m:mi>v</m:mi>
+                            <m:mo stretchy="true">-</m:mo>
+                          </m:mover>
+                          <m:mi>t</m:mi>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{x=`x rSub { size 8{0} } `+` { bar  {v}}t} {}</m:annotation>
+                </m:semantics>
+              </m:math> </equation><equation id="eip-557"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mover accent="true">
+                              <m:mi>v</m:mi>
+                              <m:mo stretchy="true">-</m:mo>
+                            </m:mover>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mi/>
+                          </m:mrow>
+                          <m:mfrac>
+                            <m:mrow>
+                              <m:msub>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:mi>v</m:mi>
+                            </m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mfrac>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{ { bar  {v}}=` {  {v rSub { size 8{0} } +v}  over  {2} } } {}</m:annotation>
+                </m:semantics>
+              </m:math> 
+</equation><equation id="eip-405"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mi>v</m:mi>
+                          <m:mo stretchy="false">=</m:mo>
+                          <m:mrow>
+                            <m:msub>
+                              <m:mi>v</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>0</m:mn>
+                                </m:mrow>
+                              
+                            </m:msub>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mstyle fontstyle="italic">
+                              <m:mrow>
+                                <m:mtext>at</m:mtext>
+                              </m:mrow>
+                            </m:mstyle>
+                          </m:mrow>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{v=v rSub { size 8{0} } + ital "at"} {}</m:annotation>
+                </m:semantics>
+              </m:math>
+</equation><equation id="eip-556"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mrow>
+                              <m:msub>
+                                <m:mi>x</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:msub>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msub>
+                            </m:mrow>
+                          </m:mrow>
+                          <m:mrow>
+                            <m:mi>t</m:mi>
+                            <m:mo stretchy="false">+</m:mo>
+                            <m:mfrac>
+                              <m:mn>1</m:mn>
+                              <m:mn>2</m:mn>
+                            </m:mfrac>
+                          </m:mrow>
+                            <m:mrow>
+                              <m:msup>
+                                <m:mtext fontstyle="italic">at</m:mtext>
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+</m:msup>
+                            </m:mrow>
+                        
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{0} } t+ {  {1}  over  {2} }  ital "at" rSup { size 8{2} } } {}</m:annotation>
+                </m:semantics>
+              </m:math> </equation><equation id="eip-389"><m:math display="block">
+                <m:semantics>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+                            <m:msup>
+                              <m:mi>v</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>2</m:mn>
+                                </m:mrow>
+                              
+                            </m:msup>
+                            <m:mo stretchy="false">=</m:mo>
+                            <m:mrow>
+                              <m:msubsup>
+                                <m:mi>v</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>0</m:mn>
+                                  </m:mrow>
+                                
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msubsup>
+                              <m:mo stretchy="false">+</m:mo>
+                              <m:mn>2</m:mn><m:mi>a</m:mi>
+                            </m:mrow>
+                          </m:mrow>
+                          <m:mo stretchy="false">(</m:mo>
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:msub>
+                              <m:mi>x</m:mi>
+                              
+                                <m:mrow>
+                                  <m:mn>0</m:mn>
+                                </m:mrow>
+                              
+                            </m:msub>
+                          </m:mrow>
+                          <m:mo stretchy="false">)</m:mo>
+                        </m:mrow>
+                      </m:mrow>
+                    <m:mtext>.</m:mtext>
+                    <m:mrow/>
+                  </m:mrow>
+                  <m:annotation encoding="StarMath 5.0"> size 12{v rSup { size 8{2} } =v rSub { size 8{0} }  rSup { size 8{2} } +2a \( x - x rSub { size 8{0} }  \) } {}</m:annotation>
+                </m:semantics>
+              </m:math> 
+</equation></note><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2242290"><media id="import-auto-id1402609" alt="A soccer player is kicking a soccer ball. The ball travels in a projectile motion and reaches a point whose vertical distance is y and horizontal distance is x. The displacement between the kicking point and the final point is s. The angle made by this displacement vector with x axis is theta.">
+        <image mime-type="image/jpg" src="Figure_03_04_01.jpg" width="350"/>
+      </media>
+      
+    <caption>The total displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> of a soccer ball at a point along its path. The vector <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> has components <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> along the horizontal and vertical axes. Its magnitude is <m:math><m:semantics><m:mrow><m:mrow><m:mi>s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math>, and it makes an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> with the horizontal.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-36">Given these assumptions, the following steps are then used to analyze projectile motion:</para>
+
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction, as shown in <link target-id="import-auto-id1815222"/>. Initial values are denoted with a subscript 0, as usual.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-205"><emphasis effect="italics"><emphasis>Step 2.</emphasis></emphasis>  <emphasis effect="italics">Treat the motion as two independent one-dimensional motions, one horizontal and the other vertical.</emphasis> The kinematic equations for horizontal and vertical motion take the following forms:
+</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-338"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Horizontal Motion</m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>a</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mn>0</m:mn>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal Motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-362"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>x</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-627"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math>
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-293"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Vertical Motion</m:mtext>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mtext>assuming positive is up</m:mtext>
+<m:mspace width="0.25em"/>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:mrow>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>a</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">=</m:mo>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mi>g</m:mi>
+                      </m:mrow>
+                    </m:mrow>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mn>9.</m:mn>
+                      </m:mrow>
+                     
+                      <m:mtext>80</m:mtext>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false"> </m:mo>
+                  <m:msup>
+                    <m:mtext>m/s</m:mtext>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Vertical Motion " \( "assuming positive is up "a rSub { size 8{y} } = - g= - 9/"80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-131"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:mfrac>
+                        <m:mn>1</m:mn>
+                        <m:mn>2</m:mn>
+                      </m:mfrac>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-305"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:msub>
+                    <m:mi>v</m:mi>
+                    
+                      <m:mrow>
+                        <m:mi>y</m:mi>
+                      </m:mrow>
+                    
+                  </m:msub>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mstyle fontstyle="italic">
+                      <m:mrow>
+                        <m:mtext>gt</m:mtext>
+                      </m:mrow>
+                    </m:mstyle>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-542"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi fontstyle="italic">gt</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+         
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-243"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-708"><emphasis effect="italics"><emphasis>Step 3.</emphasis></emphasis>  <emphasis effect="italics"> Solve for the unknowns in the two separate motions&#8212;one horizontal and one vertical.</emphasis> Note that the only common variable between the motions is time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>. The problem solving procedures here are the same as for one-dimensional <term>kinematics</term> and are illustrated in the solved examples below.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-979"><emphasis effect="italics"><emphasis>Step 4.</emphasis></emphasis>  <emphasis effect="italics">Recombine the two motions to find the total displacement</emphasis> <m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">s</m:mtext></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math><emphasis effect="italics"> and velocity </emphasis><m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">v</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>. Because the <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are perpendicular, we determine these vectors by using the techniques outlined in the <link document="m42128">Vector Addition and Subtraction: Analytical Methods</link> and employing <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>A</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>A</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>A</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+        and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( A rSub { size 8{y} } /A rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math> in the following form, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is the direction of the displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is the direction of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>:
+</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-245"><emphasis>Total displacement and velocity</emphasis></para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-743"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>s</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msup>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-373"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>&#952;</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:mi>x</m:mi>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-679"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>v</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+</equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-264"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1815222"><media id="import-auto-id2275311" alt="In part a the figure shows projectile motion of a ball with initial velocity of v zero at an angle of theta zero with the horizontal x axis. The horizontal component v x and the vertical component v y at various positions of ball in the projectile path is shown. In part b only the horizontal velocity component v sub x is shown whose magnitude is constant at various positions in the path. In part c only vertical velocity component v sub y is shown. The vertical velocity component v sub y is upwards till it reaches the maximum point and then its direction changes to downwards. In part d resultant v of horizontal velocity component v sub x and downward vertical velocity component v sub y is found which makes an angle theta with the horizontal x axis. The direction of resultant velocity v is towards south east.">
+          <image mime-type="image/jpg" src="Figure_03_04_02.jpg" height="600"/>
+        </media>
+        
+  <caption>(a) We analyze two-dimensional projectile motion by breaking it into two independent one-dimensional motions along the vertical and horizontal axes. (b) The horizontal motion is simple, because <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is thus constant. (c) The velocity in the vertical direction begins to decrease as the object rises; at its highest point, the vertical velocity is zero. As the object falls towards the Earth again, the vertical velocity increases again in magnitude but points in the opposite direction to the initial vertical velocity. (d) The <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are recombined to give the total velocity at any given point on the trajectory.</caption></figure><example id="fs-id2175010">
+    <title>A Fireworks Projectile Explodes High and Away</title>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and  
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero and solve for the desired quantities.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-774"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1669571">By &#8220;height&#8221; we mean the altitude or vertical position <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> above the starting point. The highest point in any trajectory, called the apex, is reached when <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ v rSub { size 8{y} } =0} {}</m:annotation></m:semantics></m:math>. Since we know the initial and final velocities as well as the initial position, we use the following equation to find <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>:
+
+</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-734"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id934168"><media id="import-auto-id1576299" alt="The x y graph shows the trajectory of fireworks shell. The initial velocity of the shell v zero is at angle theta zero equal to seventy five degrees with the horizontal x axis. The fuse is set to explode the shell at the highest point of the trajectory which is at a height h equal to two hundred thirty three meters and at a horizontal distance x equal to one hundred twenty five meters from the origin.">
+        <image mime-type="image/jpg" src="Figure_03_04_03a.jpg" height="250"/>
+      </media>
+      
+    <caption>The trajectory of a fireworks shell. The fuse is set to explode the shell at the highest point in its trajectory, which is found to be at a height of 233 m and 125 m away horizontally.</caption></figure><para id="import-auto-id1163607">Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> are both zero, the equation simplifies to</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-42"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mn>0</m:mn><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn></m:mrow></m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gy.</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{0=v rSub { size 8{0y} }  rSup { size 8{2} }  - 2 ital "gy."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2114969">Solving for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> gives</para>
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-256"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                         
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                     <m:mrow> <m:mn>2</m:mn><m:mi>g</m:mi></m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>75.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-677"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70.0 m/s</m:mtext><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>sin 75&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>67.6 m/s.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } = \( "70" "." 0" m/s" \)  \( "sin""75" { size 12{ circ } }  \) ="67" "." 6" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2271493">and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-512"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>y</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mfrac>
+                    <m:mrow>
+                      <m:mo stretchy="false">(</m:mo>
+                      <m:mtext>67</m:mtext>
+                      <m:mtext>.6 m/s</m:mtext>
+                      <m:msup>
+                        <m:mo stretchy="false">)</m:mo>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                    <m:mrow>
+                      <m:mn>2</m:mn>
+                      <m:mo stretchy="false">(</m:mo>
+                      <m:mn>9</m:mn>
+                      <m:mtext>.</m:mtext>
+                      <m:mtext>80 m</m:mtext>
+                      <m:msup>
+                        <m:mtext>/s</m:mtext>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">)</m:mo>
+                    </m:mrow>
+                  </m:mfrac>
+                </m:mrow>
+
+              </m:mrow>
+            <m:mo>,</m:mo>
+                   </m:mrow>
+
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  { \( "67" "." 6" m/s" \)  rSup { size 8{2} } }  over  {2 \( 9 "." "80"" m/s" rSup { size 8{2} }  \) } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1919502">so that</para>
+    
+    <equation id="eip-310"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>233</m:mtext></m:mrow><m:mo stretchy="false"> </m:mo><m:mtext> m.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y="233"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-429"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2165781">Note that because up is positive, the initial velocity is positive, as is the maximum height, but the acceleration due to gravity is negative. Note also that the maximum height depends only on the vertical component of the initial velocity, so that any projectile with a 67.6 m/s initial vertical component of velocity will reach a maximum height of 233 m (neglecting air resistance). The numbers in this example are reasonable for large fireworks displays, the shells of which do reach such heights before exploding. In practice, air resistance is not completely negligible, and so the initial velocity would have to be somewhat larger than that given to reach the same height.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-449"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1632028">As in many physics problems, there is more than one way to solve for the time to the highest point. In this case, the easiest method is to use <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation></m:semantics></m:math>. Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is zero, this equation reduces to simply</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-383"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            <m:mtext>.</m:mtext>
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1383088">Note that the final vertical velocity, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>, at the highest point is zero. Thus,</para>
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-50"><m:math>
+        <m:semantics>
+          <m:mrow>
+            <m:mrow>
+              <m:mtable columnalign="left">
+                <m:mtr><m:mtd>                            <m:mi>t</m:mi></m:mtd>
+<m:mtd>                            <m:mo stretchy="false">=</m:mo></m:mtd>
+<m:mtd>
+                  <m:mrow>
+                    
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mrow>
+
+
+                            <m:mfrac>
+<m:mrow>
+                              <m:mn>2</m:mn>
+<m:mi>y</m:mi>
+
+</m:mrow>                                 
+                              <m:mrow>
+                                <m:mo stretchy="false">(</m:mo>
+                                <m:mrow>
+                                  <m:msub>
+                                    <m:mi>v</m:mi>
+                                    
+                                      <m:mrow>
+                                        <m:mn>0y</m:mn>
+                                      </m:mrow>
+                                    
+                                  </m:msub>
+                                  <m:mo stretchy="false">+</m:mo>
+                                  <m:msub>
+                                    <m:mi>v</m:mi>
+                                    
+                                      <m:mrow>
+                                        <m:mi>y</m:mi>
+                                      </m:mrow>
+                                    
+                                  </m:msub>
+                                </m:mrow>
+                                <m:mo stretchy="false">)</m:mo>
+                              </m:mrow>
+                            </m:mfrac>
+                          </m:mrow>
+                          <m:mo stretchy="false">=</m:mo>
+                          <m:mfrac>
+                            <m:mrow>
+                              <m:mrow>
+                                <m:mn>2</m:mn>
+                                <m:mo stretchy="false">(</m:mo>
+                                <m:mtext>233 m</m:mtext>
+                              </m:mrow>
+                               <m:mo stretchy="false">)</m:mo>
+                            </m:mrow>
+                            <m:mrow>
+                              <m:mo stretchy="false">(</m:mo>
+                              <m:mtext>67.6 m/s</m:mtext>
+                             
+                              <m:mo stretchy="false">)</m:mo>
+                            </m:mrow>
+                          </m:mfrac>
+                        </m:mrow>
+                      </m:mrow>
+                    
+                    <m:mrow/>
+                  </m:mrow></m:mtd>
+                </m:mtr>
+                <m:mtr><m:mtd/>
+<m:mtd><m:mo>=</m:mo></m:mtd>
+<m:mtd>
+                  <m:mrow>
+                   
+                    <m:mtext>6.90 s</m:mtext><m:mtext>.</m:mtext>
+                 
+                  </m:mrow></m:mtd>
+                </m:mtr>
+              </m:mtable>
+              <m:mrow/>
+            </m:mrow>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0">alignl { stack {
+ size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} # 
+=6 "." "90"" s" {} 
+} } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-31"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1848626">This time is also reasonable for large fireworks. When you are able to see the launch of fireworks, you will notice several seconds pass before the shell explodes. (Another way of finding the time is by using <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>, and solving the quadratic equation for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-939"><emphasis>Solution for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2262600">Because air resistance is negligible, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and the horizontal velocity is constant, as discussed above. The horizontal displacement is horizontal velocity multiplied by time as given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is equal to zero:</para><equation id="eip-675"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{x} } t ","} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1871833">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-component of the velocity, which is given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} }  "." } {}</m:annotation></m:semantics></m:math> Now,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-884"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 75.0&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>18</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>1 m/s.</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 12{0} } = \( "70" "." 0" m/s" \)  \( "cos""75.0&#186;"  \) ="18" "." 1" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2046887">The time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> for both motions is the same, and so <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-685"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mn>1 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mtext>90 s</m:mtext><m:mtext/><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>125 m.</m:mtext></m:mrow><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x= \( "18" "." 1" m/s" \)  \( 6 "." "90"" s" \) ="125"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-247"><emphasis>Discussion for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1857186">The horizontal motion is a constant velocity in the absence of air resistance. The horizontal displacement found here could be useful in keeping the fireworks fragments from falling on spectators. Once the shell explodes, air resistance has a major effect, and many fragments will land directly below.</para></example>
+    <para id="import-auto-id1986266">In solving part (a) of the preceding example, the expression we found for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is valid for any projectile motion where air resistance is negligible. Call the maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mi>h</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=h} {}</m:annotation></m:semantics></m:math>; then,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-803"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>h</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+<m:mrow>
+                      <m:mn>2</m:mn>
+<m:mi>g</m:mi>
+</m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1973673">This equation defines the <emphasis effect="italics"><emphasis effect="italics">maximum height of a projectile</emphasis></emphasis> and depends only on the vertical component of the initial velocity.</para>
+    <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1479427"><label/><title>Defining a Coordinate System</title>
+    
+    <para id="import-auto-id2275341">It is important to set up a coordinate system when analyzing projectile motion. One part of defining the coordinate system is to define an origin for the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions. Often, it is convenient to choose the initial position of the object as the origin such that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math>. It is also important to define the positive and negative directions in the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> directions. Typically, we define the positive vertical direction as upwards, and the positive horizontal direction is usually the direction of the object&#8217;s motion. When this is the case, the vertical acceleration, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>, takes a negative value (since it is directed downwards towards the Earth). However, it is occasionally useful to define the coordinates differently. For example, if you are analyzing the motion of a ball thrown downwards from the top of a cliff, it may make sense to define the positive direction downwards since the motion of the ball is solely in the downwards direction. If this is the case, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math> takes a positive value.</para>
+    </note><example id="fs-id708626">
+    <title>Calculating Projectile Motion: Hot Rock Projectile</title>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1916950">Kilauea in Hawaii is the world&#8217;s most continuously active volcano. Very active volcanoes characteristically eject red-hot rocks and lava rather than smoke and ash. Suppose a large rock is ejected from the volcano with a speed of 25.0 m/s and at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"35"&#176;} {}</m:annotation></m:semantics></m:math> above the horizontal, as shown in <link target-id="import-auto-id1817519"/>. The rock strikes the side of the volcano at an altitude 20.0 m lower than its starting point. (a) Calculate the time it takes the rock to follow this path. (b) What are the magnitude and direction of the rock&#8217;s velocity at impact?</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1817519"><media id="import-auto-id1817520" alt="The trajectory of a rock ejected from a volcano is shown. The initial velocity of rock v zero is equal to twenty five meters per second and it makes an angle of thirty five degrees with the horizontal x axis. The figure shows rock falling down a height of twenty meters below the volcano level. The velocity at this point is v which makes an angle of theta with horizontal x axis. The direction of v is south east.">
+        <image mime-type="image/jpg" src="Figure_03_04_04a.jpg" width="400"/>
+      </media>
+      
+    <caption>The trajectory of a rock ejected from the Kilauea volcano.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-770"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1823692">Again, resolving this two-dimensional motion into two independent one-dimensional motions will allow us to solve for the desired quantities. The time a projectile is in the air is governed by its vertical motion alone. We will solve for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> first. While the rock is rising and falling vertically, the horizontal motion continues at a constant velocity. This example asks for the final velocity. Thus, the vertical and horizontal results will be recombined to obtain <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> at the final time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> determined in the first part of the example.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-408"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1608071">While the rock is in the air, it rises and then falls to a final position 20.0 m lower than its starting altitude. We can find the time for this by using</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-895"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
+<m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1843834">If we take the initial position <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero, then the final position is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow></m:mrow><m:mtext>.0  m</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= - "20" "." 0" m" "." } {}</m:annotation></m:semantics></m:math> Now the initial vertical velocity is the vertical component of the initial velocity, found from  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> = (<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25" "." "0&#160;m/s"} {}</m:annotation></m:semantics></m:math>)(<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>sin 35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"sin 35"&#176;} {}</m:annotation></m:semantics></m:math>) = <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Substituting known values yields</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-722"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>0 m</m:mn><m:mrow><m:mtext/><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mn>3 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced></m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
+<m:mtext>.</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ - "20" "." 0" m"= \( "14" "." 3" m/s" \) t -  left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1561988">Rearranging terms gives a quadratic equation in <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form 
+<m:math>
+<m:semantics>
+<m:mrow><m:mrow><m:mrow><m:mrow><m:mrow>
+<m:msup>
+<m:mstyle fontstyle="italic">
+<m:mi>at</m:mi></m:mstyle><m:mn>2</m:mn>
+</m:msup>
+<m:mo stretchy="false">+</m:mo>
+
+<m:mstyle fontstyle="italic"><m:mi>bt</m:mi></m:mstyle>
+<m:mo stretchy="false">+</m:mo>
+<m:mi>c</m:mi>
+<m:mo stretchy="false">=</m:mo>
+<m:mn>0</m:mn>
+</m:mrow></m:mrow></m:mrow></m:mrow></m:mrow>
+<m:annotation encoding="StarMath 5.0"> size 12{ ital "at" rSup { size 8{2} } + ital "bt"+c=0} {}</m:annotation>
+</m:semantics>
+</m:math>, where the constants are 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>a</m:mi><m:mo>=</m:mo><m:mn>4.90</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math>, 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>b</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>14.3</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math>, and 
+
+<m:math><m:semantics>
+<m:mrow><m:mrow>
+<m:mi>c</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>20.0.</m:mn>
+</m:mrow></m:mrow></m:semantics></m:math> Its solutions are given by the quadratic formula:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-880"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mrow>
+                        <m:mrow>
+                          <m:mo stretchy="false">&#8722;</m:mo>
+                          <m:mi>b</m:mi>
+                        </m:mrow>
+                        <m:mo stretchy="false">&#177;</m:mo>
+                        <m:msqrt>
+                          <m:mrow>
+                            <m:mrow>
+                              <m:msup>
+                                <m:mi>b</m:mi>
+                                
+                                  <m:mrow>
+                                    <m:mn>2</m:mn>
+                                  </m:mrow>
+                                
+                              </m:msup>
+                              <m:mo stretchy="false">&#8722;</m:mo>
+                              <m:mn>4</m:mn>
+                            </m:mrow>
+                            <m:mstyle fontstyle="italic">
+                              <m:mrow>
+                                <m:mtext>ac</m:mtext>
+                              </m:mrow>
+                            </m:mstyle>
+                          </m:mrow>
+                        </m:msqrt>
+                      </m:mrow>
+                      <m:mrow><m:mtext>2</m:mtext><m:mtext fontstyle="italic">a</m:mtext></m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{t= {  { - b +-  sqrt {b rSup { size 8{2} }  - 4 ital "ac"} }  over  {"2a"} }  "." } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions: 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and 
+
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{-1 "." "03""s"} {}</m:annotation></m:semantics></m:math>. The negative value of time implies an event before the start of motion, and so we discard it. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-267"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>96 s</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"" s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-46"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1368589">The time for projectile motion is completely determined by the vertical motion. So any projectile that has an initial vertical velocity of 14.3 m/s and lands 20.0 m below its starting altitude will spend 3.96 s in the air.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-653"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1599448">From the information now in hand, we can find the final horizontal and vertical velocities <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> and combine them to find the total velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and the angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> it makes with the horizontal. Of course, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is constant so we can solve for it at any horizontal location. In this case, we chose the starting point since we know both the initial velocity and initial angle. Therefore:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-873"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 35&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} } = \( "25" "." 0" m/s" \)  \( "cos""35" rSup { size 8{ circ } }  \) ="20" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2252925">The final vertical velocity is given by the following equation:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-168"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">&#8722;</m:mo><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gt,</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt,"} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2173689">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0y</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> was found in part (a) to be <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Thus,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-113"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mtext>14</m:mtext>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                  <m:mn>3 m/s</m:mn>
+                  <m:mrow>
+                    <m:mtext/>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mo stretchy="false">(</m:mo>
+                  </m:mrow>
+                  <m:mn>9</m:mn>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>80 m/s</m:mtext>
+                  <m:msup>
+                    <m:mtext/>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mn>3</m:mn>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>96 s</m:mtext>
+                  <m:mtext/>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } ="14" "." 3" m/s" -  \( 9 "." "80"" m/s" rSup { size 8{2} }  \)  \( 3 "." "96"" s" \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1792451">so that</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-571"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } = - "24" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2239982">To find the magnitude of the final velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> we combine its perpendicular components, using the following equation:</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-394"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">+</m:mo><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup></m:mrow></m:msqrt></m:mrow><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:mo stretchy="false">(</m:mo><m:mtext>20</m:mtext><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:mrow><m:mrow><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">+</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:msqrt><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } = sqrt { \( "20" "." 5" m/s" \)  rSup { size 8{2} } + \(  - "24" "." 5" m/s" \)  rSup { size 8{2} } } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1677955">which gives</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-60"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>31</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>9 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v="31" "." 9" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1645980">The direction <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is found from the equation:</para>
+    
+    <equation id="eip-353"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>&#952;</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>v</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><para id="import-auto-id1972156">so that</para>
+    
+    <equation id="eip-589"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mrow><m:mn>5</m:mn><m:mo stretchy="false">/</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5</m:mn><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>19</m:mtext><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \(  - "24" "." 5/"20" "." 5 \) ="tan" rSup { size 8{ - 1} }  \(  - 1 "." "19" \) "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1613163">Thus,</para>
+    
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-379"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>50</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>1</m:mn><m:mrow><m:mo stretchy="false">&#186;</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } = - "50" "." 1 rSup { size 12{ circ } "."} } {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-299"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1459619">The negative angle means that the velocity is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>50</m:mtext><m:mtext>.</m:mtext><m:mn>1&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50" "." 1&#176;} {}</m:annotation></m:semantics></m:math> below the horizontal. This result is consistent with the fact that the final vertical velocity is negative and hence downward&#8212;as you would expect because the final altitude is 20.0 m lower than the initial altitude. (See <link target-id="import-auto-id1817519"/>.)</para></example>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1532818">One of the most important things illustrated by projectile motion is that vertical and horizontal motions are independent of each other. Galileo was the first person to fully comprehend this characteristic. He used it to predict the range of a projectile. On level ground, we define <term id="import-auto-id1751163">range</term> to be the horizontal distance <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> traveled by a projectile. Galileo and many others were interested in the range of projectiles primarily for military purposes&#8212;such as aiming cannons. However, investigating the range of projectiles can shed light on other interesting phenomena, such as the orbits of satellites around the Earth. Let us consider projectile range further.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1904800"><media id="import-auto-id1904802" alt="Part a of the figure shows three different trajectories of projectiles on level ground. In each case the projectiles makes an angle of forty five degrees with the horizontal axis. The first projectile of initial velocity thirty meters per second travels a horizontal distance of R equal to ninety one point eight meters. The second projectile of initial velocity forty meters per second travels a horizontal distance of R equal to one hundred sixty three meters. The third projectile of initial velocity fifty meters per second travels a horizontal distance of R equal to two hundred fifty five meters.">
+          <image mime-type="image/jpg" src="Figure_03_04_05a.jpg" height="300"/>
+        </media>
+        
+<caption>Trajectories of projectiles on level ground. (a) The greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range for a given initial angle. (b) The effect of initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> on the range of a projectile with a given initial speed. Note that the range is the same for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>15&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"15"&#176;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mtext>75&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"75&#176;"} {}</m:annotation></m:semantics></m:math>, although the maximum heights of those paths are different.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1750749">How does the initial velocity of a projectile affect its range? Obviously, the greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range, as shown in <link target-id="import-auto-id1904800"/>(a). The initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> also has a dramatic effect on the range, as illustrated in <link target-id="import-auto-id1904800"/>(b). For a fixed initial speed, such as might be produced by a cannon, the maximum range is obtained with <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } &#160;=&#160;"45&#186;"} {}</m:annotation></m:semantics></m:math>. This is true only for conditions neglecting air resistance. If air resistance is considered, the maximum angle is approximately <m:math><m:semantics><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38&#186;"} {}</m:annotation></m:semantics></m:math>. Interestingly, for every initial angle except <m:math><m:semantics><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45&#186;"} {}</m:annotation></m:semantics></m:math>, there are two angles that give the same range&#8212;the sum of those angles is <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#186;"} {}</m:annotation></m:semantics></m:math>. The range also depends on the value of the acceleration of gravity <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. The lunar astronaut Alan Shepherd was able to drive a golf ball a great distance on the Moon because gravity is weaker there. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on <emphasis effect="italics"><emphasis effect="italics">level ground</emphasis></emphasis> for which air resistance is negligible is given by </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-240"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mtext>,</m:mtext><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1674836">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial speed and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle relative to the horizontal. The proof of this equation is left as an end-of-chapter problem (hints are given), but it does fit the major features of projectile range as described.</para>
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1686986">When we speak of the range of a projectile on level ground, we assume that <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> is very small compared with the circumference of the Earth. If, however, the range is large, the Earth curves away below the projectile and acceleration of gravity changes direction along the path. The range is larger than predicted by the range equation given above because the projectile has farther to fall than it would on level ground. (See <link target-id="import-auto-id1645881"/>.) If the initial speed is great enough, the projectile goes into orbit.  This possibility was recognized centuries before it could be accomplished. When an object is in orbit, the Earth curves away from underneath the object at the same rate as it falls. The object thus falls continuously but never hits the surface. These and other aspects of orbital motion, such as the rotation of the Earth, will be covered analytically and in greater depth later in this text.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645878">Once again we see that thinking about one topic, such as the range of a projectile, can lead us to others, such as the Earth orbits. In  <link document="m42045">Addition of Velocities</link>, we will examine the addition of velocities, which is another important aspect of two-dimensional kinematics and will also yield insights beyond the immediate topic.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645881"><media id="import-auto-id1825851" alt="A figure of the Earth is shown and on top of it a very high tower is placed. A projectile satellite is launched from this very high tower with initial velocity of v zero in the horizontal direction. Several trajectories are shown with increasing range. A circular trajectory is shown indicating the satellite achieved its orbit and it is revolving around the Earth.">
+        <image mime-type="image/jpg" src="Figure_03_04_06a.jpg" width="200"/>
+      </media>
+      
+    <caption>Projectile to satellite. In each case shown here, a projectile is launched from a very high tower to avoid air resistance. With increasing initial speed, the range increases and becomes longer than it would be on level ground because the Earth curves away underneath its path. With a large enough initial speed, orbit is achieved.</caption></figure>
+<note xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-89"><label/><title>PhET Explorations: Projectile Motion</title>
+
+<para id="eip-id1169738107387">Blast a Buick out of a cannon! Learn about projectile motion by firing various objects. Set the angle, initial speed, and mass. Add air resistance. Make a game out of this simulation by trying to hit a target.</para>
+
+ <figure id="eip-id1462984"><media id="Phet_module_3.4" alt="">
+
+  <image mime-type="image/png" for="online" src="projectile-motion_en.jar" thumbnail="PhET_Icon.png" width="450"/>
+  <image mime-type="image/png" for="pdf" src="PhET_Icon.png" width="450"/>
+   
+</media>
+
+      <caption><link url="projectile-motion_en.jar">Projectile Motion</link></caption></figure></note><section id="fs-id1843457" class="section-summary">
+<title>Summary</title><list xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2130996"><item id="import-auto-id1677012">Projectile motion is the motion of an object through the air that is subject only to the acceleration of gravity.</item>
+    <item id="import-auto-id1786765">To solve projectile motion problems, perform the following steps:
+      <list id="fs-id1842700" list-type="enumerated" number-style="arabic" class="stepwise"><item id="import-auto-id1830314">Determine a coordinate system. Then, resolve the position and/or velocity of the object in the horizontal and vertical components. The components of position <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> are given by the quantities <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>, and the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction.</item>
+      <item id="import-auto-id1830316">Analyze the motion of the projectile in the horizontal direction using the following equations:
+    <equation id="eip-898"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Horizontal motion </m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>a</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>x</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mn>0</m:mn>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
+        </m:semantics>
+      </m:math></equation>
+    <equation id="eip-236"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>x</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
+        </m:semantics>
+      </m:math> </equation>
+    <equation id="eip-612"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo>
+
+<m:msub>
+<m:mtext mathvariant="bold">v</m:mtext>
+<m:mrow>
+<m:mtext>x</m:mtext>
+</m:mrow>
+</m:msub>
+
+
+</m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math></equation></item>
+        <item id="import-auto-id1939082">Analyze the motion of the projectile in the vertical direction using the following equations:
+    <equation id="import-auto-id1939084"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mtext>Vertical motion </m:mtext>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mtext>Assuming positive direction is up; </m:mtext><m:mspace width="0.25em"/>
+                  <m:mrow>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>a</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">=</m:mo>
+                      <m:mrow>
+                        <m:mo stretchy="false">&#8722;</m:mo>
+                        <m:mi>g</m:mi>
+                      </m:mrow>
+                    </m:mrow>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:mo stretchy="false">&#8722;</m:mo>
+                      <m:mn>9</m:mn>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mtext>.</m:mtext>
+                  <m:mtext>80 m</m:mtext>
+                  <m:msup>
+                    <m:mtext>/s</m:mtext>
+                    
+                      <m:mrow>
+                        <m:mn>2</m:mn>
+                      </m:mrow>
+                    
+                  </m:msup>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{"Vertical motion " \( "Assuming positive direction is up; "a rSub { size 8{y} } = - g= - 9 "." "80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><equation id="import-auto-id1492830"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:mfrac>
+                        <m:mn>1</m:mn>
+                        <m:mn>2</m:mn>
+                      </m:mfrac>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn><m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">+</m:mo>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                  <m:mi>t</m:mi>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation><equation id="import-auto-id2022844"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:msub>
+                    <m:mi>v</m:mi>
+                    
+                      <m:mrow>
+                        <m:mi>y</m:mi>
+                      </m:mrow>
+                    
+                  </m:msub>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:mrow>
+                    <m:msub>
+                      <m:mi>v</m:mi>
+                      
+                        <m:mrow>
+                          <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                        </m:mrow>
+                      
+                    </m:msub>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mstyle fontstyle="italic">
+                      <m:mrow>
+                        <m:mtext>gt</m:mtext>
+                      </m:mrow>
+                    </m:mstyle>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id1677876"><m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mrow>
+                      <m:msub>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+                          </m:mrow>
+                        
+                      </m:msub>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msub>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>0</m:mn>
+<m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                      </m:msub>
+                    </m:mrow>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mi>t</m:mi>
+                    <m:mo stretchy="false">&#8722;</m:mo>
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mn>2</m:mn>
+                    </m:mfrac>
+                  </m:mrow>
+                  
+                    <m:mrow>
+                      <m:msup>
+                        <m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+<equation id="import-auto-id1653540"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mo>.</m:mo><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) } {}</m:annotation></m:semantics></m:math></equation>
+        </item>
+        <item id="import-auto-id1552181">Recombine the horizontal and vertical components of location and/or velocity using the following equations:
+    <equation id="import-auto-id2092332">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>s</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msup>
+                        <m:mi>x</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msup>
+                        <m:mi>y</m:mi>
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id2282348">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>&#952;</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msup>
+                      <m:mtext>tan</m:mtext>
+                      
+                        <m:mrow>
+                          <m:mrow>
+                            <m:mo stretchy="false">&#8722;</m:mo>
+                            <m:mn>1</m:mn>
+                          </m:mrow>
+                        </m:mrow>
+                      
+                    </m:msup>
+                  </m:mrow>
+                  <m:mo stretchy="false">(</m:mo>
+                  <m:mrow>
+                    <m:mi>y</m:mi>
+                    <m:mo stretchy="false">/</m:mo>
+                    <m:mi>x</m:mi>
+                  </m:mrow>
+                  <m:mo stretchy="false">)</m:mo>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id2274748">
+      <m:math>
+        <m:semantics>
+          <m:mrow>
+            
+              <m:mrow>
+                <m:mrow>
+                  <m:mi>v</m:mi>
+                  <m:mo stretchy="false">=</m:mo>
+                  <m:msqrt>
+                    <m:mrow>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>x</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                      <m:mo stretchy="false">+</m:mo>
+                      <m:msubsup>
+                        <m:mi>v</m:mi>
+                        
+                          <m:mrow>
+                            <m:mi>y</m:mi>
+                          </m:mrow>
+                        
+                        
+                          <m:mrow>
+                            <m:mn>2</m:mn>
+                          </m:mrow>
+                        
+                      </m:msubsup>
+                    </m:mrow>
+                  </m:msqrt>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </equation>
+    <equation id="import-auto-id1979208"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mtext>v</m:mtext></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math></equation></item></list></item>
+  <item id="import-auto-id1888635">The maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mi>h</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h} {}</m:annotation></m:semantics></m:math> of a projectile launched with initial vertical velocity <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> is given by
+  <equation id="import-auto-id1534227"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>h</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mrow><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} } } {}</m:annotation></m:semantics></m:math></equation></item>
+    <item id="import-auto-id1823593">The maximum horizontal distance traveled by a projectile is called the <emphasis>range</emphasis>. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on level ground launched at an angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> above the horizontal with initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is given by
+  <equation id="import-auto-id1951750"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } } {}</m:annotation></m:semantics></m:math></equation></item>
+</list></section>
+    <section id="fs-id2865659" type="conceptual-questions" class="conceptual-questions"><title>Conceptual Questions</title><exercise id="fs-id2183300" type="conceptual-questions">
+        <problem id="fs-id2183302"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2298558">Answer the following questions for projectile motion on level ground assuming negligible air resistance (the initial angle being neither <m:math><m:semantics><m:mrow><m:mrow><m:mtext>0&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"0&#176;"} {}</m:annotation></m:semantics></m:math> nor <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#176;"} {}</m:annotation></m:semantics></m:math>): (a) Is the velocity ever zero? (b) When is the velocity a minimum? A maximum? (c) Can the velocity ever be the same as the initial velocity at a time other than at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=0} {}</m:annotation></m:semantics></m:math>? (d) Can the speed ever be the same as the initial speed at a time other than at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=0} {}</m:annotation></m:semantics></m:math>?
+        </para></problem>
+      </exercise>
+      <exercise id="fs-id1638420" type="conceptual-questions">
+        <problem id="fs-id1638423"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1638424">Answer the following questions for projectile motion on level ground assuming negligible air resistance (the initial angle being neither <m:math><m:semantics><m:mrow><m:mrow><m:mtext>0&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"0&#176;"} {}</m:annotation></m:semantics></m:math> nor <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#176;"} {}</m:annotation></m:semantics></m:math>): (a) Is the acceleration ever zero? (b) Is the acceleration ever in the same direction as a component of velocity? (c) Is the acceleration ever opposite in direction to a component of velocity?
+        </para></problem>
+      </exercise>
+      <exercise id="fs-id2062475" type="conceptual-questions">
+        <problem id="fs-id2062477"><para id="fs-id2062478">For a fixed initial speed, the range of a projectile is determined by the angle at which it is fired. For all but the maximum, there are two angles that give the same range. Considering factors that might affect the ability of an archer to hit a target, such as wind, explain why the smaller angle (closer to the horizontal) is preferable. When would it be necessary for the archer to use the larger angle? Why does the punter in a football game use the higher trajectory?</para></problem></exercise>
+      <exercise id="fs-id1875651" type="conceptual-questions"><problem id="fs-id1875652"><para id="fs-id1875653">During a lecture demonstration, a professor places two coins on the edge of a table. She then flicks one of the coins horizontally off the table, simultaneously nudging the other over the edge. Describe the subsequent motion of the two coins, in particular discussing whether they hit the floor at the same time.
+        </para></problem>
+        </exercise>
+    </section>
+   <section id="fs-id1875655" type="problems-exercises" class="problems-exercises"><title>Problems &amp; Exercises</title><exercise id="fs-id1923898" type="problems-exercises">      <problem id="fs-id1105650"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1105652">A projectile is launched at ground level with an initial speed of 50.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>30.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal. It strikes a target above the ground 3.00 seconds later. What are the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> distances from where the projectile was launched to where it lands?</para></problem>
+  <solution id="fs-id1543587">
+ <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1915206"><m:math><m:semantics>
+
+<m:mtable columnalign="left">
+ <m:mtr>
+  <m:mtd><m:mi>x</m:mi></m:mtd>
+  <m:mtd><m:mo stretchy="false">=</m:mo></m:mtd>
+  <m:mtd><m:mtext>1.30 m</m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mn>10</m:mn><m:mn>2</m:mn></m:msup>
+  </m:mtd>
+ </m:mtr>
+
+ <m:mtr>
+  <m:mtd><m:mi>y</m:mi></m:mtd>
+  <m:mtd><m:mo stretchy="false">=</m:mo></m:mtd>
+  <m:mtd><m:mtext>30</m:mtext><m:mtext>.9 m.</m:mtext>
+  </m:mtd>
+ </m:mtr>
+
+</m:mtable>
+</m:semantics></m:math></para></solution>
+</exercise>
+      <exercise id="fs-id1275043" type="problems-exercises"><problem id="fs-id1019417"><para id="fs-id1980036">A ball is kicked with an initial velocity of 16 m/s in the horizontal direction and 12 m/s in the vertical direction. (a) At what speed does the ball hit the ground? (b) For how long does the ball remain in the air? (c)What maximum height is attained by the ball?
+      </para></problem></exercise>
+          <exercise id="fs-id2889503" type="problems-exercises">  <problem id="fs-id1790979"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1790980">A ball is thrown horizontally from the top of a 60.0-m building and lands 100.0 m from the base of the building. Ignore air resistance. (a) How long is the ball in the air? (b) What must have been the initial horizontal component of the velocity? (c) What is the vertical component of the velocity just before the ball hits the ground? (d) What is the velocity (including both the horizontal and vertical components) of the ball just before it hits the ground?</para></problem>
+            <solution id="fs-id1945253">
+              <para id="fs-id2167208">(a) 3.50 s</para>
+              <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1612943">(b) 28.6  m/s (c) 34.3 m/s</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id916496">(d) 44.7 m/s,  <m:math><m:semantics><m:mrow><m:mn>50.2&#186;</m:mn></m:mrow></m:semantics></m:math> below horizontal</para></solution>
+          </exercise>
+      <exercise id="fs-id2197387" type="problems-exercises"><problem id="fs-id2261404"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2261405">(a) A daredevil is attempting to jump his motorcycle over a line of buses parked end to end by driving up a <m:math><m:semantics><m:mrow><m:mrow><m:mtext>32&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"32&#176;"} {}</m:annotation></m:semantics></m:math> ramp at a speed of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>40</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s&#160;</m:mtext><m:mo stretchy="false">(</m:mo><m:mtext>144&#160;km/h</m:mtext><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40" "." "0&#160;m/s&#160;" \( "144&#160;km/h" \) } {}</m:annotation></m:semantics></m:math>. How many buses can he clear if the top of the takeoff ramp is at the same height as the bus tops and the buses are 20.0 m long? (b) Discuss what your answer implies about the margin of error in this act&#8212;that is, consider how much greater the range is than the horizontal distance he must travel to miss the end of the last bus. (Neglect air resistance.)
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1420192" type="problems-exercises"><problem id="fs-id1078714"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1078715">An archer shoots an arrow at a 75.0 m distant target; the bull&#8217;s-eye of the target is at same height as the release height of the arrow. (a) At what angle must the arrow be released to hit the bull&#8217;s-eye if its initial speed is 35.0 m/s? In this part of the problem, explicitly show how you follow the steps involved in solving projectile motion problems. (b) There is a large tree halfway between the archer and the target with an overhanging horizontal branch 3.50 m above the release height of the arrow. Will the arrow go over or under the branch?</para></problem>
+        <solution id="fs-id1970452">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1970455">(a) <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mtext>4&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"18" "." "4&#176;"} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1678230">(b) The arrow will go over the branch.</para></solution>
+      </exercise>
+     <exercise id="fs-id1934878" type="problems-exercises"><problem id="fs-id2226553"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2226554">A rugby player passes the ball 7.00 m across the field, where it is caught at the same height as it left his hand. (a) At what angle was the ball thrown if its initial speed was 12.0 m/s, assuming that the smaller of the two possible angles was used? (b) What other angle gives the same range, and why would it not be used? (c) How long did this pass take?</para></problem>
+     </exercise>
+      <exercise id="fs-id2126267" type="problems-exercises"><problem id="fs-id2889922"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2889923">Verify the ranges for the projectiles in <link target-id="import-auto-id1904800"/>(a) for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="45"&#176;} {}</m:annotation></m:semantics></m:math> and the given initial velocities.</para></problem><solution id="fs-id1903883">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1912801"><m:math><m:semantics><m:mrow><m:mrow><m:mtable><m:mtr><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup>
+<m:mrow>
+<m:mtext>sin</m:mtext><m:msub><m:mn>2&#952;</m:mn><m:mn>0</m:mn></m:msub><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow></m:mtr><m:mtr><m:mrow><m:mtext>For </m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow><m:mo>,</m:mo><m:mrow/></m:mrow><m:mrow><m:mrow>
+
+<m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup><m:mi>g</m:mi></m:mfrac></m:mrow><m:mrow/></m:mrow></m:mtr></m:mtable><m:mrow/></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0">alignl { stack {
+ size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} # 
+"For "&#952;="45"&#176;: {} # 
+R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {} 
+} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>; 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>163</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math>
+
+ for 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>; 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>50</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50 m/s"} {}</m:annotation></m:semantics></m:math>.</para></solution>
+      </exercise>
+      <exercise id="fs-id2214647" type="problems-exercises"><problem id="fs-id2214182"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2214183">Verify the ranges shown for the projectiles in <link target-id="import-auto-id1904800"/>(b) for an initial velocity of 50 m/s at the given initial angles.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id2905201" type="problems-exercises"><problem id="fs-id1851487"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1851488">The cannon on a battleship can fire a shell a maximum distance of 32.0 km. (a) Calculate the initial velocity of the shell. (b) What maximum height does it reach? (At its highest, the shell is above 60% of the atmosphere&#8212;but air resistance is not really negligible as assumed to make this problem easier.) (c) The ocean is not flat, because the Earth is curved. Assume that the radius of the Earth is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mrow><m:mtext>37</m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mtext>10</m:mtext><m:mrow><m:mn>3</m:mn></m:mrow></m:msup></m:mrow><m:mspace width="0.25em"/><m:mtext> km</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{6 "." "37" times "10" rSup { size 8{3} } " km"} {}</m:annotation></m:semantics></m:math>. How many meters lower will its surface be 32.0 km from the ship along a horizontal line parallel to the surface at the ship? Does your answer imply that error introduced by the assumption of a flat Earth in projectile motion is significant here?</para></problem>
+        <solution id="fs-id2075683">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1862278">(a) 560 m/s</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2252609">(b) <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>8</m:mn><m:mtext>.</m:mtext><m:mrow><m:mtext>00 </m:mtext><m:mo stretchy="false">&#215;</m:mo><m:msup><m:mtext> 10</m:mtext><m:mrow><m:mn>3</m:mn></m:mrow></m:msup></m:mrow><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{8 "." "00 " times " 10" rSup { size 8{3} } " m"} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2262837">(c) 80.0 m. This error is not significant because it is only 1% of the answer in part (b).</para></solution>
+      </exercise>
+      <exercise id="fs-id1925728" type="problems-exercises"><problem id="fs-id2282381"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2282382">An arrow is shot from a height of 1.5 m toward a cliff of height <m:math><m:semantics><m:mrow><m:mrow><m:mi>H</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{H} {}</m:annotation></m:semantics></m:math>. It is shot with a velocity of 30 m/s at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mtext>60&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"60&#176;"} {}</m:annotation></m:semantics></m:math> above the horizontal. It lands on the top edge of the cliff 4.0 s later. (a) What is the height of the cliff? (b) What is the maximum height reached by the arrow along its trajectory? (c) What is the arrow&#8217;s impact speed just before hitting the cliff?
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1745072" type="problems-exercises"><problem id="fs-id2275266"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2275267">In the standing broad jump, one squats and then pushes off with the legs to see how far one can jump. Suppose the extension of the legs from the crouch position is 0.600 m and the acceleration achieved from this position is 1.25 times the acceleration due to gravity, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. How far can they jump? State your assumptions. (Increased range can be achieved by swinging the arms in the direction of the jump.)</para></problem>
+      <solution id="fs-id2864553">
+        <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2864555">1.50 m, assuming launch angle of  <m:math><m:semantics><m:mrow><m:mn>45&#186;</m:mn></m:mrow></m:semantics></m:math></para></solution>
+      </exercise>
+      <exercise id="fs-id1875777" type="problems-exercises"><problem id="fs-id2864558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2864559">The world long jump record is 8.95 m (Mike Powell, USA, 1991). Treated as a projectile, what is the maximum range obtainable by a person if he has a take-off speed of 9.5 m/s? State your assumptions.
+      </para></problem>
+      </exercise>
+     <exercise id="fs-id2254986" type="problems-exercises"><problem id="fs-id1543443"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1543444">Serving at a speed of 170 km/h, a tennis player hits the ball at a height of 2.5 m and an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> below the horizontal. The service line is 11.9 m from the net, which is 0.91 m high. What is the angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> such that the ball just crosses the net? Will the ball land in the service box, whose out line is 6.40 m from the net?</para></problem>
+      <solution id="fs-id722706">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2260869"><m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo>=</m:mo><m:mn>6.1&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2088346">yes, the ball lands at 5.3 m from the net</para></solution>
+      </exercise>
+      <exercise id="fs-id2173828" type="problems-exercises"><problem id="fs-id2088349"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2088350">A football quarterback is moving straight backward at a speed of 2.00 m/s when he throws a pass to a player 18.0 m straight downfield. (a) If the ball is thrown at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mtext>25&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25&#176;"} {}</m:annotation></m:semantics></m:math> relative to the ground and is caught at the same height as it is released, what is its initial speed relative to the ground? (b) How long does it take to get to the receiver? (c) What is its maximum height above its point of release?
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1796436" type="problems-exercises"><problem id="fs-id1979282"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1979284">Gun sights are adjusted to aim high to compensate for the effect of gravity, effectively making the gun accurate only for a specific range. (a) If a gun is sighted to hit targets that are at the same height as the gun and 100.0 m away, how low will the bullet hit if aimed directly at a target 150.0 m away? The muzzle velocity of the bullet is 275 m/s. (b) Discuss qualitatively how a larger muzzle velocity would affect this problem and what would be the effect of air resistance.</para></problem>
+        <solution id="fs-id2175653">
+      <para id="fs-id2175655">(a) &#8722;0.486 m</para>
+      <para id="fs-id1461088">(b) The larger the muzzle velocity, the smaller the deviation in the vertical direction, because the time of flight would be smaller. Air resistance would have the effect of decreasing the time of flight, therefore increasing the vertical deviation.</para>
+      </solution>
+      </exercise>
+      <exercise id="fs-id2177814" type="problems-exercises"><problem id="fs-id1781566"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1781567">An eagle is flying horizontally at a speed of 3.00 m/s when the fish in her talons wiggles loose and falls into the lake 5.00 m below. Calculate the velocity of the fish relative to the water when it hits the water.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id1914025" type="problems-exercises"><problem id="fs-id2057849"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2057850">An owl is carrying a mouse to the chicks in its nest. Its position at that time is 4.00 m west and 12.0 m above the center of the 30.0 cm diameter nest. The owl is flying east at 3.50 m/s at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mn>30.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30&#186;}</m:annotation></m:semantics></m:math> below the horizontal when it accidentally drops the mouse. Is the owl lucky enough to have the mouse hit the nest? To answer this question, calculate the horizontal position of the mouse when it has fallen 12.0 m.</para></problem>
+        <solution id="fs-id2042074">
+        <para id="fs-id2042076">4.23 m. No, the owl is not lucky; he misses the nest.</para></solution>
+      </exercise>
+      <exercise id="fs-id1403577" type="problems-exercises"><problem id="fs-id2865734"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2865735">Suppose a soccer player kicks the ball from a distance 30 m toward the goal. Find the initial speed of the ball if it just passes over the goal, 2.4 m above the ground, given the initial direction to be <m:math><m:semantics><m:mrow><m:mrow><m:mtext>40&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40" rSup { size 8{o} } } {}</m:annotation></m:semantics></m:math> above the horizontal.
+      </para></problem>
+      </exercise>
+      <exercise id="fs-id2260735" type="problems-exercises"><problem id="fs-id1789803"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1789804">Can a goalkeeper at her/ his goal kick a soccer ball into the opponent&#8217;s goal without the ball touching the ground? The distance will be about 95 m. A goalkeeper can give the ball a speed of 30 m/s.</para></problem>
+      <solution id="fs-id1985242">
+        <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1985244">No, the maximum range (neglecting air resistance) is about 92 m. </para></solution>
+      </exercise>      
+     <exercise id="fs-id1437858" type="problems-exercises"><problem id="fs-id1891285"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1891286">The free throw line in basketball is 4.57 m (15 ft) from the basket, which is 3.05 m (10 ft) above the floor. A player standing on the free throw line throws the ball with an initial speed of 7.15 m/s, releasing it at a height of 2.44 m (8 ft) above the floor. At what angle above the horizontal must the ball be thrown to exactly hit the basket? Note that most players will use a large initial angle rather than a flat shot because it allows for a larger margin of error. Explicitly show how you follow the steps involved in solving projectile motion problems.</para></problem>
+     </exercise>
+      <exercise id="fs-id1827481" type="problems-exercises"><problem id="fs-id1750926"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1750928">In 2007, Michael Carter (U.S.) set a world record in the shot put with a throw of 24.77 m. What was the initial speed of the shot if he released it at a height of 2.10 m and threw it at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>38.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> above the horizontal? (Although the maximum distance for a projectile on level ground is achieved at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> when air resistance is neglected, the actual angle to achieve maximum range is smaller; thus, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> will give a longer range than <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> in the shot put.)</para></problem>
+        <solution id="fs-id1630701">
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2261978">15.0 m/s</para></solution>
+      </exercise>
+          <exercise id="fs-id1670278" type="problems-exercises"><problem id="fs-id1945400"><para id="fs-id1945401">A basketball player is running at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>5</m:mn><m:mtext>.</m:mtext><m:mtext>00&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{5 "." "00&#160;m/s"} {}</m:annotation></m:semantics></m:math> directly toward the basket when he jumps into the air to dunk the ball. He maintains his horizontal velocity. (a) What vertical velocity does he need to rise 0.750 m above the floor? (b) How far from the basket (measured in the horizontal direction) must he start his jump to reach his maximum height at the same time as he reaches the basket?
+          </para></problem>
+          </exercise>
+      <exercise id="fs-id1779635" type="problems-exercises">
+        <problem id="fs-id1637691"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1637692">A football player punts the ball at a <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>45.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#176;} {}</m:annotation></m:semantics></m:math> angle. Without an effect from the wind, the ball would travel 60.0 m horizontally. (a) What is the initial speed of the ball? (b) When the ball is near its maximum height it experiences a brief gust of wind that reduces its horizontal velocity by 1.50 m/s. What distance does the ball travel horizontally?</para></problem>
+      <solution id="fs-id1545352">
+      <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1545354">(a) 24.2 m/s
+</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1796132">(b) The ball travels a total of 57.4 m with the brief gust of wind.</para></solution>
+      </exercise>
+<exercise id="fs-id2046931" type="problems-exercises">
+  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for 
+
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mo>&#8211;</m:mo><m:mo stretchy="false">(</m:mo><m:mrow><m:mn>1</m:mn><m:mo stretchy="false">/</m:mo><m:mn>2</m:mn></m:mrow><m:mo stretchy="false">)</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=&#965; rSub { size 8{0y} } t \( 1/2 \)  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> (These equations describe the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions of a projectile that starts at the origin.) You should obtain an equation of the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> where <m:math><m:semantics><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{b} {}</m:annotation></m:semantics></m:math> are constants.
+</para></problem>
+</exercise>
+<exercise id="fs-id2133758" type="problems-exercises"><problem id="fs-id2890360"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2890361">Derive <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mn>2&#952;</m:mn><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } } {}</m:annotation></m:semantics></m:math> for the range of a projectile on level ground by finding the time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> at which <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> becomes zero and substituting this value of <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> into the expression for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x - x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, noting that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=x - x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math></para></problem>
+<solution id="eip-id2932521">
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id2932523"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mi>gt</m:mi></m:mstyle><m:mn>2</m:mn></m:msup><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo>
+
+</m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mi>gt</m:mi></m:mstyle><m:mn>2</m:mn></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y - y rSub { size 8{0} } =0=v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } = \( v rSub { size 8{0} } "sin"&#952; \) t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>,</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1990384">so that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:mn>2</m:mn><m:mo stretchy="false">(</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/>
+<m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+<m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t= {  {2 \( v rSub { size 8{0} } "sin"&#952; \) }  over  {g} } } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1355828"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mspace width="0.25em"/>
+<m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+<m:mi>&#952;</m:mi><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mi>R</m:mi></m:mrow><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x - x rSub { size 8{0} } =v rSub { size 8{0x} } t= \( v rSub { size 8{0} } "cos"&#952; \) t=R,} {}</m:annotation></m:semantics></m:math> and substituting for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> gives:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3306953"><m:math>
+        <m:semantics>
+          <m:mrow>
+              <m:mrow>
+                <m:mrow>
+                  <m:mrow>
+                    <m:mi>R</m:mi>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:msub>
+<m:mstyle fontstyle="italic">
+                      <m:mi>v</m:mi> </m:mstyle>
+                          <m:mn>0</m:mn>
+                    </m:msub>
+                  </m:mrow><m:mspace width="0.25em"/>
+                  <m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+                  <m:mi>&#952;</m:mi>
+                  <m:mrow>
+                    <m:mfenced open="(" close=")">
+                      <m:mfrac>
+
+                        <m:mrow>
+                          <m:msub>
+<m:mrow>
+                            <m:mn>2</m:mn>
+<m:mi>v</m:mi>
+</m:mrow>
+                                <m:mn>0</m:mn>
+                          </m:msub><m:mspace width="0.25em"/>
+                          <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+                          <m:mi>&#952;</m:mi>
+                        </m:mrow>
+                        <m:mi>g</m:mi>
+                      </m:mfrac>
+                    </m:mfenced>
+                    <m:mo stretchy="false">=</m:mo>
+                    <m:mfrac>
+                      <m:mrow>
+                        <m:msubsup>
+<m:mrow>
+                          <m:mn>2</m:mn> <m:mi>v</m:mi>
+</m:mrow>
+                          <m:mn>0</m:mn>
+                          <m:mn>2</m:mn>
+                 
+                        </m:msubsup><m:mspace width="0.25em"/>
+                        <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
+                        <m:mi>&#952;</m:mi><m:mspace width="0.25em"/>
+                        <m:mtext>cos</m:mtext><m:mspace width="0.25em"/>
+                        <m:mi>&#952;</m:mi>
+                      </m:mrow>
+                      <m:mi>g</m:mi>
+                    </m:mfrac>
+                  </m:mrow>
+                </m:mrow>
+              </m:mrow>
+            
+            <m:mrow/>
+          </m:mrow>
+          <m:annotation encoding="StarMath 5.0"> size 12{R=v rSub { size 8{0} } "cos"&#952; left ( {  {2v rSub { size 8{0} } "sin"&#952;}  over  {g} }  right )= {  {2v rSub { size 8{0}   rSup { size 8{2} } } "sin"&#952;"cos"&#952;}  over  {g} } } {}</m:annotation>
+        </m:semantics>
+      </m:math> 
+    </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1599732">since <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>2</m:mn><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>sin</m:mtext><m:mspace width="0.25em"/></m:mrow><m:mn>2&#952;</m:mn><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{2"sin"&#952;"cos"&#952;="sin"2&#952;,} {}</m:annotation></m:semantics></m:math> the range is:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3385487"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow>
+<m:msup>
+<m:msub>
+<m:mi>v</m:mi>
+
+
+<m:mn>0</m:mn></m:msub>
+<m:mrow>
+<m:mn>2</m:mn>
+</m:mrow>
+</m:msup><m:mspace width="0.25em"/>
+<m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mn>2&#952;</m:mn></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ {underline  {R= {  {v rSub { size 8{0}   rSup { size 8{2} } } "sin"2&#952;}  over  {g} } }} } {}</m:annotation></m:semantics></m:math>.</para></solution></exercise>
+
+    
+    
+    
+    
+ 
+<exercise id="fs-id1794949" type="problems-exercises"><problem id="fs-id1626931"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1626932"><emphasis>Unreasonable Results</emphasis> (a) Find the maximum range of a super cannon that has a muzzle velocity of 4.0 km/s. (b) What is unreasonable about the range you found? (c) Is the premise unreasonable or is the available equation inapplicable? Explain your answer. (d) If such a muzzle velocity could be obtained, discuss the effects of air resistance, thinning air with altitude, and the curvature of the Earth on the range of the super cannon.
+</para></problem>
+</exercise>
+ <exercise xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1815382" type="problems-exercises"><problem id="fs-id2255165"><para id="fs-id2255166"><emphasis>Construct Your Own Problem</emphasis> Consider a ball tossed over a fence. Construct a problem in which you calculate the ball&#8217;s needed initial velocity to just clear the fence. Among the things to determine are; the height of the fence, the distance to the fence from the point of release of the ball, and the height at which the ball is released. You should also consider whether it is possible to choose the initial speed for the ball and just calculate the angle at which it is thrown. Also examine the possibility of multiple solutions given the distances and heights you have chosen.
+ </para></problem>
+</exercise></section>
+</content>
+    <glossary>
+      <definition id="import-auto-id2275857"><term>air resistance</term> <meaning id="fs-id1668212">a frictional force that slows the motion of objects as they travel through the air; when solving basic physics problems, air resistance is assumed to be zero</meaning></definition>
+      
+<definition id="fs-id1405173"><term>kinematics</term><meaning id="fs-id1949378">the study of motion without regard to mass or force</meaning></definition>
+
+<definition id="fs-id1949381"><term>motion</term><meaning id="fs-id2324535">displacement of an object as a function of time</meaning></definition>
+
+<definition id="import-auto-id1459204"><term>projectile</term> <meaning id="fs-id1798529">an object that travels through the air and experiences only acceleration due to gravity</meaning></definition>
+
+      <definition id="import-auto-id1981500"><term>projectile motion</term> <meaning id="fs-id2253704">the motion of an object that is subject only to the acceleration of gravity</meaning></definition>
+      <definition id="import-auto-id2257218"><term>range</term> <meaning id="fs-id1883200">the maximum horizontal distance that a projectile travels</meaning></definition>
+      <definition id="import-auto-id2852095"><term>trajectory</term> <meaning id="fs-id2222621">the path of a projectile through the air</meaning></definition>
+    </glossary>
+</document>

--- a/cnxml/tests/data/valid-derived-from.cnxml
+++ b/cnxml/tests/data/valid-derived-from.cnxml
@@ -42,45 +42,45 @@
        where CONTENT_URL is the value provided above in the <md:content-url> element.
   -->
   <md:derived-from url="http://legacy-staging.cnx.org/content/m48590/1.11">
-  <md:repository>http://legacy-staging.cnx.org/content</md:repository>
-  <md:content-url>http://legacy-staging.cnx.org/content/m48590/1.11</md:content-url>
-  <md:content-id>m48590</md:content-id>
-  <md:title>Introduction</md:title>
-  <md:version>1.11</md:version>
-  <md:created>2014/01/01 13:57:36 -0600</md:created>
-  <md:revised>2015/06/24 10:59:20 -0500</md:revised>
-  <md:actors>
-    <md:person userid="cnxecon">
-      <md:firstname>OpenStax</md:firstname>
-      <md:surname>College</md:surname>
-      <md:fullname>OpenStax Economics</md:fullname>
-      <md:email>info@openstaxcollege.org</md:email>
-    </md:person>
-    <md:organization userid="OpenStaxCollege">
-      <md:shortname>OpenStax</md:shortname>
-      <md:fullname>OpenStax</md:fullname>
-      <md:email>info@openstax.org</md:email>
-    </md:organization>
-    <md:person userid="OSCRiceUniversity">
-      <md:firstname>Rice</md:firstname>
-      <md:surname>University</md:surname>
-      <md:fullname>Rice University</md:fullname>
-      <md:email>info@openstaxcollege.org</md:email>
-    </md:person>
-  </md:actors>
-  <md:roles>
-    <md:role type="author">OpenStaxCollege</md:role>
-    <md:role type="maintainer">OpenStaxCollege cnxecon</md:role>
-    <md:role type="licensor">OSCRiceUniversity</md:role>
-  </md:roles>
-  <md:license url="http://creativecommons.org/licenses/by/4.0/" />
-  <!-- For information on license requirements for use or modification, see license url in the
-       above <md:license> element.
-       For information on formatting required attribution, see the URL:
-         CONTENT_URL/content_info#cnx_cite_header
-       where CONTENT_URL is the value provided above in the <md:content-url> element.
-  -->
-  <md:language>en</md:language>
+    <md:repository>http://legacy-staging.cnx.org/content</md:repository>
+    <md:content-url>http://legacy-staging.cnx.org/content/m48590/1.11</md:content-url>
+    <md:content-id>m48590</md:content-id>
+    <md:title>Introduction</md:title>
+    <md:version>1.11</md:version>
+    <md:created>2014/01/01 13:57:36 -0600</md:created>
+    <md:revised>2015/06/24 10:59:20 -0500</md:revised>
+    <md:actors>
+      <md:person userid="cnxecon">
+        <md:firstname>OpenStax</md:firstname>
+        <md:surname>College</md:surname>
+        <md:fullname>OpenStax Economics</md:fullname>
+        <md:email>info@openstaxcollege.org</md:email>
+      </md:person>
+      <md:organization userid="OpenStaxCollege">
+        <md:shortname>OpenStax</md:shortname>
+        <md:fullname>OpenStax</md:fullname>
+        <md:email>info@openstax.org</md:email>
+      </md:organization>
+      <md:person userid="OSCRiceUniversity">
+        <md:firstname>Rice</md:firstname>
+        <md:surname>University</md:surname>
+        <md:fullname>Rice University</md:fullname>
+        <md:email>info@openstaxcollege.org</md:email>
+      </md:person>
+    </md:actors>
+    <md:roles>
+      <md:role type="author">OpenStaxCollege</md:role>
+      <md:role type="maintainer">OpenStaxCollege cnxecon</md:role>
+      <md:role type="licensor">OSCRiceUniversity</md:role>
+    </md:roles>
+    <md:license url="http://creativecommons.org/licenses/by/4.0/" />
+    <!-- For information on license requirements for use or modification, see license url in the
+         above <md:license> element.
+         For information on formatting required attribution, see the URL:
+           CONTENT_URL/content_info#cnx_cite_header
+         where CONTENT_URL is the value provided above in the <md:content-url> element.
+    -->
+    <md:language>en</md:language>
   </md:derived-from>
   <md:keywordlist>
     <md:keyword>Air resistance</md:keyword>
@@ -105,16 +105,16 @@
 </metadata>
 
 <content>
-    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple: 
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1846742"><term id="import-auto-id1560216">Projectile motion</term> is the <term id="import-auto-id1846113">motion</term> of an object thrown or projected into the air, subject to only the acceleration of gravity. The object is called a <term id="import-auto-id1809247">projectile</term>, and its path is called its <term id="import-auto-id1397020">trajectory</term>. The motion of falling objects, as covered in <link document="m42125">Problem-Solving Basics for One-Dimensional Kinematics</link>, is a simple one-dimensional type of projectile motion in which there is no horizontal movement. In this section, we consider two-dimensional projectile motion, such as that of a football or other object for which <term id="import-auto-id1230666">air resistance</term> <emphasis effect="italics"><emphasis effect="italics">is negligible</emphasis></emphasis>.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1696126">The most important fact to remember here is that <emphasis effect="italics"><emphasis effect="italics">motions along perpendicular axes are independent</emphasis></emphasis> and thus can be analyzed separately. This fact was discussed in <link document="m42104">Kinematics in Two Dimensions: An Introduction</link>, where vertical and horizontal motions were seen to be independent. The key to analyzing two-dimensional projectile motion is to break it into two motions, one along the horizontal axis and the other along the vertical. (This choice of axes is the most sensible, because acceleration due to gravity is vertical&#8212;thus, there will be no acceleration along the horizontal axis when air resistance is negligible.) As is customary, we call the horizontal axis the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-axis and the vertical axis the <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axis. <link target-id="import-auto-id2242290"/> illustrates the notation for displacement, where <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> is defined to be the total displacement and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> are its components along the horizontal and vertical axes, respectively. The magnitudes of these vectors are <emphasis effect="italics"><emphasis effect="italics">s</emphasis></emphasis>, <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>, and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>. (Note that in the last section we used the notation <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">A</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A} {}</m:annotation></m:semantics></m:math> to represent a vector with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. If we continued this format, we would call displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> with components <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi mathvariant="bold">s</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>. However, to simplify the notation, we will simply represent the component vectors as <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1576953">Of course, to describe motion we must deal with velocity and acceleration, as well as with displacement. We must find their components along the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>- and <emphasis effect="italics"><emphasis effect="italics">y</emphasis></emphasis>-axes, too. We will assume all forces except gravity (such as air resistance and friction, for example) are negligible. The components of acceleration are then very simple:
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical, 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>9.80 m</m:mn><m:msup><m:mtext>/s</m:mtext><m:mn>2</m:mn></m:msup></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{y} } ="-g"="-9.80" "m/s" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. (Note that this definition assumes that the upwards direction is defined as the positive direction. If you arrange the coordinate system instead such that the downwards direction is positive, then acceleration due to gravity takes a positive value.) Because gravity is vertical,
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo>=</m:mo><m:mn>0</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math>. Both accelerations are constant, so the kinematic equations can be used.</para><note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1767845"><label/><title>Review of Kinematic Equations (constant <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow></m:mrow></m:mrow></m:semantics></m:math>)</title>
-    
+
     <equation id="eip-891"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -124,11 +124,11 @@
                           </m:mrow>
                           <m:msub>
                             <m:mi>x</m:mi>
-                            
+
                               <m:mrow>
                                 <m:mn>0</m:mn>
                               </m:mrow>
-                            
+
                           </m:msub>
                           <m:mrow>
                             <m:mi/>
@@ -142,7 +142,7 @@
                           <m:mi>t</m:mi>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{x=`x rSub { size 8{0} } `+` { bar  {v}}t} {}</m:annotation>
@@ -150,7 +150,7 @@
               </m:math> </equation><equation id="eip-557"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -165,11 +165,11 @@
                             <m:mrow>
                               <m:msub>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                               <m:mo stretchy="false">+</m:mo>
                               <m:mi>v</m:mi>
@@ -178,16 +178,16 @@
                           </m:mfrac>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{ { bar  {v}}=` {  {v rSub { size 8{0} } +v}  over  {2} } } {}</m:annotation>
                 </m:semantics>
-              </m:math> 
+              </m:math>
 </equation><equation id="eip-405"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mi>v</m:mi>
@@ -195,11 +195,11 @@
                           <m:mrow>
                             <m:msub>
                               <m:mi>v</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>0</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msub>
                             <m:mo stretchy="false">+</m:mo>
                             <m:mstyle fontstyle="italic">
@@ -210,7 +210,7 @@
                           </m:mrow>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{v=v rSub { size 8{0} } + ital "at"} {}</m:annotation>
@@ -219,7 +219,7 @@
 </equation><equation id="eip-556"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -228,20 +228,20 @@
                             <m:mrow>
                               <m:msub>
                                 <m:mi>x</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                               <m:mo stretchy="false">+</m:mo>
                               <m:msub>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msub>
                             </m:mrow>
                           </m:mrow>
@@ -256,16 +256,16 @@
                             <m:mrow>
                               <m:msup>
                                 <m:mtext fontstyle="italic">at</m:mtext>
-                                
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
 </m:msup>
                             </m:mrow>
-                        
+
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{0} } t+ {  {1}  over  {2} }  ital "at" rSup { size 8{2} } } {}</m:annotation>
@@ -273,32 +273,32 @@
               </m:math> </equation><equation id="eip-389"><m:math display="block">
                 <m:semantics>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
                             <m:msup>
                               <m:mi>v</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>2</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msup>
                             <m:mo stretchy="false">=</m:mo>
                             <m:mrow>
                               <m:msubsup>
                                 <m:mi>v</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>0</m:mn>
                                   </m:mrow>
-                                
-                                
+
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msubsup>
                               <m:mo stretchy="false">+</m:mo>
                               <m:mn>2</m:mn><m:mi>a</m:mi>
@@ -310,11 +310,11 @@
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:msub>
                               <m:mi>x</m:mi>
-                              
+
                                 <m:mrow>
                                   <m:mn>0</m:mn>
                                 </m:mrow>
-                              
+
                             </m:msub>
                           </m:mrow>
                           <m:mo stretchy="false">)</m:mo>
@@ -325,32 +325,32 @@
                   </m:mrow>
                   <m:annotation encoding="StarMath 5.0"> size 12{v rSup { size 8{2} } =v rSub { size 8{0} }  rSup { size 8{2} } +2a \( x - x rSub { size 8{0} }  \) } {}</m:annotation>
                 </m:semantics>
-              </m:math> 
+              </m:math>
 </equation></note><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2242290"><media id="import-auto-id1402609" alt="A soccer player is kicking a soccer ball. The ball travels in a projectile motion and reaches a point whose vertical distance is y and horizontal distance is x. The displacement between the kicking point and the final point is s. The angle made by this displacement vector with x axis is theta.">
         <image mime-type="image/jpg" src="Figure_03_04_01.jpg" width="350"/>
       </media>
-      
+
     <caption>The total displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> of a soccer ball at a point along its path. The vector <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> has components <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> along the horizontal and vertical axes. Its magnitude is <m:math><m:semantics><m:mrow><m:mrow><m:mi>s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math>, and it makes an angle <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> with the horizontal.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-36">Given these assumptions, the following steps are then used to analyze projectile motion:</para>
 
-<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so 
+<para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-822"><emphasis effect="italics"><emphasis>Step 1.</emphasis></emphasis>     <emphasis effect="italics">Resolve or break the motion into horizontal and vertical components along the x- and y-axes.</emphasis> These axes are perpendicular, so
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{x} } =A"cos"&#952;} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>A</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{A rSub { size 8{y} } =A"sin"&#952;} {}</m:annotation></m:semantics></m:math> are used. The magnitude of the components of displacement
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> along these axes are <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi fontstyle="italic">y.</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> The magnitudes of the components of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> are
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v"cos"&#952;} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mi>v</m:mi></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v"sin"&#952;} {}</m:annotation></m:semantics></m:math> where
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> is the magnitude of the velocity and <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is its direction, as shown in <link target-id="import-auto-id1815222"/>. Initial values are denoted with a subscript 0, as usual.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-205"><emphasis effect="italics"><emphasis>Step 2.</emphasis></emphasis>  <emphasis effect="italics">Treat the motion as two independent one-dimensional motions, one horizontal and the other vertical.</emphasis> The kinematic equations for horizontal and vertical motion take the following forms:
 </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-338"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Horizontal Motion</m:mtext>
@@ -358,11 +358,11 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>a</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mn>0</m:mn>
@@ -370,16 +370,16 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal Motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-362"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -388,37 +388,37 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-627"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">=</m:mo><m:mtext>velocity is a constant.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0x} } =v rSub { size 8{x} } ="velocity is a constant."} {}</m:annotation></m:semantics></m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-293"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Vertical Motion</m:mtext>
@@ -431,11 +431,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>a</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">=</m:mo>
                       <m:mrow>
@@ -449,23 +449,23 @@
                         <m:mo stretchy="false">&#8722;</m:mo>
                         <m:mn>9.</m:mn>
                       </m:mrow>
-                     
+
                       <m:mtext>80</m:mtext>
                     </m:mrow>
                   </m:mrow>
                   <m:mo stretchy="false"> </m:mo>
                   <m:msup>
                     <m:mtext>m/s</m:mtext>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Vertical Motion " \( "assuming positive is up "a rSub { size 8{y} } = - g= - 9/"80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
@@ -473,7 +473,7 @@
       </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-131"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -482,11 +482,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:mfrac>
@@ -499,55 +499,55 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-305"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:msub>
                     <m:mi>v</m:mi>
-                    
+
                       <m:mrow>
                         <m:mi>y</m:mi>
                       </m:mrow>
-                    
+
                   </m:msub>
                   <m:mo stretchy="false">=</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">&#8722;</m:mo>
                     <m:mstyle fontstyle="italic">
@@ -558,16 +558,16 @@
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-542"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -576,21 +576,21 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
-                          
+
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
@@ -602,33 +602,33 @@
                       <m:mn>2</m:mn>
                     </m:mfrac>
                   </m:mrow>
-                
+
                     <m:mrow>
                       <m:msup>
                         <m:mi fontstyle="italic">gt</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
-         
+
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-243"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-708"><emphasis effect="italics"><emphasis>Step 3.</emphasis></emphasis>  <emphasis effect="italics"> Solve for the unknowns in the two separate motions&#8212;one horizontal and one vertical.</emphasis> Note that the only common variable between the motions is time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>. The problem solving procedures here are the same as for one-dimensional <term>kinematics</term> and are illustrated in the solved examples below.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-979"><emphasis effect="italics"><emphasis>Step 4.</emphasis></emphasis>  <emphasis effect="italics">Recombine the two motions to find the total displacement</emphasis> <m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">s</m:mtext></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math><emphasis effect="italics"> and velocity </emphasis><m:math><m:semantics><m:mrow><m:mrow><m:mtext mathvariant="bold">v</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>. Because the <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are perpendicular, we determine these vectors by using the techniques outlined in the <link document="m42128">Vector Addition and Subtraction: Analytical Methods</link> and employing <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>A</m:mi>
@@ -637,46 +637,46 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>A</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>A</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
         and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>A</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>A</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( A rSub { size 8{y} } /A rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math> in the following form, where <m:math><m:semantics><m:mrow><m:mrow><m:mi>&#952;</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952;} {}</m:annotation></m:semantics></m:math> is the direction of the displacement <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">s</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{s} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is the direction of the velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi mathvariant="bold">v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math>:
 </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-245"><emphasis>Total displacement and velocity</emphasis></para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-743"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>s</m:mi>
@@ -685,26 +685,26 @@
                     <m:mrow>
                       <m:msup>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msup>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
@@ -712,7 +712,7 @@
       </m:math></equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-373"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -720,14 +720,14 @@
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
@@ -739,16 +739,16 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-679"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>v</m:mi>
@@ -757,59 +757,59 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
 </equation><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-264"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1815222"><media id="import-auto-id2275311" alt="In part a the figure shows projectile motion of a ball with initial velocity of v zero at an angle of theta zero with the horizontal x axis. The horizontal component v x and the vertical component v y at various positions of ball in the projectile path is shown. In part b only the horizontal velocity component v sub x is shown whose magnitude is constant at various positions in the path. In part c only vertical velocity component v sub y is shown. The vertical velocity component v sub y is upwards till it reaches the maximum point and then its direction changes to downwards. In part d resultant v of horizontal velocity component v sub x and downward vertical velocity component v sub y is found which makes an angle theta with the horizontal x axis. The direction of resultant velocity v is towards south east.">
           <image mime-type="image/jpg" src="Figure_03_04_02.jpg" height="600"/>
         </media>
-        
+
   <caption>(a) We analyze two-dimensional projectile motion by breaking it into two independent one-dimensional motions along the vertical and horizontal axes. (b) The horizontal motion is simple, because <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is thus constant. (c) The velocity in the vertical direction begins to decrease as the object rises; at its highest point, the vertical velocity is zero. As the object falls towards the Earth again, the vertical velocity increases again in magnitude but points in the opposite direction to the initial vertical velocity. (d) The <emphasis effect="italics">x</emphasis> - and <emphasis effect="italics">y</emphasis> -motions are recombined to give the total velocity at any given point on the trajectory.</caption></figure><example id="fs-id2175010">
     <title>A Fireworks Projectile Explodes High and Away</title>
-    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and  
+    <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1896064">During a fireworks display, a shell is shot into the air with an initial speed of 70.0 m/s at an angle of <m:math><m:semantics><m:mrow><m:mn>75.0&#186;</m:mn></m:mrow></m:semantics></m:math> above the horizontal, as illustrated in <link target-id="import-auto-id934168"/>. The fuse is timed to ignite the shell just as it reaches its highest point above the ground. (a) Calculate the height at which the shell explodes. (b) How much time passed between the launch of the shell and the explosion? (c) What is the horizontal displacement of the shell when it explodes?</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-149"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1629969">Because air resistance is negligible for the unexploded shell, the analysis method outlined above can be used. The motion can be broken into horizontal and vertical motions in which  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mi>g</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ a rSub { size 8{y} } =-g} {}</m:annotation></m:semantics></m:math>. We can then define
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero and solve for the desired quantities.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-774"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1669571">By &#8220;height&#8221; we mean the altitude or vertical position <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> above the starting point. The highest point in any trajectory, called the apex, is reached when <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ v rSub { size 8{y} } =0} {}</m:annotation></m:semantics></m:math>. Since we know the initial and final velocities as well as the initial position, we use the following equation to find <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math>:
 
 </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-734"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) "."} {}</m:annotation></m:semantics></m:math></equation><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id934168"><media id="import-auto-id1576299" alt="The x y graph shows the trajectory of fireworks shell. The initial velocity of the shell v zero is at angle theta zero equal to seventy five degrees with the horizontal x axis. The fuse is set to explode the shell at the highest point of the trajectory which is at a height h equal to two hundred thirty three meters and at a horizontal distance x equal to one hundred twenty five meters from the origin.">
         <image mime-type="image/jpg" src="Figure_03_04_03a.jpg" height="250"/>
       </media>
-      
+
     <caption>The trajectory of a fireworks shell. The fuse is set to explode the shell at the highest point in its trajectory, which is found to be at a height of 233 m and 125 m away horizontally.</caption></figure><para id="import-auto-id1163607">Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> are both zero, the equation simplifies to</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-42"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mn>0</m:mn><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi>
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
@@ -817,7 +817,7 @@
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-256"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -826,16 +826,16 @@
                     <m:mfrac>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
-                         
+
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                      <m:mrow> <m:mn>2</m:mn><m:mi>g</m:mi></m:mrow>
                     </m:mfrac>
@@ -843,24 +843,24 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
-    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find 
+      </m:math>
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1877237">Now we must find
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math>, the component of the initial velocity in the <emphasis effect="italics">y</emphasis>-direction. It is given by
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:msup><m:mn>0</m:mn></m:msup></m:msub></m:mrow><m:mrow><m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y rSup} =v rSub {0 rSup   size 12{"sin"&#952;}} {}</m:annotation></m:semantics></m:math>, where
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow></m:semantics></m:math> is the initial velocity of 70.0 m/s, and
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>75.0&#186;</m:mn></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-677"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70.0 m/s</m:mtext><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>sin 75&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>67.6 m/s.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } = \( "70" "." 0" m/s" \)  \( "sin""75" { size 12{ circ } }  \) ="67" "." 6" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2271493">and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-512"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>y</m:mi>
@@ -872,11 +872,11 @@
                       <m:mtext>.6 m/s</m:mtext>
                       <m:msup>
                         <m:mo stretchy="false">)</m:mo>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                     <m:mrow>
@@ -887,11 +887,11 @@
                       <m:mtext>80 m</m:mtext>
                       <m:msup>
                         <m:mtext>/s</m:mtext>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">)</m:mo>
                     </m:mrow>
@@ -904,13 +904,13 @@
 
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  { \( "67" "." 6" m/s" \)  rSup { size 8{2} } }  over  {2 \( 9 "." "80"" m/s" rSup { size 8{2} }  \) } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1919502">so that</para>
-    
+
     <equation id="eip-310"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>233</m:mtext></m:mrow><m:mo stretchy="false"> </m:mo><m:mtext> m.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y="233"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-429"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2165781">Note that because up is positive, the initial velocity is positive, as is the maximum height, but the acceleration due to gravity is negative. Note also that the maximum height depends only on the vertical component of the initial velocity, so that any projectile with a 67.6 m/s initial vertical component of velocity will reach a maximum height of 233 m (neglecting air resistance). The numbers in this example are reasonable for large fireworks displays, the shells of which do reach such heights before exploding. In practice, air resistance is not completely negligible, and so the initial velocity would have to be somewhat larger than that given to reach the same height.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-449"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1632028">As in many physics problems, there is more than one way to solve for the time to the highest point. In this case, the easiest method is to use <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation></m:semantics></m:math>. Because <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is zero, this equation reduces to simply</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-383"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -925,20 +925,20 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
@@ -950,7 +950,7 @@
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1383088">Note that the final vertical velocity, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math>, at the highest point is zero. Thus,</para>
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-50"><m:math>
         <m:semantics>
@@ -961,7 +961,7 @@
 <m:mtd>                            <m:mo stretchy="false">=</m:mo></m:mtd>
 <m:mtd>
                   <m:mrow>
-                    
+
                       <m:mrow>
                         <m:mrow>
                           <m:mrow>
@@ -972,26 +972,26 @@
                               <m:mn>2</m:mn>
 <m:mi>y</m:mi>
 
-</m:mrow>                                 
+</m:mrow>
                               <m:mrow>
                                 <m:mo stretchy="false">(</m:mo>
                                 <m:mrow>
                                   <m:msub>
                                     <m:mi>v</m:mi>
-                                    
+
                                       <m:mrow>
                                         <m:mn>0y</m:mn>
                                       </m:mrow>
-                                    
+
                                   </m:msub>
                                   <m:mo stretchy="false">+</m:mo>
                                   <m:msub>
                                     <m:mi>v</m:mi>
-                                    
+
                                       <m:mrow>
                                         <m:mi>y</m:mi>
                                       </m:mrow>
-                                    
+
                                   </m:msub>
                                 </m:mrow>
                                 <m:mo stretchy="false">)</m:mo>
@@ -1011,13 +1011,13 @@
                             <m:mrow>
                               <m:mo stretchy="false">(</m:mo>
                               <m:mtext>67.6 m/s</m:mtext>
-                             
+
                               <m:mo stretchy="false">)</m:mo>
                             </m:mrow>
                           </m:mfrac>
                         </m:mrow>
                       </m:mrow>
-                    
+
                     <m:mrow/>
                   </m:mrow></m:mtd>
                 </m:mtr>
@@ -1025,9 +1025,9 @@
 <m:mtd><m:mo>=</m:mo></m:mtd>
 <m:mtd>
                   <m:mrow>
-                   
+
                     <m:mtext>6.90 s</m:mtext><m:mtext>.</m:mtext>
-                 
+
                   </m:mrow></m:mtd>
                 </m:mtr>
               </m:mtable>
@@ -1035,18 +1035,18 @@
             </m:mrow>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0">alignl { stack {
- size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} # 
-=6 "." "90"" s" {} 
+ size 12{t= {  {2y}  over  { \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) } } = {  {2 times "233"" m"}  over  { \( "67" "." 6" m/s" \) } } }  {} #
+=6 "." "90"" s" {}
 } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-31"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1848626">This time is also reasonable for large fireworks. When you are able to see the launch of fireworks, you will notice several seconds pass before the shell explodes. (Another way of finding the time is by using <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>, and solving the quadratic equation for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>.)</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-939"><emphasis>Solution for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2262600">Because air resistance is negligible, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>a</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a rSub { size 8{x} } =0} {}</m:annotation></m:semantics></m:math> and the horizontal velocity is constant, as discussed above. The horizontal displacement is horizontal velocity multiplied by time as given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation></m:semantics></m:math>, where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is equal to zero:</para><equation id="eip-675"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{x} } t ","} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1871833">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is the <emphasis effect="italics"><emphasis effect="italics">x</emphasis></emphasis>-component of the velocity, which is given by <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} }  "." } {}</m:annotation></m:semantics></m:math> Now,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-884"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>70</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 75.0&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>18</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>1 m/s.</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 12{0} } = \( "70" "." 0" m/s" \)  \( "cos""75.0&#186;"  \) ="18" "." 1" m/s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2046887">The time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> for both motions is the same, and so <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> is</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-685"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>18</m:mtext><m:mtext>.</m:mtext><m:mn>1 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mn>6</m:mn><m:mtext>.</m:mtext><m:mtext>90 s</m:mtext><m:mtext/><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>125 m.</m:mtext></m:mrow><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x= \( "18" "." 1" m/s" \)  \( 6 "." "90"" s" \) ="125"" m."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-247"><emphasis>Discussion for (c)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1857186">The horizontal motion is a constant velocity in the absence of air resistance. The horizontal displacement found here could be useful in keeping the fireworks fragments from falling on spectators. Once the shell explodes, air resistance has a major effect, and many fragments will land directly below.</para></example>
     <para id="import-auto-id1986266">In solving part (a) of the preceding example, the expression we found for <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> is valid for any projectile motion where air resistance is negligible. Call the maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mi>h</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=h} {}</m:annotation></m:semantics></m:math>; then,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-803"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1055,17 +1055,17 @@
                     <m:mfrac>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
 <m:mrow>
                       <m:mn>2</m:mn>
@@ -1076,27 +1076,27 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y= {  {v rSub { size 8{0y} }  rSup { size 8{2} } }  over  {2g} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1973673">This equation defines the <emphasis effect="italics"><emphasis effect="italics">maximum height of a projectile</emphasis></emphasis> and depends only on the vertical component of the initial velocity.</para>
     <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1479427"><label/><title>Defining a Coordinate System</title>
-    
+
     <para id="import-auto-id2275341">It is important to set up a coordinate system when analyzing projectile motion. One part of defining the coordinate system is to define an origin for the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions. Often, it is convenient to choose the initial position of the object as the origin such that <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>x</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mn>0</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } =0} {}</m:annotation></m:semantics></m:math>. It is also important to define the positive and negative directions in the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> directions. Typically, we define the positive vertical direction as upwards, and the positive horizontal direction is usually the direction of the object&#8217;s motion. When this is the case, the vertical acceleration, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>, takes a negative value (since it is directed downwards towards the Earth). However, it is occasionally useful to define the coordinates differently. For example, if you are analyzing the motion of a ball thrown downwards from the top of a cliff, it may make sense to define the positive direction downwards since the motion of the ball is solely in the downwards direction. If this is the case, <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math> takes a positive value.</para>
     </note><example id="fs-id708626">
     <title>Calculating Projectile Motion: Hot Rock Projectile</title>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1916950">Kilauea in Hawaii is the world&#8217;s most continuously active volcano. Very active volcanoes characteristically eject red-hot rocks and lava rather than smoke and ash. Suppose a large rock is ejected from the volcano with a speed of 25.0 m/s and at an angle <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"35"&#176;} {}</m:annotation></m:semantics></m:math> above the horizontal, as shown in <link target-id="import-auto-id1817519"/>. The rock strikes the side of the volcano at an altitude 20.0 m lower than its starting point. (a) Calculate the time it takes the rock to follow this path. (b) What are the magnitude and direction of the rock&#8217;s velocity at impact?</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1817519"><media id="import-auto-id1817520" alt="The trajectory of a rock ejected from a volcano is shown. The initial velocity of rock v zero is equal to twenty five meters per second and it makes an angle of thirty five degrees with the horizontal x axis. The figure shows rock falling down a height of twenty meters below the volcano level. The velocity at this point is v which makes an angle of theta with horizontal x axis. The direction of v is south east.">
         <image mime-type="image/jpg" src="Figure_03_04_04a.jpg" width="400"/>
       </media>
-      
+
     <caption>The trajectory of a rock ejected from the Kilauea volcano.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-770"><emphasis>Strategy</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1823692">Again, resolving this two-dimensional motion into two independent one-dimensional motions will allow us to solve for the desired quantities. The time a projectile is in the air is governed by its vertical motion alone. We will solve for <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> first. While the rock is rising and falling vertically, the horizontal motion continues at a constant velocity. This example asks for the final velocity. Thus, the vertical and horizontal results will be recombined to obtain <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> at the final time <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> determined in the first part of the example.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-408"><emphasis>Solution for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1608071">While the rock is in the air, it rises and then falls to a final position 20.0 m lower than its starting altitude. We can find the time for this by using</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-895"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">+</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow></m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfrac><m:mn>1</m:mn><m:mn>2</m:mn></m:mfrac></m:mrow><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
 <m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1843834">If we take the initial position <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> to be zero, then the final position is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow></m:mrow><m:mtext>.0  m</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= - "20" "." 0" m" "." } {}</m:annotation></m:semantics></m:math> Now the initial vertical velocity is the vertical component of the initial velocity, found from  <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } =v rSub { size 8{0} } "sin"&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> = (<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mtext>0&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"25" "." "0&#160;m/s"} {}</m:annotation></m:semantics></m:math>)(<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>sin 35.0&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"sin 35"&#176;} {}</m:annotation></m:semantics></m:math>) = <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Substituting known values yields</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-722"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>0 m</m:mn><m:mrow><m:mtext/><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mn>3 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced></m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow>
 <m:mtext>.</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ - "20" "." 0" m"= \( "14" "." 3" m/s" \) t -  left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} } "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1561988">Rearranging terms gives a quadratic equation in <m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math>:</para>
-    
-    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form 
+
+    <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-931"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mfenced open="(" close=")"><m:mrow><m:mn>4</m:mn><m:mtext>.</m:mtext><m:mtext>90 m/s</m:mtext><m:msup><m:mtext/><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mfenced><m:mrow><m:msup><m:mi>t</m:mi><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3 m/s</m:mtext></m:mrow></m:mfenced></m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:mfenced open="(" close=")"><m:mrow><m:mtext>20.0 m</m:mtext></m:mrow></m:mfenced></m:mrow><m:mo stretchy="false">=</m:mo><m:mn>0.</m:mn></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ left (4 "." "90"" m/s" rSup { size 8{2} }  right )t rSup { size 8{2} }  -  left ("14" "." "3 m/s" right )t -  left ("20" "." 0" m" right )=0.} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id2244917">This expression is a quadratic equation of the form
 <m:math>
 <m:semantics>
 <m:mrow><m:mrow><m:mrow><m:mrow><m:mrow>
@@ -1114,17 +1114,17 @@
 </m:mrow></m:mrow></m:mrow></m:mrow></m:mrow>
 <m:annotation encoding="StarMath 5.0"> size 12{ ital "at" rSup { size 8{2} } + ital "bt"+c=0} {}</m:annotation>
 </m:semantics>
-</m:math>, where the constants are 
+</m:math>, where the constants are
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
 <m:mi>a</m:mi><m:mo>=</m:mo><m:mn>4.90</m:mn>
-</m:mrow></m:mrow></m:semantics></m:math>, 
+</m:mrow></m:mrow></m:semantics></m:math>,
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
 <m:mi>b</m:mi><m:mo>=</m:mo><m:mo>&#8211;</m:mo><m:mn>14.3</m:mn>
-</m:mrow></m:mrow></m:semantics></m:math>, and 
+</m:mrow></m:mrow></m:semantics></m:math>, and
 
 <m:math><m:semantics>
 <m:mrow><m:mrow>
@@ -1132,7 +1132,7 @@
 </m:mrow></m:mrow></m:semantics></m:math> Its solutions are given by the quadratic formula:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-880"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1150,11 +1150,11 @@
                             <m:mrow>
                               <m:msup>
                                 <m:mi>b</m:mi>
-                                
+
                                   <m:mrow>
                                     <m:mn>2</m:mn>
                                   </m:mrow>
-                                
+
                               </m:msup>
                               <m:mo stretchy="false">&#8722;</m:mo>
                               <m:mn>4</m:mn>
@@ -1173,39 +1173,39 @@
                   <m:mtext>.</m:mtext>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{t= {  { - b +-  sqrt {b rSup { size 8{2} }  - 4 ital "ac"} }  over  {"2a"} }  "." } {}</m:annotation>
         </m:semantics>
-      </m:math> 
-    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions: 
+      </m:math>
+    </equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1600199">This equation yields two solutions:
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math> and
 
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn></m:mrow></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"} {}</m:annotation></m:semantics></m:math>. (It is left as an exercise for the reader to verify these solutions.) The time is
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3.96</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96""s"} {}</m:annotation></m:semantics></m:math> or
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mo>&#8211;</m:mo><m:mn>1.03</m:mn><m:mspace width="0.25em"/><m:mtext>s</m:mtext></m:mrow></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{-1 "." "03""s"} {}</m:annotation></m:semantics></m:math>. The negative value of time implies an event before the start of motion, and so we discard it. Thus,</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-267"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>t</m:mi><m:mo stretchy="false">=</m:mo><m:mn>3</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>96 s</m:mtext><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t=3 "." "96"" s."} {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-46"><emphasis>Discussion for (a)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1368589">The time for projectile motion is completely determined by the vertical motion. So any projectile that has an initial vertical velocity of 14.3 m/s and lands 20.0 m below its starting altitude will spend 3.96 s in the air.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-653"><emphasis>Solution for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1599448">From the information now in hand, we can find the final horizontal and vertical velocities <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } } {}</m:annotation></m:semantics></m:math> and combine them to find the total velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> and the angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> it makes with the horizontal. Of course, <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } } {}</m:annotation></m:semantics></m:math> is constant so we can solve for it at any horizontal location. In this case, we chose the starting point since we know both the initial velocity and initial angle. Therefore:</para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-873"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mtext>25</m:mtext><m:mtext>.</m:mtext><m:mn>0 m/s</m:mn><m:mtext/><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">(</m:mo><m:mtext>cos 35&#186;</m:mtext><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{x} } =v rSub { size 8{0} } "cos"&#952; rSub { size 8{0} } = \( "25" "." 0" m/s" \)  \( "cos""35" rSup { size 8{ circ } }  \) ="20" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2252925">The final vertical velocity is given by the following equation:</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-168"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">&#8722;</m:mo><m:mstyle fontstyle="italic"><m:mrow><m:mtext>gt,</m:mtext></m:mrow></m:mstyle></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt,"} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2173689">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0y</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> was found in part (a) to be <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>14</m:mtext><m:mtext>.</m:mtext><m:mtext>3&#160;m/s</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"14" "." "3&#160;m/s"} {}</m:annotation></m:semantics></m:math>. Thus,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-113"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mtext>14</m:mtext>
@@ -1222,11 +1222,11 @@
                   <m:mtext>80 m/s</m:mtext>
                   <m:msup>
                     <m:mtext/>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mo stretchy="false">(</m:mo>
@@ -1237,91 +1237,91 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } ="14" "." 3" m/s" -  \( 9 "." "80"" m/s" rSup { size 8{2} }  \)  \( 3 "." "96"" s" \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1792451">so that</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-571"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } = - "24" "." 5" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id2239982">To find the magnitude of the final velocity <m:math><m:semantics><m:mrow><m:mrow><m:mi>v</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v} {}</m:annotation></m:semantics></m:math> we combine its perpendicular components, using the following equation:</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-394"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">+</m:mo><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup></m:mrow></m:msqrt></m:mrow><m:mo stretchy="false">=</m:mo><m:msqrt><m:mrow><m:mo stretchy="false">(</m:mo><m:mtext>20</m:mtext><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:mrow><m:mrow><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo stretchy="false">+</m:mo><m:mo stretchy="false">(</m:mo></m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5 m/s</m:mn><m:mtext/><m:msup><m:mo stretchy="false">)</m:mo><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:msqrt><m:mtext>,</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } = sqrt { \( "20" "." 5" m/s" \)  rSup { size 8{2} } + \(  - "24" "." 5" m/s" \)  rSup { size 8{2} } } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1677955">which gives</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-60"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>v</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>31</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>9 m/s.</m:mn><m:mtext/></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v="31" "." 9" m/s."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1645980">The direction <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } } {}</m:annotation></m:semantics></m:math> is found from the equation:</para>
-    
+
     <equation id="eip-353"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
                     <m:msub>
                       <m:mi>&#952;</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>v</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">/</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><para id="import-auto-id1972156">so that</para>
-    
+
     <equation id="eip-589"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mtext>24</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mrow><m:mn>5</m:mn><m:mo stretchy="false">/</m:mo><m:mtext>20</m:mtext></m:mrow><m:mtext>.</m:mtext><m:mn>5</m:mn><m:mrow><m:mo stretchy="false">)</m:mo><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mrow><m:mo stretchy="false">(</m:mo><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow><m:mtext>.</m:mtext><m:mtext>19</m:mtext><m:mo stretchy="false">)</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \(  - "24" "." 5/"20" "." 5 \) ="tan" rSup { size 8{ - 1} }  \(  - 1 "." "19" \) "."} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1613163">Thus,</para>
-    
+
     <equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-379"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mi>v</m:mi></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mtext>50</m:mtext></m:mrow></m:mrow><m:mtext>.</m:mtext><m:mn>1</m:mn><m:mrow><m:mo stretchy="false">&#186;</m:mo><m:mtext>.</m:mtext></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } = - "50" "." 1 rSup { size 12{ circ } "."} } {}</m:annotation></m:semantics></m:math></equation><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-299"><emphasis>Discussion for (b)</emphasis></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1459619">The negative angle means that the velocity is <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>50</m:mtext><m:mtext>.</m:mtext><m:mn>1&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50" "." 1&#176;} {}</m:annotation></m:semantics></m:math> below the horizontal. This result is consistent with the fact that the final vertical velocity is negative and hence downward&#8212;as you would expect because the final altitude is 20.0 m lower than the initial altitude. (See <link target-id="import-auto-id1817519"/>.)</para></example>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1532818">One of the most important things illustrated by projectile motion is that vertical and horizontal motions are independent of each other. Galileo was the first person to fully comprehend this characteristic. He used it to predict the range of a projectile. On level ground, we define <term id="import-auto-id1751163">range</term> to be the horizontal distance <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> traveled by a projectile. Galileo and many others were interested in the range of projectiles primarily for military purposes&#8212;such as aiming cannons. However, investigating the range of projectiles can shed light on other interesting phenomena, such as the orbits of satellites around the Earth. Let us consider projectile range further.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1904800"><media id="import-auto-id1904802" alt="Part a of the figure shows three different trajectories of projectiles on level ground. In each case the projectiles makes an angle of forty five degrees with the horizontal axis. The first projectile of initial velocity thirty meters per second travels a horizontal distance of R equal to ninety one point eight meters. The second projectile of initial velocity forty meters per second travels a horizontal distance of R equal to one hundred sixty three meters. The third projectile of initial velocity fifty meters per second travels a horizontal distance of R equal to two hundred fifty five meters.">
           <image mime-type="image/jpg" src="Figure_03_04_05a.jpg" height="300"/>
         </media>
-        
+
 <caption>Trajectories of projectiles on level ground. (a) The greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range for a given initial angle. (b) The effect of initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> on the range of a projectile with a given initial speed. Note that the range is the same for <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>15&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"15"&#176;} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mtext>75&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"75&#176;"} {}</m:annotation></m:semantics></m:math>, although the maximum heights of those paths are different.</caption></figure><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1750749">How does the initial velocity of a projectile affect its range? Obviously, the greater the initial speed <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math>, the greater the range, as shown in <link target-id="import-auto-id1904800"/>(a). The initial angle <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> also has a dramatic effect on the range, as illustrated in <link target-id="import-auto-id1904800"/>(b). For a fixed initial speed, such as might be produced by a cannon, the maximum range is obtained with <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } &#160;=&#160;"45&#186;"} {}</m:annotation></m:semantics></m:math>. This is true only for conditions neglecting air resistance. If air resistance is considered, the maximum angle is approximately <m:math><m:semantics><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38&#186;"} {}</m:annotation></m:semantics></m:math>. Interestingly, for every initial angle except <m:math><m:semantics><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45&#186;"} {}</m:annotation></m:semantics></m:math>, there are two angles that give the same range&#8212;the sum of those angles is <m:math><m:semantics><m:mrow><m:mrow><m:mtext>90&#186;</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"90&#186;"} {}</m:annotation></m:semantics></m:math>. The range also depends on the value of the acceleration of gravity <m:math><m:semantics><m:mrow><m:mrow><m:mi>g</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{g} {}</m:annotation></m:semantics></m:math>. The lunar astronaut Alan Shepherd was able to drive a golf ball a great distance on the Moon because gravity is weaker there. The range <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> of a projectile on <emphasis effect="italics"><emphasis effect="italics">level ground</emphasis></emphasis> for which air resistance is negligible is given by </para><equation xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-240"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:msub><m:mrow><m:mn>2</m:mn><m:mi>&#952;</m:mi></m:mrow><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mtext>,</m:mtext><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R= {  {v rSub { size 8{0} }  rSup { size 8{2} } "sin"2&#952; rSub { size 8{0} } }  over  {g} } ","} {}</m:annotation></m:semantics></m:math></equation><para id="import-auto-id1674836">where <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial speed and <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{0} } } {}</m:annotation></m:semantics></m:math> is the initial angle relative to the horizontal. The proof of this equation is left as an end-of-chapter problem (hints are given), but it does fit the major features of projectile range as described.</para>
     <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1686986">When we speak of the range of a projectile on level ground, we assume that <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> is very small compared with the circumference of the Earth. If, however, the range is large, the Earth curves away below the projectile and acceleration of gravity changes direction along the path. The range is larger than predicted by the range equation given above because the projectile has farther to fall than it would on level ground. (See <link target-id="import-auto-id1645881"/>.) If the initial speed is great enough, the projectile goes into orbit.  This possibility was recognized centuries before it could be accomplished. When an object is in orbit, the Earth curves away from underneath the object at the same rate as it falls. The object thus falls continuously but never hits the surface. These and other aspects of orbital motion, such as the rotation of the Earth, will be covered analytically and in greater depth later in this text.</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645878">Once again we see that thinking about one topic, such as the range of a projectile, can lead us to others, such as the Earth orbits. In  <link document="m42045">Addition of Velocities</link>, we will examine the addition of velocities, which is another important aspect of two-dimensional kinematics and will also yield insights beyond the immediate topic.</para><figure xmlns:q="http://cnx.rice.edu/qml/1.0" id="import-auto-id1645881"><media id="import-auto-id1825851" alt="A figure of the Earth is shown and on top of it a very high tower is placed. A projectile satellite is launched from this very high tower with initial velocity of v zero in the horizontal direction. Several trajectories are shown with increasing range. A circular trajectory is shown indicating the satellite achieved its orbit and it is revolving around the Earth.">
         <image mime-type="image/jpg" src="Figure_03_04_06a.jpg" width="200"/>
       </media>
-      
+
     <caption>Projectile to satellite. In each case shown here, a projectile is launched from a very high tower to avoid air resistance. With increasing initial speed, the range increases and becomes longer than it would be on level ground because the Earth curves away underneath its path. With a large enough initial speed, orbit is achieved.</caption></figure>
 <note xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-89"><label/><title>PhET Explorations: Projectile Motion</title>
 
@@ -1331,7 +1331,7 @@
 
   <image mime-type="image/png" for="online" src="projectile-motion_en.jar" thumbnail="PhET_Icon.png" width="450"/>
   <image mime-type="image/png" for="pdf" src="PhET_Icon.png" width="450"/>
-   
+
 </media>
 
       <caption><link url="projectile-motion_en.jar">Projectile Motion</link></caption></figure></note><section id="fs-id1843457" class="section-summary">
@@ -1342,7 +1342,7 @@
     <equation id="eip-898"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Horizontal motion </m:mtext>
@@ -1350,11 +1350,11 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>a</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>x</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">=</m:mo>
                     <m:mn>0</m:mn>
@@ -1362,7 +1362,7 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Horizontal motion " \( a rSub { size 8{x} } =0 \) } {}</m:annotation>
@@ -1371,7 +1371,7 @@
     <equation id="eip-236"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1380,27 +1380,27 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{x=x rSub { size 8{0} } +v rSub { size 8{x} } t} {}</m:annotation>
@@ -1421,7 +1421,7 @@
     <equation id="import-auto-id1939084"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mtext>Vertical motion </m:mtext>
@@ -1431,11 +1431,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>a</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">=</m:mo>
                       <m:mrow>
@@ -1453,25 +1453,25 @@
                   <m:mtext>80 m</m:mtext>
                   <m:msup>
                     <m:mtext>/s</m:mtext>
-                    
+
                       <m:mrow>
                         <m:mn>2</m:mn>
                       </m:mrow>
-                    
+
                   </m:msup>
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{"Vertical motion " \( "Assuming positive direction is up; "a rSub { size 8{y} } = - g= - 9 "." "80"" m/s" rSup { size 8{2} }  \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><equation id="import-auto-id1492830"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1480,11 +1480,11 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:mfrac>
@@ -1497,56 +1497,56 @@
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn><m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">+</m:mo>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                   </m:mrow>
                   <m:mo stretchy="false">)</m:mo>
                   <m:mi>t</m:mi>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } + {  {1}  over  {2} }  \( v rSub { size 8{0y} } +v rSub { size 8{y} }  \) t} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation><equation id="import-auto-id2022844"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:msub>
                     <m:mi>v</m:mi>
-                    
+
                       <m:mrow>
                         <m:mi>y</m:mi>
                       </m:mrow>
-                    
+
                   </m:msub>
                   <m:mo stretchy="false">=</m:mo>
                   <m:mrow>
                     <m:msub>
                       <m:mi>v</m:mi>
-                      
+
                         <m:mrow>
                           <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                         </m:mrow>
-                      
+
                     </m:msub>
                     <m:mo stretchy="false">&#8722;</m:mo>
                     <m:mstyle fontstyle="italic">
@@ -1557,17 +1557,17 @@
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} } =v rSub { size 8{0y} }  -  ital "gt"} {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id1677876"><m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1576,21 +1576,21 @@
                     <m:mrow>
                       <m:msub>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
                           </m:mrow>
-                        
+
                       </m:msub>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msub>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>0</m:mn>
 <m:mi>y</m:mi>
                           </m:mrow>
-                        
+
                       </m:msub>
                     </m:mrow>
                   </m:mrow>
@@ -1602,26 +1602,26 @@
                       <m:mn>2</m:mn>
                     </m:mfrac>
                   </m:mrow>
-                  
+
                     <m:mrow>
                       <m:msup>
                         <m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
-                  
+
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{y=y rSub { size 8{0} } +v rSub { size 8{0y} } t -  {  {1}  over  {2} }  ital "gt" rSup { size 8{2} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
 <equation id="import-auto-id1653540"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">=</m:mo><m:mrow><m:msubsup><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msubsup><m:mo stretchy="false">&#8722;</m:mo><m:mn>2</m:mn><m:mi>g</m:mi></m:mrow></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">&#8722;</m:mo><m:msub><m:mi>y</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mo>.</m:mo><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{y} }  rSup { size 8{2} } =v rSub { size 8{0y} }  rSup { size 8{2} }  - 2g \( y - y rSub { size 8{0} }  \) } {}</m:annotation></m:semantics></m:math></equation>
         </item>
@@ -1630,7 +1630,7 @@
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>s</m:mi>
@@ -1639,37 +1639,37 @@
                     <m:mrow>
                       <m:msup>
                         <m:mi>x</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msup>
                         <m:mi>y</m:mi>
-                        
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{s= sqrt {x rSup { size 8{2} } +y rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id2282348">
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mrow>
@@ -1677,14 +1677,14 @@
                     <m:mo stretchy="false">=</m:mo>
                     <m:msup>
                       <m:mtext>tan</m:mtext>
-                      
+
                         <m:mrow>
                           <m:mrow>
                             <m:mo stretchy="false">&#8722;</m:mo>
                             <m:mn>1</m:mn>
                           </m:mrow>
                         </m:mrow>
-                      
+
                     </m:msup>
                   </m:mrow>
                   <m:mo stretchy="false">(</m:mo>
@@ -1696,18 +1696,18 @@
                   <m:mo stretchy="false">)</m:mo>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{&#952;="tan" rSup { size 8{ - 1} }  \( y/x \) } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id2274748">
       <m:math>
         <m:semantics>
           <m:mrow>
-            
+
               <m:mrow>
                 <m:mrow>
                   <m:mi>v</m:mi>
@@ -1716,41 +1716,41 @@
                     <m:mrow>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>x</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                       <m:mo stretchy="false">+</m:mo>
                       <m:msubsup>
                         <m:mi>v</m:mi>
-                        
+
                           <m:mrow>
                             <m:mi>y</m:mi>
                           </m:mrow>
-                        
-                        
+
+
                           <m:mrow>
                             <m:mn>2</m:mn>
                           </m:mrow>
-                        
+
                       </m:msubsup>
                     </m:mrow>
                   </m:msqrt>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{v= sqrt {v rSub { size 8{x} }  rSup { size 8{2} } +v rSub { size 8{y} }  rSup { size 8{2} } } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </equation>
     <equation id="import-auto-id1979208"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:msub><m:mi>&#952;</m:mi><m:mrow><m:mtext>v</m:mtext></m:mrow></m:msub><m:mo stretchy="false">=</m:mo><m:msup><m:mtext>tan</m:mtext><m:mrow><m:mrow><m:mo stretchy="false">&#8722;</m:mo><m:mn>1</m:mn></m:mrow></m:mrow></m:msup></m:mrow><m:mo stretchy="false">(</m:mo><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mi>y</m:mi></m:mrow></m:msub><m:mo stretchy="false">/</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mi>x</m:mi></m:mrow></m:msub></m:mrow><m:mo stretchy="false">)</m:mo></m:mrow></m:mrow><m:mrow/><m:mo>.</m:mo></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{&#952; rSub { size 8{v} } ="tan" rSup { size 8{ - 1} }  \( v rSub { size 8{y} } /v rSub { size 8{x} }  \) } {}</m:annotation></m:semantics></m:math></equation></item></list></item>
   <item id="import-auto-id1888635">The maximum height <m:math><m:semantics><m:mrow><m:mrow><m:mi>h</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{h} {}</m:annotation></m:semantics></m:math> of a projectile launched with initial vertical velocity <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{v rSub { size 8{0y} } } {}</m:annotation></m:semantics></m:math> is given by
@@ -1816,19 +1816,19 @@
 <m:mtext>sin</m:mtext><m:msub><m:mn>2&#952;</m:mn><m:mn>0</m:mn></m:msub><m:mi>g</m:mi></m:mrow></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow></m:mtr><m:mtr><m:mrow><m:mtext>For </m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>45&#186;</m:mtext></m:mrow><m:mo>,</m:mo><m:mrow/></m:mrow><m:mrow><m:mrow>
 
 <m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:msup><m:msub><m:mi>v</m:mi><m:mn>0</m:mn><m:mn>2</m:mn></m:msub></m:msup><m:mi>g</m:mi></m:mfrac></m:mrow><m:mrow/></m:mrow></m:mtr></m:mtable><m:mrow/></m:mrow></m:mrow><m:annotation encoding="StarMath 5.0">alignl { stack {
- size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} # 
-"For "&#952;="45"&#176;: {} # 
-R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {} 
-} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for 
+ size 12{R= {  {v rSub { size 8{0}   rSup { size 8{2} } }  "sin"2&#952; rSub { size 8{0} } }  over  {g} } }  {} #
+"For "&#952;="45"&#176;: {} #
+R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
+} } {}</m:annotation></m:semantics></m:math></para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1630295"><m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>91.8</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math> for
 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>; 
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>30</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"30 m/s"} {}</m:annotation></m:semantics></m:math>;
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>163</m:mn><m:mspace width="0.25em"/><m:mtext> m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R=91.8} {}</m:annotation></m:semantics></m:math>
 
- for 
-<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>; 
+ for
+<m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>40</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"40 m/s"} {}</m:annotation></m:semantics></m:math>;
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>R</m:mi><m:mo>=</m:mo><m:mn>255</m:mn><m:mspace width="0.25em"/><m:mtext>m</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{R} {}</m:annotation></m:semantics></m:math> for
 
 <m:math><m:semantics><m:mrow><m:mrow><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn></m:mrow></m:msub><m:mo>=</m:mo><m:mn>50</m:mn><m:mspace width="0.25em"/><m:mtext> m/s</m:mtext></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"50 m/s"} {}</m:annotation></m:semantics></m:math>.</para></solution>
       </exercise>
@@ -1875,7 +1875,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
       <exercise id="fs-id2260735" type="problems-exercises"><problem id="fs-id1789803"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1789804">Can a goalkeeper at her/ his goal kick a soccer ball into the opponent&#8217;s goal without the ball touching the ground? The distance will be about 95 m. A goalkeeper can give the ball a speed of 30 m/s.</para></problem>
       <solution id="fs-id1985242">
         <para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1985244">No, the maximum range (neglecting air resistance) is about 92 m. </para></solution>
-      </exercise>      
+      </exercise>
      <exercise id="fs-id1437858" type="problems-exercises"><problem id="fs-id1891285"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1891286">The free throw line in basketball is 4.57 m (15 ft) from the basket, which is 3.05 m (10 ft) above the floor. A player standing on the free throw line throws the ball with an initial speed of 7.15 m/s, releasing it at a height of 2.44 m (8 ft) above the floor. At what angle above the horizontal must the ball be thrown to exactly hit the basket? Note that most players will use a large initial angle rather than a flat shot because it allows for a larger margin of error. Explicitly show how you follow the steps involved in solving projectile motion problems.</para></problem>
      </exercise>
       <exercise id="fs-id1827481" type="problems-exercises"><problem id="fs-id1750926"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1750928">In 2007, Michael Carter (U.S.) set a world record in the shot put with a throw of 24.77 m. What was the initial speed of the shot if he released it at a height of 2.10 m and threw it at an angle of <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>38.0&#186;</m:mn></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> above the horizontal? (Although the maximum distance for a projectile on level ground is achieved at <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> when air resistance is neglected, the actual angle to achieve maximum range is smaller; thus, <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>38&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"38"&#186;} {}</m:annotation></m:semantics></m:math> will give a longer range than <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mtext>45&#186;</m:mtext></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{"45"&#186;} {}</m:annotation></m:semantics></m:math> in the shot put.)</para></problem>
@@ -1892,11 +1892,11 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1796132">(b) The ball travels a total of 57.4 m with the brief gust of wind.</para></solution>
       </exercise>
 <exercise id="fs-id2046931" type="problems-exercises">
-  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation 
+  <problem id="fs-id2241558"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id2241559">Prove that the trajectory of a projectile is parabolic, having the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math>. To obtain this expression, solve the equation
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>x</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>x</m:mi></m:mrow></m:msub><m:mi>t</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x=v rSub { size 8{0x} } } {t}</m:annotation></m:semantics></m:math> for
 
-<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for 
+<m:math><m:semantics><m:mrow><m:mrow><m:mi>t</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{t} {}</m:annotation></m:semantics></m:math> and substitute it into the expression for
 
 <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:msub><m:mi>v</m:mi><m:mrow><m:mn>0</m:mn><m:mi>y</m:mi></m:mrow></m:msub></m:mrow><m:mi>t</m:mi><m:mo>&#8211;</m:mo><m:mo stretchy="false">(</m:mo><m:mrow><m:mn>1</m:mn><m:mo stretchy="false">/</m:mo><m:mn>2</m:mn></m:mrow><m:mo stretchy="false">)</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>gt</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y=&#965; rSub { size 8{0y} } t \( 1/2 \)  ital "gt" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> (These equations describe the <m:math><m:semantics><m:mrow><m:mrow><m:mi>x</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{x} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>y</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y} {}</m:annotation></m:semantics></m:math> positions of a projectile that starts at the origin.) You should obtain an equation of the form <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>y</m:mi><m:mo stretchy="false">=</m:mo><m:mrow><m:mstyle fontstyle="italic"><m:mrow><m:mtext>ax</m:mtext></m:mrow></m:mstyle><m:mo stretchy="false">+</m:mo><m:mrow><m:msup><m:mstyle fontstyle="italic"><m:mtext>bx</m:mtext></m:mstyle><m:mrow><m:mn>2</m:mn></m:mrow></m:msup></m:mrow></m:mrow></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{y= ital "ax"+ ital "bx" rSup { size 8{2} } } {}</m:annotation></m:semantics></m:math> where <m:math><m:semantics><m:mrow><m:mrow><m:mi>a</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{a} {}</m:annotation></m:semantics></m:math> and <m:math><m:semantics><m:mrow><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{b} {}</m:annotation></m:semantics></m:math> are constants.
 </para></problem>
@@ -1952,7 +1952,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </m:mrow>
                           <m:mn>0</m:mn>
                           <m:mn>2</m:mn>
-                 
+
                         </m:msubsup><m:mspace width="0.25em"/>
                         <m:mtext>sin</m:mtext><m:mspace width="0.25em"/>
                         <m:mi>&#952;</m:mi><m:mspace width="0.25em"/>
@@ -1964,12 +1964,12 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
                   </m:mrow>
                 </m:mrow>
               </m:mrow>
-            
+
             <m:mrow/>
           </m:mrow>
           <m:annotation encoding="StarMath 5.0"> size 12{R=v rSub { size 8{0} } "cos"&#952; left ( {  {2v rSub { size 8{0} } "sin"&#952;}  over  {g} }  right )= {  {2v rSub { size 8{0}   rSup { size 8{2} } } "sin"&#952;"cos"&#952;}  over  {g} } } {}</m:annotation>
         </m:semantics>
-      </m:math> 
+      </m:math>
     </para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id1599732">since <m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mn>2</m:mn><m:mspace width="0.25em"/><m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mi>&#952;</m:mi><m:mspace width="0.25em"/><m:mtext>cos</m:mtext><m:mspace width="0.25em"/><m:mrow><m:mi>&#952;</m:mi><m:mo stretchy="false">=</m:mo><m:mtext>sin</m:mtext><m:mspace width="0.25em"/></m:mrow><m:mn>2&#952;</m:mn><m:mi>,</m:mi></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{2"sin"&#952;"cos"&#952;="sin"2&#952;,} {}</m:annotation></m:semantics></m:math> the range is:</para><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="eip-id3385487"><m:math><m:semantics><m:mrow><m:mrow><m:mrow><m:mi>R</m:mi><m:mo stretchy="false">=</m:mo><m:mfrac><m:mrow>
 <m:msup>
 <m:msub>
@@ -1983,11 +1983,11 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </m:msup><m:mspace width="0.25em"/>
 <m:mtext>sin</m:mtext><m:mspace width="0.25em"/><m:mn>2&#952;</m:mn></m:mrow><m:mi>g</m:mi></m:mfrac></m:mrow></m:mrow><m:mrow/></m:mrow><m:annotation encoding="StarMath 5.0"> size 12{ {underline  {R= {  {v rSub { size 8{0}   rSup { size 8{2} } } "sin"2&#952;}  over  {g} } }} } {}</m:annotation></m:semantics></m:math>.</para></solution></exercise>
 
-    
-    
-    
-    
- 
+
+
+
+
+
 <exercise id="fs-id1794949" type="problems-exercises"><problem id="fs-id1626931"><para xmlns:q="http://cnx.rice.edu/qml/1.0" id="fs-id1626932"><emphasis>Unreasonable Results</emphasis> (a) Find the maximum range of a super cannon that has a muzzle velocity of 4.0 km/s. (b) What is unreasonable about the range you found? (c) Is the premise unreasonable or is the available equation inapplicable? Explain your answer. (d) If such a muzzle velocity could be obtained, discuss the effects of air resistance, thinning air with altitude, and the curvature of the Earth on the range of the super cannon.
 </para></problem>
 </exercise>
@@ -1997,7 +1997,7 @@ R= {  {v rSub { size 8{0}   rSup { size 8{2} } } }  over  {g} }  {}
 </content>
     <glossary>
       <definition id="import-auto-id2275857"><term>air resistance</term> <meaning id="fs-id1668212">a frictional force that slows the motion of objects as they travel through the air; when solving basic physics problems, air resistance is assumed to be zero</meaning></definition>
-      
+
 <definition id="fs-id1405173"><term>kinematics</term><meaning id="fs-id1949378">the study of motion without regard to mass or force</meaning></definition>
 
 <definition id="fs-id1949381"><term>motion</term><meaning id="fs-id2324535">displacement of an object as a function of time</meaning></definition>

--- a/cnxml/tests/test_validation.py
+++ b/cnxml/tests/test_validation.py
@@ -78,5 +78,5 @@ def test_invalid_derived_from_cnxml(datadir):
           'missing required element "md:language"')],
     )
 
-    errors = validate_cnxml()
+    errors = validate_cnxml(filepath)
     assert tuple(list(l) for l in errors) == expected

--- a/cnxml/tests/test_validation.py
+++ b/cnxml/tests/test_validation.py
@@ -53,3 +53,30 @@ def test_collxml_validation_messages(datadir):
 
     errors = validate_collxml(datafile)
     assert tuple(list(l) for l in errors) == expected
+
+
+def test_valid_derived_from_cnxml(datadir):
+    # This contains the full metadata for the derived-from.
+    errors = validate_cnxml(datadir / 'valid-derived-from.cnxml')
+    assert errors == tuple()
+
+
+def test_valid_derived_from_cnxml_with_no_children(datadir):
+    # This contains only a md:derived-from tag with the url attribute.
+    # The tag contains no children tags.
+    errors = validate_cnxml(datadir / 'valid-derived-from-2.cnxml')
+    assert errors == tuple()
+
+
+def test_invalid_derived_from_cnxml(datadir):
+    filepath = datadir / 'invalid-derived-from.cnxml'
+    # In this case the document is missing one md:derived-from
+    # required child tag.
+    expected = (
+        [str(filepath), '83', '21', 'error',
+         ('element "md:derived-from" incomplete; '
+          'missing required element "md:language"')],
+    )
+
+    errors = validate_cnxml()
+    assert tuple(list(l) for l in errors) == expected


### PR DESCRIPTION
This moves forward with the idea that the <md:derived-from> will no longer
contain child information. Instead we'll go with the simple form that
uses the `url` attribute to parse parentage.

This follows up on #12 by adding tests for the change.

Addresses connexions/cnx-press#135