### PR TITLE
enable passing multiple files for validation

### DIFF
--- a/cnxml/cli.py
+++ b/cnxml/cli.py
@@ -12,7 +12,7 @@ from .validation import validate_cnxml, validate_collxml
 
 def _format_error_line(error):
     """Formats the error line for human consumption"""
-    return "{}:{} -- {}: {}".format(*error)
+    return "{}:{}:{} -- {}: {}".format(*error)
 
 
 def print_errors(errors):
@@ -24,16 +24,16 @@ def print_errors(errors):
 def _arg_parser():
     """Factory for creating the argument parser"""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('xml')
+    parser.add_argument('xml', nargs='*')
     return parser
 
 
 def cnxml(argv=None):
     args = _arg_parser().parse_args(argv)
 
-    xml = Path(args.xml)
+    xml = [Path(x) for x in args.xml]
 
-    errors = validate_cnxml(xml)
+    errors = validate_cnxml(*xml)
     print_errors(errors)
 
     retcode = errors and 1 or 0
@@ -43,9 +43,9 @@ def cnxml(argv=None):
 def collxml(argv=None):
     args = _arg_parser().parse_args(argv)
 
-    xml = Path(args.xml)
+    xml = [Path(x) for x in args.xml]
 
-    errors = validate_collxml(xml)
+    errors = validate_collxml(*xml)
     print_errors(errors)
 
     retcode = errors and 1 or 0

--- a/cnxml/jing.py
+++ b/cnxml/jing.py
@@ -19,7 +19,7 @@ KNOWN_FATAL_MESSAGES_MAPPING = {
 }
 
 
-ErrorLine = namedtuple('ErrorLine', 'line, column, type, message')
+ErrorLine = namedtuple('ErrorLine', 'filename, line, column, type, message')
 
 
 def _parse_jing_line(line):
@@ -28,11 +28,11 @@ def _parse_jing_line(line):
 
     """
     parts = line.split(':', 4)
-    line, column, type_, message = [x.strip() for x in parts[1:]]
+    filename, line, column, type_, message = [x.strip() for x in parts]
     if type_ == 'fatal':
         if message in KNOWN_FATAL_MESSAGES_MAPPING:
             message = KNOWN_FATAL_MESSAGES_MAPPING[message]
-    return ErrorLine(line, column, type_, message)
+    return ErrorLine(filename, line, column, type_, message)
 
 
 def _parse_jing_output(output):
@@ -44,10 +44,12 @@ def _parse_jing_output(output):
     return tuple(values)
 
 
-def jing(rng_filepath, xml_filepath):
+def jing(rng_filepath, *xml_filepaths):
     """Run jing.jar using the RNG file against the given XML file."""
     cmd = ['java', '-jar']
-    cmd.extend([str(JING_JAR), str(rng_filepath), str(xml_filepath)])
+    cmd.extend([str(JING_JAR), str(rng_filepath)])
+    for xml_filepath in xml_filepaths:
+        cmd.append(str(xml_filepath))
     proc = subprocess.Popen(cmd,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,

--- a/cnxml/tests/test_cli.py
+++ b/cnxml/tests/test_cli.py
@@ -11,17 +11,19 @@ def test_valid_cnxml(capsys, datadir):
 
 
 def test_invalid_cnxml(capsys, datadir):
+    datafile = str(datadir / 'invalid.cnxml')
     expected_out_lines = [
-        '30:17 -- error: element "md:person" incomplete;'
-        ' missing required element "md:firstname"',
-        '55:20 -- error: element "md:subjectlist" incomplete;'
-        ' missing required element "md:subject"',
-        '67:11 -- error: element "para" missing required attribute "id"'
+        '{}:30:17 -- error: element "md:person" incomplete;'
+        ' missing required element "md:firstname"'.format(datafile),
+        '{}:55:20 -- error: element "md:subjectlist" incomplete;'
+        ' missing required element "md:subject"'.format(datafile),
+        '{}:67:11 -- error: element "para"'
+        ' missing required attribute "id"'.format(datafile)
         ]
 
-    retcode = cnxml([str(datadir / 'invalid.cnxml')])
+    retcode = cnxml([datafile])
     out, err = capsys.readouterr()
-    assert out.strip().split('\n') == expected_out_lines
+    assert out.splitlines() == expected_out_lines
     assert err == ''
     assert retcode == 1
 
@@ -35,16 +37,17 @@ def test_valid_collxml(capsys, datadir):
 
 
 def test_invalid_collxml(capsys, datadir):
+    datafile = str(datadir / 'invalid_collection.xml')
     expected_out_lines = [
-        '47:15 -- error: element "cnx:para" not allowed here;'
+        '{}:47:15 -- error: element "cnx:para" not allowed here;'
         ' expected the element end-tag or element'
-        ' "module", "segue" or "subcollection"',
-        '139:18 -- error: element "col:collection" incomplete;'
-        ' missing required element "metadata"'
+        ' "module", "segue" or "subcollection"'.format(datafile),
+        '{}:139:18 -- error: element "col:collection" incomplete;'
+        ' missing required element "metadata"'.format(datafile)
         ]
 
-    retcode = collxml([str(datadir / 'invalid_collection.xml')])
+    retcode = collxml([datafile])
     out, err = capsys.readouterr()
-    assert out.strip().split('\n') == expected_out_lines
+    assert out.splitlines() == expected_out_lines
     assert err == ''
     assert retcode == 1

--- a/cnxml/tests/test_jing.py
+++ b/cnxml/tests/test_jing.py
@@ -10,13 +10,13 @@ JING_TEST_DIR = here / 'data' / 'jing'
 
 def test_line_parsing():
     line = '/home/fred/broken.cnxml:30:17: error: unfinished element'
-    expected = ErrorLine('30',  '17', 'error', 'unfinished element')
+    expected = ErrorLine('/home/fred/broken.cnxml', '30',  '17', 'error', 'unfinished element')
     assert _parse_jing_line(line) == expected
 
 
 def test_parse_fatal_doctype_line():
     line = '/home/fred/broken.cnxml:1:1: fatal: exception "java.io.IOException" thrown: Stream closed.'
-    expected = ErrorLine('1', '1', 'fatal', 'DOCTYPE declaration not allowed')
+    expected = ErrorLine('/home/fred/broken.cnxml', '1', '1', 'fatal', 'DOCTYPE declaration not allowed')
     assert _parse_jing_line(line) == expected
 
 
@@ -27,9 +27,9 @@ def test_parse_output():
 /home/fred/broken.cnxml:67:11: error: required attributes missing
 """
     expected = (
-        ErrorLine('30', '17', 'error', 'unfinished element'),
-        ErrorLine('55', '20', 'error', 'unfinished element'),
-        ErrorLine('67', '11', 'error', 'required attributes missing'),
+        ErrorLine('/home/fred/broken.cnxml', '30', '17', 'error', 'unfinished element'),
+        ErrorLine('/home/fred/broken.cnxml', '55', '20', 'error', 'unfinished element'),
+        ErrorLine('/home/fred/broken.cnxml', '67', '11', 'error', 'required attributes missing'),
     )
     assert _parse_jing_output(lines) == expected
 
@@ -43,5 +43,5 @@ def test_jing_call_valid_xml():
 def test_jing_call_invalid_xml():
     rng = JING_TEST_DIR / 'test.rng'
     xml = JING_TEST_DIR / 'invalid.xml'
-    expected = (ErrorLine('1', '7', 'error', 'element "c" not allowed anywhere; expected the element end-tag or element "b"'),)
+    expected = (ErrorLine(str(xml), '1', '7', 'error', 'element "c" not allowed anywhere; expected the element end-tag or element "b"'),)
     assert jing(rng, xml) == expected

--- a/cnxml/tests/test_validation.py
+++ b/cnxml/tests/test_validation.py
@@ -7,13 +7,32 @@ def test_validate_cnxml(datadir):
     assert errors == tuple()
 
 
+def test_validate_multiple_cnxml(datadir):
+    datafile = datadir / 'valid.cnxml'
+    errors = validate_cnxml(datafile, datafile)
+    assert errors == tuple()
+
+
 def test_cnxml_validation_messages(datadir):
+    datafile = datadir / 'invalid.cnxml'
     expected = (
-        ['30', '17', 'error', 'element "md:person" incomplete; missing required element "md:firstname"'],
-        ['55', '20', 'error', 'element "md:subjectlist" incomplete; missing required element "md:subject"'],
-        ['67', '11', 'error', 'element "para" missing required attribute "id"']
+        [str(datafile), '30', '17', 'error', 'element "md:person" incomplete; missing required element "md:firstname"'],
+        [str(datafile), '55', '20', 'error', 'element "md:subjectlist" incomplete; missing required element "md:subject"'],
+        [str(datafile), '67', '11', 'error', 'element "para" missing required attribute "id"']
     )
-    errors = validate_cnxml(datadir / 'invalid.cnxml')
+    errors = validate_cnxml(datafile)
+    assert tuple(list(l) for l in errors) == expected
+
+
+def test_cnxml_multiple_validation_messages(datadir):
+    bad_datafile = datadir / 'invalid.cnxml'
+    good_datafile = datadir / 'valid.cnxml'
+    expected = (
+        [str(bad_datafile), '30', '17', 'error', 'element "md:person" incomplete; missing required element "md:firstname"'],
+        [str(bad_datafile), '55', '20', 'error', 'element "md:subjectlist" incomplete; missing required element "md:subject"'],
+        [str(bad_datafile), '67', '11', 'error', 'element "para" missing required attribute "id"']
+    )
+    errors = validate_cnxml(good_datafile, bad_datafile)
     assert tuple(list(l) for l in errors) == expected
 
 
@@ -23,13 +42,14 @@ def test_validate_collxml(datadir):
 
 
 def test_collxml_validation_messages(datadir):
+    datafile = datadir / 'invalid_collection.xml'
     expected = (
-        ['47', '15', 'error',
+        [str(datafile), '47', '15', 'error',
             'element "cnx:para" not allowed here;'
             ' expected the element end-tag or element "module", "segue" or "subcollection"'],
-        ['139', '18', 'error', 'element "col:collection" incomplete;'
+        [str(datafile), '139', '18', 'error', 'element "col:collection" incomplete;'
             ' missing required element "metadata"']
     )
 
-    errors = validate_collxml(datadir / 'invalid_collection.xml')
+    errors = validate_collxml(datafile)
     assert tuple(list(l) for l in errors) == expected

--- a/cnxml/validation.py
+++ b/cnxml/validation.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import subprocess
 from pathlib import Path
 
 from .jing import jing
@@ -18,13 +17,13 @@ COLLXML_JING_RNG = lookup_resource(
     'xml/collxml/schema/rng/2.0/collxml-jing.rng')
 
 
-def validate_cnxml(content_filepath):
+def validate_cnxml(*content_filepaths):
     """Validates the given CNXML file against the cnxml-jing.rng RNG."""
-    content_filepath = Path(content_filepath).resolve()
-    return jing(CNXML_JING_RNG, content_filepath)
+    content_filepaths = [Path(path).resolve() for path in content_filepaths]
+    return jing(CNXML_JING_RNG, *content_filepaths)
 
 
-def validate_collxml(content_filepath):
+def validate_collxml(*content_filepaths):
     """Validates the given COLLXML file against the collxml-jing.rng RNG."""
-    content_filepath = Path(content_filepath).resolve()
-    return jing(COLLXML_JING_RNG, content_filepath)
+    content_filepaths = [Path(path).resolve() for path in content_filepaths]
+    return jing(COLLXML_JING_RNG, *content_filepaths)


### PR DESCRIPTION
This takes advantage of jing's ability to validate multiple XML files against the same schema in a single pass. This speeds up validating a 181 module collection by 1000% (yes 100x) - from 3m 44s to 2.4s
Needed to alter the internal ErrorLine to include the filename, nice of jing to pass that back. 
fixes https://github.com/Connexions/cnxml/issues/19